### PR TITLE
Fix welcome dialog item model

### DIFF
--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -36,7 +36,10 @@ from novelwriter.common import decodeMimeHandles, encodeMimeHandles, minmax
 from novelwriter.constants import nwConst
 from novelwriter.core.item import NWItem
 from novelwriter.enum import nwItemClass
-from novelwriter.types import QtAlignRight
+from novelwriter.types import (
+    QtAccessibleTextRole, QtAlignRight, QtDecorationRole, QtDisplayRole,
+    QtFontRole, QtTextAlignmentRole, QtToolTipRole
+)
 
 if TYPE_CHECKING:
     from novelwriter.core.tree import NWTree
@@ -46,20 +49,20 @@ logger = logging.getLogger(__name__)
 INV_ROOT = "invisibleRoot"
 C_FACTOR = 0x0100
 
-C_LABEL_TEXT    = 0x0000 | Qt.ItemDataRole.DisplayRole
-C_LABEL_ICON    = 0x0000 | Qt.ItemDataRole.DecorationRole
-C_LABEL_FONT    = 0x0000 | Qt.ItemDataRole.FontRole
-C_COUNT_TEXT    = 0x0100 | Qt.ItemDataRole.DisplayRole
-C_COUNT_ICON    = 0x0100 | Qt.ItemDataRole.DecorationRole
-C_COUNT_ALIGN   = 0x0100 | Qt.ItemDataRole.TextAlignmentRole
-C_COUNT_TIP     = 0x0100 | Qt.ItemDataRole.ToolTipRole
-C_COUNT_ACCESS  = 0x0100 | Qt.ItemDataRole.AccessibleTextRole
-C_ACTIVE_ICON   = 0x0200 | Qt.ItemDataRole.DecorationRole
-C_ACTIVE_TIP    = 0x0200 | Qt.ItemDataRole.ToolTipRole
-C_ACTIVE_ACCESS = 0x0200 | Qt.ItemDataRole.AccessibleTextRole
-C_STATUS_ICON   = 0x0300 | Qt.ItemDataRole.DecorationRole
-C_STATUS_TIP    = 0x0300 | Qt.ItemDataRole.ToolTipRole
-C_STATUS_ACCESS = 0x0300 | Qt.ItemDataRole.AccessibleTextRole
+C_LABEL_TEXT    = 0x0000 | QtDisplayRole
+C_LABEL_ICON    = 0x0000 | QtDecorationRole
+C_LABEL_FONT    = 0x0000 | QtFontRole
+C_COUNT_TEXT    = 0x0100 | QtDisplayRole
+C_COUNT_ICON    = 0x0100 | QtDecorationRole
+C_COUNT_ALIGN   = 0x0100 | QtTextAlignmentRole
+C_COUNT_TIP     = 0x0100 | QtToolTipRole
+C_COUNT_ACCESS  = 0x0100 | QtAccessibleTextRole
+C_ACTIVE_ICON   = 0x0200 | QtDecorationRole
+C_ACTIVE_TIP    = 0x0200 | QtToolTipRole
+C_ACTIVE_ACCESS = 0x0200 | QtAccessibleTextRole
+C_STATUS_ICON   = 0x0300 | QtDecorationRole
+C_STATUS_TIP    = 0x0300 | QtToolTipRole
+C_STATUS_ACCESS = 0x0300 | QtAccessibleTextRole
 
 NODE_FLAGS = Qt.ItemFlag.ItemIsEnabled
 NODE_FLAGS |= Qt.ItemFlag.ItemIsSelectable

--- a/novelwriter/core/novelmodel.py
+++ b/novelwriter/core/novelmodel.py
@@ -33,7 +33,10 @@ from PyQt6.QtGui import QIcon, QPixmap
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwKeyWords, nwLabels, nwStyles, trConst
 from novelwriter.enum import nwNovelExtra
-from novelwriter.types import QtAlignRight
+from novelwriter.types import (
+    QtAccessibleTextRole, QtAlignRight, QtDecorationRole, QtDisplayRole,
+    QtTextAlignmentRole, QtToolTipRole
+)
 
 if TYPE_CHECKING:
     from novelwriter.core.indexdata import IndexHeading, IndexNode
