### PR TITLE
Update manuscript build settings label

### DIFF
--- a/i18n/nw_base.ts
+++ b/i18n/nw_base.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_cs_CZ.ts
+++ b/i18n/nw_cs_CZ.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_de_DE.ts
+++ b/i18n/nw_de_DE.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_en_US.ts
+++ b/i18n/nw_en_US.ts
@@ -120,8 +120,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
-        <translation>Add titles for notes</translation>
+        <source>Add titles for note root folders</source>
+        <translation type="unfinished" />
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="163" />

--- a/i18n/nw_es_419.ts
+++ b/i18n/nw_es_419.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_fr_FR.ts
+++ b/i18n/nw_fr_FR.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_it_IT.ts
+++ b/i18n/nw_it_IT.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_ja_JP.ts
+++ b/i18n/nw_ja_JP.ts
@@ -120,8 +120,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
-        <translation>ノートにタイトルを追加</translation>
+        <source>Add titles for note root folders</source>
+        <translation type="unfinished" />
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="163" />

--- a/i18n/nw_nb_NO.ts
+++ b/i18n/nw_nb_NO.ts
@@ -120,8 +120,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
-        <translation>Legg til titler for notatsider</translation>
+        <source>Add titles for note root folders</source>
+        <translation type="unfinished" />
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="163" />

--- a/i18n/nw_nl_NL.ts
+++ b/i18n/nw_nl_NL.ts
@@ -120,8 +120,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
-        <translation>Titels voor notities toevoegen</translation>
+        <source>Add titles for note root folders</source>
+        <translation type="unfinished" />
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="163" />

--- a/i18n/nw_pl_PL.ts
+++ b/i18n/nw_pl_PL.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_pt_BR.ts
+++ b/i18n/nw_pt_BR.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_ru_RU.ts
+++ b/i18n/nw_ru_RU.ts
@@ -120,7 +120,7 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
+        <source>Add titles for note root folders</source>
         <translation type="unfinished" />
     </message>
     <message>

--- a/i18n/nw_zh_CN.ts
+++ b/i18n/nw_zh_CN.ts
@@ -120,8 +120,8 @@
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="161" />
-        <source>Add titles for notes</source>
-        <translation>为笔记添加标题</translation>
+        <source>Add titles for note root folders</source>
+        <translation type="unfinished" />
     </message>
     <message>
         <location filename="../novelwriter/core/buildsettings.py" line="163" />

--- a/novelwriter/core/buildsettings.py
+++ b/novelwriter/core/buildsettings.py
@@ -158,7 +158,7 @@ SETTINGS_LABELS = {
     "text.includeNotes":       QT_TRANSLATE_NOOP("Builds", "Include manuscript notes"),
     "text.includeKeywords":    QT_TRANSLATE_NOOP("Builds", "Include keywords"),
     "text.ignoredKeywords":    QT_TRANSLATE_NOOP("Builds", "Ignore these keywords"),
-    "text.addNoteHeadings":    QT_TRANSLATE_NOOP("Builds", "Add titles for notes"),
+    "text.addNoteHeadings":    QT_TRANSLATE_NOOP("Builds", "Add titles for note root folders"),
 
     "format.grpFormat":        QT_TRANSLATE_NOOP("Builds", "Text Format"),
     "format.textFont":         QT_TRANSLATE_NOOP("Builds", "Text font"),


### PR DESCRIPTION
**Summary:**

Since there are more things called "notes" now, this GUI label needs to be clearer.

**Related Issue(s):**

Closes #2727

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
