### PR TITLE
Fix path label focus colour change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![MacOS](https://github.com/vkbo/novelWriter/actions/workflows/test_mac.yml/badge.svg)](https://github.com/vkbo/novelWriter/actions/workflows/test_mac.yml)
 [![Linting](https://github.com/vkbo/novelWriter/actions/workflows/syntax.yml/badge.svg)](https://github.com/vkbo/novelWriter/actions/workflows/syntax.yml)
 [![CodeCov](https://codecov.io/gh/vkbo/novelWriter/branch/main/graph/badge.svg)](https://codecov.io/gh/vkbo/novelWriter)
-[![PDM](https://img.shields.io/endpoint?url=https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2Fpdm-project%2F.github%2Fbadge.json)](https://pdm-project.org)
 
 <img align="left" style="margin: 0 0 4px 0;" src="https://raw.githubusercontent.com/vkbo/novelWriter/main/setup/novelwriter_readme.png">
 

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -291,15 +291,15 @@ class NColorLabel(QLabel):
         self._color = color or self._color
         self._faded = faded or self._faded
         self._error = error or self._error
-        self._refeshTextColor()
+        self._refreshTextColor()
 
     def setColorState(self, state: nwState) -> None:
         """Change the colour state."""
         if self._state is not state:
             self._state = state
-            self._refeshTextColor()
+            self._refreshTextColor()
 
-    def _refeshTextColor(self) -> None:
+    def _refreshTextColor(self) -> None:
         """Refresh the colour of the text on the label."""
         palette = self.palette()
         match self._state:
@@ -329,11 +329,11 @@ class NPathColorLabel(NColorLabel):
                     for h, n in value
                 ]))
             ))
-            self._refeshTextColor()
+            self._refreshTextColor()
 
-    def _refeshTextColor(self) -> None:
+    def _refreshTextColor(self) -> None:
         """Refresh the colour of the text on the label."""
-        super()._refeshTextColor()
+        super()._refreshTextColor()
         color = self.palette().windowText().color().name(QtHexArgb)
         super().setText(self._text.replace("#000000", color))
 

--- a/novelwriter/extensions/configlayout.py
+++ b/novelwriter/extensions/configlayout.py
@@ -334,7 +334,7 @@ class NPathColorLabel(NColorLabel):
     def _refeshTextColor(self) -> None:
         """Refresh the colour of the text on the label."""
         super()._refeshTextColor()
-        color = self.palette().text().color().name(QtHexArgb)
+        color = self.palette().windowText().color().name(QtHexArgb)
         super().setText(self._text.replace("#000000", color))
 
 


### PR DESCRIPTION
**Summary:**

This PR fixes a bug with focus/defocus colouring in the custom label widget used for the breadcrumbs path in the editor and viewer.

**Related Issue(s):**

Closes #2716

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