@@ -41,12 +44,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 C_FACTOR = 0x0100
-
-R_TEXT   = Qt.ItemDataRole.DisplayRole
-R_ICON   = Qt.ItemDataRole.DecorationRole
-R_ALIGN  = Qt.ItemDataRole.TextAlignmentRole
-R_TIP    = Qt.ItemDataRole.ToolTipRole
-R_ACCESS = Qt.ItemDataRole.AccessibleTextRole
 R_HANDLE = 0xff01
 R_KEY    = 0xff02
 
@@ -205,22 +202,22 @@ class NovelModel(QAbstractTableModel):
         countInfo = f"{countValue} {CONFIG.countUnit}"
 
         data = {}
-        data[C_FACTOR*0 | R_TIP] = head.title
-        data[C_FACTOR*0 | R_TEXT] = head.title
-        data[C_FACTOR*0 | R_ICON] = SHARED.theme.getHeaderDecoration(iLevel)
-        data[C_FACTOR*1 | R_TEXT] = countValue
-        data[C_FACTOR*1 | R_TIP] = countInfo
-        data[C_FACTOR*1 | R_ACCESS] = countInfo
-        data[C_FACTOR*1 | R_ALIGN] = QtAlignRight
+        data[C_FACTOR*0 | QtToolTipRole] = head.title
+        data[C_FACTOR*0 | QtDisplayRole] = head.title
+        data[C_FACTOR*0 | QtDecorationRole] = SHARED.theme.getHeaderDecoration(iLevel)
+        data[C_FACTOR*1 | QtDisplayRole] = countValue
+        data[C_FACTOR*1 | QtToolTipRole] = countInfo
+        data[C_FACTOR*1 | QtAccessibleTextRole] = countInfo
+        data[C_FACTOR*1 | QtTextAlignmentRole] = QtAlignRight
         if self._columns == 3:
-            data[C_FACTOR*2 | R_ICON] = self._more
+            data[C_FACTOR*2 | QtDecorationRole] = self._more
         else:
             if self._extraKey and (refs := head.getReferencesByKeyword(self._extraKey)):
                 text = ", ".join(refs)
-                data[C_FACTOR*2 | R_TEXT] = text
-                data[C_FACTOR*2 | R_TIP] = f"<b>{self._extraLabel}:</b> {text}"
-                data[C_FACTOR*2 | R_ACCESS] = f"{self._extraLabel}: {text}"
-            data[C_FACTOR*3 | R_ICON] = self._more
+                data[C_FACTOR*2 | QtDisplayRole] = text
+                data[C_FACTOR*2 | QtToolTipRole] = f"<b>{self._extraLabel}:</b> {text}"
+                data[C_FACTOR*2 | QtAccessibleTextRole] = f"{self._extraLabel}: {text}"
+            data[C_FACTOR*3 | QtDecorationRole] = self._more
         data[R_HANDLE] = handle
         data[R_KEY] = key
         return data

--- a/novelwriter/gui/docviewerpanel.py
+++ b/novelwriter/gui/docviewerpanel.py
@@ -40,7 +40,7 @@ from novelwriter.constants import nwLabels, nwLists, nwStyles, trConst
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass
 from novelwriter.extensions.modified import NIconToolButton
 from novelwriter.gui.theme import STYLES_FLAT_TABS, STYLES_MIN_TOOLBUTTON
-from novelwriter.types import QtDecoration, QtHeaderFixed, QtHeaderToContents, QtUserRole
+from novelwriter.types import QtDecorationRole, QtHeaderFixed, QtHeaderToContents, QtUserRole
 
 if TYPE_CHECKING:
     from novelwriter.core.indexdata import IndexHeading, IndexNode
@@ -340,7 +340,7 @@ class _ViewPanelBackRefs(QTreeWidget):
             trItem.setToolTip(self.C_DOC, nwItem.itemName)
             trItem.setIcon(self.C_EDIT, self._editIcon)
             trItem.setIcon(self.C_VIEW, self._viewIcon)
-            trItem.setData(self.C_TITLE, QtDecoration, hDec)
+            trItem.setData(self.C_TITLE, QtDecorationRole, hDec)
             trItem.setText(self.C_TITLE, hItem.title)
             trItem.setToolTip(self.C_TITLE, hItem.title)
             trItem.setData(self.C_DATA, self.D_HANDLE, tHandle)
@@ -442,7 +442,7 @@ class _ViewPanelKeyWords(QTreeWidget):
         trItem.setIcon(self.C_DOC, nwItem.getMainIcon())
         trItem.setText(self.C_DOC, nwItem.itemName)
         trItem.setToolTip(self.C_DOC, nwItem.itemName)
-        trItem.setData(self.C_TITLE, QtDecoration, hDec)
+        trItem.setData(self.C_TITLE, QtDecorationRole, hDec)
         trItem.setText(self.C_TITLE, hItem.title)
         trItem.setToolTip(self.C_TITLE, hItem.title)
         trItem.setText(self.C_SHORT, hItem.synopsis)

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -50,7 +50,7 @@ from novelwriter.error import logException
 from novelwriter.extensions.configlayout import NColorLabel
 from novelwriter.extensions.novelselector import NovelSelector
 from novelwriter.types import (
-    QtAlignLeftTop, QtAlignRight, QtAlignRightTop, QtDecoration,
+    QtAlignLeftTop, QtAlignRight, QtAlignRightTop, QtDecorationRole,
     QtScrollAlwaysOff, QtScrollAsNeeded, QtSizeExpanding, QtUserRole
 )
 
@@ -680,7 +680,7 @@ class GuiOutlineTree(QTreeWidget):
             item = QTreeWidgetItem()
             hDec = SHARED.theme.getHeaderDecoration(iLevel)
 
-            item.setData(self._colIdx[nwOutline.TITLE], QtDecoration, hDec)
+            item.setData(self._colIdx[nwOutline.TITLE], QtDecorationRole, hDec)
             item.setText(self._colIdx[nwOutline.TITLE], novIdx.title)
             item.setData(self._colIdx[nwOutline.TITLE], self.D_HANDLE, tHandle)
             item.setData(self._colIdx[nwOutline.TITLE], self.D_TITLE, sTitle)

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -44,7 +44,7 @@ from novelwriter.extensions.modified import NNonBlockingDialog
 from novelwriter.extensions.novelselector import NovelSelector
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
 from novelwriter.extensions.switch import NSwitch
-from novelwriter.types import QtAlignRight, QtDecoration, QtFontSemiBold, QtRoleDestruct
+from novelwriter.types import QtAlignRight, QtDecorationRole, QtFontSemiBold, QtRoleDestruct
 
 if TYPE_CHECKING:
     from PyQt6.QtGui import QCloseEvent
@@ -459,7 +459,7 @@ class _ContentsPage(NFixedPage):
             if tTitle.strip() == "":
                 tTitle = self.tr("Untitled")
 
-            newItem.setData(self.C_TITLE, QtDecoration, hDec)
+            newItem.setData(self.C_TITLE, QtDecorationRole, hDec)
             newItem.setText(self.C_TITLE, tTitle)
             newItem.setText(self.C_WORDS, f"{wCount:n}")
             newItem.setText(self.C_PAGES, f"{pCount:n}")

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -27,6 +27,7 @@ import logging
 
 from datetime import datetime
 from pathlib import Path
+from typing import NamedTuple
 
 from PyQt6.QtCore import (
     QAbstractListModel, QModelIndex, QObject, QPoint, QSize, Qt, pyqtSignal,
@@ -48,7 +49,10 @@ from novelwriter.extensions.configlayout import NColorLabel, NWrappedWidgetBox
 from novelwriter.extensions.modified import NDialog, NIconToolButton, NSpinBox
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.extensions.versioninfo import VersionInfoWidget
-from novelwriter.types import QtAlignLeft, QtAlignRightTop, QtHexArgb, QtScrollAsNeeded, QtSelected
+from novelwriter.types import (
+    QtAccessibleTextRole, QtAlignLeft, QtAlignRightTop, QtDisplayRole,
+    QtHexArgb, QtScrollAsNeeded, QtSelected
+)
 
 logger = logging.getLogger(__name__)
 
@@ -317,8 +321,8 @@ class _OpenProjectPage(QWidget):
     @pyqtSlot()
     def openSelectedItem(self) -> None:
         """Open the currently selected project item."""
-        if (selection := self.listWidget.selectedIndexes()) and (index := selection[0]).isValid():
-            self._processOpenProjectRequest(str(index.data()[1]))
+        if (sel := self.listWidget.selectedIndexes()) and (entry := self.listModel.entry(sel[0])):
+            self._processOpenProjectRequest(entry.path)
 
     ##
     #  Private Slots
@@ -332,7 +336,7 @@ class _OpenProjectPage(QWidget):
     @pyqtSlot(QModelIndex)
     def _projectSelected(self, index: QModelIndex) -> None:
         """Process single click on project item."""
-        value = index.data()[1] if index.isValid() else ""
+        value = entry.path if (entry := self.listModel.entry(index)) else ""
         value = "" if value == SAMPLE_KEY else value
         text = f"{self._trPath}: {value}"
         self.selectedPath.setText(text)
@@ -343,19 +347,19 @@ class _OpenProjectPage(QWidget):
     @pyqtSlot(QModelIndex)
     def _projectDoubleClicked(self, index: QModelIndex) -> None:
         """Process double click on project item."""
-        if index.isValid():
-            self._processOpenProjectRequest(str(index.data()[1]))
+        if entry := self.listModel.entry(index):
+            self._processOpenProjectRequest(entry.path)
 
     @pyqtSlot()
     def _deleteSelectedItem(self) -> None:
         """Delete the currently selected project item."""
-        if (selection := self.listWidget.selectedIndexes()) and (index := selection[0]).isValid():
+        if (sel := self.listWidget.selectedIndexes()) and (entry := self.listModel.entry(sel[0])):
             text = self.tr(
                 "Remove '{0}' from the recent projects list? "
                 "The project files will not be deleted."
-            ).format(index.data()[0])
+            ).format(entry.title)
             if SHARED.question(text):
-                self.listModel.removeEntry(index)
+                self.listModel.removeEntry(sel[0])
             self._selectFirstItem()
 
     @pyqtSlot("QPoint")
@@ -422,66 +426,93 @@ class _ProjectListItem(QStyledItemDelegate):
 
     def paint(self, painter: QPainter, opt: QStyleOptionViewItem, index: QModelIndex) -> None:
         """Paint a project entry on the canvas."""
-        rect = opt.rect
-        title, _, details = index.data()
-        tFlag = Qt.TextFlag.TextSingleLine
-        x, y = self._pPx
+        if isinstance(entry := index.data(QtDisplayRole), _ProjectListEntry):
+            rect = opt.rect
+            tFlag = Qt.TextFlag.TextSingleLine
+            x, y = self._pPx
 
-        painter.save()
-        if opt.state & QtSelected == QtSelected:
-            painter.setOpacity(0.25)
-            painter.fillRect(rect, QApplication.palette().text())
-            painter.setOpacity(1.0)
+            painter.save()
+            if opt.state & QtSelected == QtSelected:
+                painter.setOpacity(0.25)
+                painter.fillRect(rect, QApplication.palette().text())
+                painter.setOpacity(1.0)
 
-        painter.drawPixmap(2, rect.top() + 6, self._icon)
-        painter.setFont(self._tFont)
-        painter.drawText(rect.adjusted(x, 4, 0, 0), tFlag, title)
-        painter.setFont(self._dFont)
-        painter.setPen(self._dPen)
-        painter.drawText(rect.adjusted(x, y, 0, 0), tFlag, details)
-        painter.restore()
+            painter.drawPixmap(2, rect.top() + 6, self._icon)
+            painter.setFont(self._tFont)
+            painter.drawText(rect.adjusted(x, 4, 0, 0), tFlag, entry.title)
+            painter.setFont(self._dFont)
+            painter.setPen(self._dPen)
+            painter.drawText(rect.adjusted(x, y, 0, 0), tFlag, entry.details)
+            painter.restore()
 
     def sizeHint(self, opt: QStyleOptionViewItem, index: QModelIndex) -> QSize:
         """Set the size hint to fixed height."""
         return QSize(opt.rect.width(), self._hPx)
 
 
+class _ProjectListEntry(NamedTuple):
+    title: str
+    path: str
+    details: str
+    accessible: str
+
+
 class _ProjectListModel(QAbstractListModel):
+
+    __slots__ = ("_data",)
 
     def __init__(self, parent: QObject) -> None:
         super().__init__(parent=parent)
-        data = []
+
+        self._data: list[_ProjectListEntry] = []
+
         words = self.tr("Word Count")
         opened = self.tr("Last Opened")
         records = sorted(CONFIG.recentProjects.listEntries(), key=lambda x: x[3], reverse=True)
         for path, title, count, time in records:
             when = CONFIG.localDate(datetime.fromtimestamp(time))
-            data.append((title, path, f"{opened}: {when}, {words}: {formatInt(count)}"))
-        if not data:
-            data.append((SAMPLE_NAME, SAMPLE_KEY, self.tr("Select to create an example project")))
-        self._data = data
+            self._data.append(_ProjectListEntry(
+                title=title,
+                path=path,
+                details=f"{opened}: {when}, {words}: {formatInt(count)}",
+                accessible=f"{title}, {opened} {when}, {words} {formatInt(count)}",
+            ))
+
+        if not self._data:
+            details = self.tr("Select to create an example project")
+            self._data.append(_ProjectListEntry(
+                title=SAMPLE_NAME,
+                path=SAMPLE_KEY,
+                details=details,
+                accessible=details
+            ))
 
     def rowCount(self, parent: QModelIndex | None = None) -> int:
         """Return the size of the model."""
         return len(self._data)
 
-    def data(self, index: QModelIndex, role: int = 0) -> tuple[str, str, str]:
+    def entry(self, index: QModelIndex) -> _ProjectListEntry | None:
+        """Return an entry in the model."""
+        if index.isValid() and 0 <= (idx := index.row()) < len(self._data):
+            return self._data[idx]
+        return None
+
+    def data(self, index: QModelIndex, role: Qt.ItemDataRole) -> _ProjectListEntry | str | None:
         """Return data for an individual item."""
-        try:
-            return self._data[index.row()] if index.isValid() else ("", "", "")
-        except IndexError:
-            return "", "", ""
+        if entry := self.entry(index):
+            if role == QtDisplayRole:
+                return entry
+            elif role == QtAccessibleTextRole:
+                return entry.accessible
+        return None
 
     def removeEntry(self, index: QModelIndex) -> bool:
         """Remove an entry in the model."""
-        if index.isValid() and (path := index.data()[1]):
-            try:
-                self.beginRemoveRows(index.parent(), index.row(), index.row())
-                self._data.pop(index.row())
-                self.endRemoveRows()
-            except IndexError:
-                return False
-            CONFIG.recentProjects.remove(path)
+        if entry := self.entry(index):
+            self.beginRemoveRows(index.parent(), index.row(), index.row())
+            self._data.pop(index.row())
+            self.endRemoveRows()
+            CONFIG.recentProjects.remove(entry.path)
             return True
         return False
 

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -44,7 +44,7 @@ from novelwriter.error import formatException
 from novelwriter.extensions.modified import NPushButton, NToolDialog
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import (
-    QtAlignLeftMiddle, QtAlignRight, QtAlignRightMiddle, QtDecoration,
+    QtAlignLeftMiddle, QtAlignRight, QtAlignRightMiddle, QtDecorationRole,
     QtRoleAction, QtRoleDestruct
 )
 
@@ -593,7 +593,7 @@ class GuiWritingStats(NToolDialog):
                     int(200*min(nWords, histMax)/listMax),
                     self.barHeight, mAspect, mTrans
                 )
-                newItem.setData(self.C_BAR, QtDecoration, wBar)
+                newItem.setData(self.C_BAR, QtDecorationRole, wBar)
 
             newItem.setTextAlignment(self.C_LENGTH, QtAlignRight)
             newItem.setTextAlignment(self.C_IDLE, QtAlignRight)

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -88,9 +88,14 @@ QtColActive = QPalette.ColorGroup.Active
 QtColInactive = QPalette.ColorGroup.Inactive
 QtColDisabled = QPalette.ColorGroup.Disabled
 
-# Qt Tree and Table Types
+# Model Item Data
 
-QtDecoration = Qt.ItemDataRole.DecorationRole
+QtAccessibleTextRole = Qt.ItemDataRole.AccessibleTextRole
+QtDecorationRole = Qt.ItemDataRole.DecorationRole
+QtDisplayRole = Qt.ItemDataRole.DisplayRole
+QtFontRole = Qt.ItemDataRole.FontRole
+QtTextAlignmentRole = Qt.ItemDataRole.TextAlignmentRole
+QtToolTipRole = Qt.ItemDataRole.ToolTipRole
 QtUserRole = Qt.ItemDataRole.UserRole
 
 # Keyboard and Mouse Buttons

--- a/tests/test_core/test_core_itemmodel.py
+++ b/tests/test_core/test_core_itemmodel.py
@@ -31,6 +31,7 @@ from novelwriter.core.item import NWItem
 from novelwriter.core.itemmodel import INV_ROOT, NODE_FLAGS, ProjectModel, ProjectNode
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwItemLayout, nwItemType
+from novelwriter.types import QtDisplayRole, QtToolTipRole
 
 from tests.tools import buildTestProject
 
@@ -239,15 +240,15 @@ def testCoreItemModel_ProjectNode_Data(mockGUI, mockRnd, fncPath):
     assert scene.item.itemName == "New Scene"
 
     # Check Data
-    assert novel.data(0, Qt.ItemDataRole.DisplayRole) == "Novel"
-    assert novel.data(1, Qt.ItemDataRole.DisplayRole) == "9"
-    assert scene.data(0, Qt.ItemDataRole.DisplayRole) == "New Scene"
-    assert scene.data(1, Qt.ItemDataRole.DisplayRole) == "2"
+    assert novel.data(0, QtDisplayRole) == "Novel"
+    assert novel.data(1, QtDisplayRole) == "9"
+    assert scene.data(0, QtDisplayRole) == "New Scene"
+    assert scene.data(1, QtDisplayRole) == "2"
 
-    assert novel.data(2, Qt.ItemDataRole.ToolTipRole) == ""
-    assert novel.data(3, Qt.ItemDataRole.ToolTipRole) == "New"
-    assert scene.data(2, Qt.ItemDataRole.ToolTipRole) == "Active"
-    assert scene.data(3, Qt.ItemDataRole.ToolTipRole) == "New"
+    assert novel.data(2, QtToolTipRole) == ""
+    assert novel.data(3, QtToolTipRole) == "New"
+    assert scene.data(2, QtToolTipRole) == "Active"
+    assert scene.data(3, QtToolTipRole) == "New"
 
     # Check Flags
     assert novel.flags() == NODE_FLAGS
@@ -304,9 +305,9 @@ def testCoreItemModel_ProjectModel_Interface(mockGUI, mockRnd, fncPath):
     assert parent.isValid() is False
 
     # Data and Flags
-    assert model.data(novelIdx, Qt.ItemDataRole.DisplayRole) == "Novel"
-    assert model.data(sceneIdx, Qt.ItemDataRole.DisplayRole) == "New Scene"
-    assert model.data(invalidIdx, Qt.ItemDataRole.DisplayRole) is None
+    assert model.data(novelIdx, QtDisplayRole) == "Novel"
+    assert model.data(sceneIdx, QtDisplayRole) == "New Scene"
+    assert model.data(invalidIdx, QtDisplayRole) is None
     assert model.flags(novelIdx) == NODE_FLAGS
     assert model.flags(sceneIdx) == NODE_FLAGS | Qt.ItemFlag.ItemIsDragEnabled
     assert model.flags(invalidIdx) == Qt.ItemFlag.NoItemFlags

--- a/tests/test_core/test_core_novelmodel.py
+++ b/tests/test_core/test_core_novelmodel.py
@@ -22,13 +22,14 @@ from __future__ import annotations
 
 import pytest
 
-from PyQt6.QtCore import QModelIndex, Qt
+from PyQt6.QtCore import QModelIndex
 from PyQt6.QtTest import QAbstractItemModelTester
 
 from novelwriter.core.indexdata import IndexHeading
 from novelwriter.core.novelmodel import NovelModel
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwNovelExtra
+from novelwriter.types import QtDisplayRole
 
 from tests.tools import C, buildTestProject
 
@@ -56,14 +57,14 @@ def testCoreNovelModel_Interface(nwGUI, fncPath, mockRnd):
     # Initial structure
     assert model.rowCount(root) == 3
     assert model.columnCount(root) == 3
-    assert model.data(model.createIndex(0, 0), Qt.ItemDataRole.DisplayRole) == "New Novel"
+    assert model.data(model.createIndex(0, 0), QtDisplayRole) == "New Novel"
     assert model.handle(model.createIndex(0, 0)) == C.hTitlePage
     assert model.key(model.createIndex(0, 0)) == "T0001"
 
     # Clear the model and check error handling
     model.clear()
 
-    assert model.data(root, Qt.ItemDataRole.DisplayRole) is None
+    assert model.data(root, QtDisplayRole) is None
     assert model.handle(root) is None
     assert model.key(root) is None
 
@@ -103,7 +104,7 @@ def testCoreNovelModel_Extra(nwGUI, fncPath, mockRnd):
     assert model.columns == 4
     assert model._extraKey == "@pov"
     assert model._extraLabel == "Point of View"
-    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "Jane"
+    assert model.data(model.createIndex(2, 2), QtDisplayRole) == "Jane"
 
     model.setExtraColumn(nwNovelExtra.HIDDEN)
     assert model.columns == 3
@@ -114,7 +115,7 @@ def testCoreNovelModel_Extra(nwGUI, fncPath, mockRnd):
     assert model.columns == 4
     assert model._extraKey == "@focus"
     assert model._extraLabel == "Focus"
-    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "John"
+    assert model.data(model.createIndex(2, 2), QtDisplayRole) == "John"
 
     model.setExtraColumn(nwNovelExtra.HIDDEN)
     assert model.columns == 3
@@ -125,7 +126,7 @@ def testCoreNovelModel_Extra(nwGUI, fncPath, mockRnd):
     assert model.columns == 4
     assert model._extraKey == "@plot"
     assert model._extraLabel == "Plot"
-    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "Main, Side"
+    assert model.data(model.createIndex(2, 2), QtDisplayRole) == "Main, Side"
 
     model.setExtraColumn(nwNovelExtra.HIDDEN)
     assert model.columns == 3
@@ -168,7 +169,7 @@ def testCoreNovelModel_Data(nwGUI, fncPath, mockRnd):
     scene.addHeading(IndexHeading(scene._cache, "T0003", 10, "H4", "Another Section"))
     assert model.refresh(scene) is True
     assert [
-        model.data(model.createIndex(i, 0), Qt.ItemDataRole.DisplayRole)
+        model.data(model.createIndex(i, 0), QtDisplayRole)
         for i in range(model.rowCount(root))
     ] == [
         "New Novel", "New Chapter", "New Scene", "A Section", "Another Section",
@@ -179,7 +180,7 @@ def testCoreNovelModel_Data(nwGUI, fncPath, mockRnd):
     del scene._headings["T0003"]
     assert model.refresh(scene) is True
     assert [
-        model.data(model.createIndex(i, 0), Qt.ItemDataRole.DisplayRole)
+        model.data(model.createIndex(i, 0), QtDisplayRole)
         for i in range(model.rowCount(root))
     ] == [
         "New Novel", "New Chapter", "New Scene",

--- a/tests/test_gui/test_gui_noveltree.py
+++ b/tests/test_gui/test_gui_noveltree.py
@@ -24,13 +24,14 @@ from pathlib import Path
 
 import pytest
 
-from PyQt6.QtCore import QModelIndex, QPoint, Qt
+from PyQt6.QtCore import QModelIndex, QPoint
 from PyQt6.QtWidgets import QInputDialog, QToolTip
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.core.novelmodel import NovelModel
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwFocus, nwItemType, nwNovelExtra, nwView
+from novelwriter.types import QtDisplayRole
 
 from tests.tools import C, buildTestProject
 
@@ -100,10 +101,10 @@ def testGuiNovelView_Content(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     # Check the items
     assert model.rowCount(root) == 3
     assert model.columnCount(root) == 3
-    assert model.data(model.createIndex(2, 1), Qt.ItemDataRole.DisplayRole) == "2"  # Word Count
+    assert model.data(model.createIndex(2, 1), QtDisplayRole) == "2"  # Word Count
 
     nwGUI.rebuildIndex()  # This should update the word count to the edited scene
-    assert model.data(model.createIndex(2, 1), Qt.ItemDataRole.DisplayRole) == "10"  # Word Count
+    assert model.data(model.createIndex(2, 1), QtDisplayRole) == "10"  # Word Count
 
     # Extra Column
     # ============
@@ -112,7 +113,7 @@ def testGuiNovelView_Content(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     assert model.columnCount(root) == 4
 
     # Scene column should contain the POV character
-    assert model.data(model.createIndex(2, 2), Qt.ItemDataRole.DisplayRole) == "Jane"
+    assert model.data(model.createIndex(2, 2), QtDisplayRole) == "Jane"
 
     # Resize the last column
     assert novelTree.lastColSize == 25

--- a/tests/test_tools/test_tools_welcome.py
+++ b/tests/test_tools/test_tools_welcome.py
@@ -33,8 +33,11 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwFiles
 from novelwriter.core.projectdata import NWProjectData
 from novelwriter.enum import nwItemClass
-from novelwriter.tools.welcome import SAMPLE_KEY, SAMPLE_NAME, GuiWelcome
-from novelwriter.types import QtMouseLeft
+from novelwriter.tools.welcome import SAMPLE_KEY, SAMPLE_NAME, GuiWelcome, _ProjectListEntry
+from novelwriter.types import (
+    QtAccessibleTextRole, QtDecorationRole, QtDisplayRole, QtFontRole,
+    QtMouseLeft, QtTextAlignmentRole, QtToolTipRole, QtUserRole
+)
 
 
 @pytest.mark.gui
@@ -96,7 +99,7 @@ def testToolWelcome_Main(qtbot, monkeypatch, nwGUI, fncPath):
 
 
 @pytest.mark.gui
-def testToolWelcome_Open(qtbot, monkeypatch, nwGUI, fncPath):
+def testToolWelcome_Open(qtbot, monkeypatch, nwGUI):
     """Test the open tab in the Welcome window."""
     monkeypatch.setattr(QMenu, "exec", lambda *a: None)
     monkeypatch.setattr(QMenu, "setParent", lambda *a: None)
@@ -129,12 +132,31 @@ def testToolWelcome_Open(qtbot, monkeypatch, nwGUI, fncPath):
     posTwo = tabOpen.listWidget.rectForIndex(listModel.createIndex(1, 0)).center()
 
     # Check items, which should be in opposite order
-    assert listModel.data(listModel.createIndex(0, 0)) == (
-        "Project Two", "/stuff/project_two", f"Last Opened: {dateOne}, Word Count: 54.3\u2009k"
-    )
-    assert listModel.data(listModel.createIndex(1, 0)) == (
-        "Project One", "/stuff/project_one", f"Last Opened: {dateTwo}, Word Count: 12.3\u2009k"
-    )
+    entry = listModel.data(listModel.createIndex(0, 0), QtDisplayRole)
+    assert isinstance(entry, _ProjectListEntry)
+    assert entry.title == "Project Two"
+    assert entry.path == "/stuff/project_two"
+    assert entry.details == f"Last Opened: {dateOne}, Word Count: 54.3\u2009k"
+    assert entry.accessible == f"Project Two, Last Opened {dateOne}, Word Count 54.3\u2009k"
+    assert listModel.data(listModel.createIndex(0, 0), QtAccessibleTextRole) == entry.accessible
+
+    entry = listModel.data(listModel.createIndex(1, 0), QtDisplayRole)
+    assert isinstance(entry, _ProjectListEntry)
+    assert entry.title == "Project One"
+    assert entry.path == "/stuff/project_one"
+    assert entry.details == f"Last Opened: {dateTwo}, Word Count: 12.3\u2009k"
+    assert entry.accessible == f"Project One, Last Opened {dateTwo}, Word Count 12.3\u2009k"
+    assert listModel.data(listModel.createIndex(1, 0), QtAccessibleTextRole) == entry.accessible
+
+    # Check other model data roles
+    assert listModel.data(listModel.createIndex(0, 0), QtDecorationRole) is None
+    assert listModel.data(listModel.createIndex(0, 0), QtFontRole) is None
+    assert listModel.data(listModel.createIndex(0, 0), QtTextAlignmentRole) is None
+    assert listModel.data(listModel.createIndex(0, 0), QtToolTipRole) is None
+    assert listModel.data(listModel.createIndex(0, 0), QtUserRole) is None
+
+    # Check out of range index
+    assert listModel.data(listModel.createIndex(2, 0), QtDisplayRole) is None
 
     # Change selection with arrow keys
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
@@ -207,17 +229,13 @@ def testToolWelcome_Open(qtbot, monkeypatch, nwGUI, fncPath):
     ctxMenu.deleteLater()
 
     # Check removing entry error handling
-    assert listModel.data(listModel.createIndex(1, 0)) == ("", "", "")
+    assert listModel.data(listModel.createIndex(1, 0), QtDisplayRole) is None
     assert listModel.removeEntry(listModel.createIndex(1, 0)) is False
-    with monkeypatch.context() as mp:
-        mp.setattr(listModel, "data", lambda *a: ("a", "b", "c"))
-        assert listModel.removeEntry(listModel.createIndex(1, 0)) is False
 
     # qtbot.stop()
     welcome.close()
 
 
-# @pytest.mark.skip
 @pytest.mark.gui
 def testToolWelcome_New(qtbot, caplog, monkeypatch, nwGUI, fncPath):
     """Test the new project tab in the Welcome window."""


### PR DESCRIPTION
**Summary:**

This PR:
* Defines constants for all Qt.ItemDataRole enums in use.
* Rewrites the item data model for the welcome dialog to only return data for DisplayRole and AccessibleTextRole.
* Format a screen reader friendly AccessibleTextRole value.

**Related Issue(s):**

Closes #2714

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
