### PR TITLE
Don't expand justified text on short lines for DocX

### DIFF
--- a/novelwriter/formats/todocx.py
+++ b/novelwriter/formats/todocx.py
@@ -1023,6 +1023,7 @@ class ToDocX(Tokenizer):
         xmlSubElem(xSet, _wTag("numFmt"), attrib={W_VAL: "decimal"})
 
         xSet = xmlSubElem(xRoot, _wTag("compat"))
+        xmlSubElem(xSet, _wTag("doNotExpandShiftReturn"))
         xmlSubElem(xSet, _wTag("compatSetting"), attrib={
             _wTag("name"): "compatibilityMode",
             _wTag("uri"): "http://schemas.microsoft.com/office/word",

--- a/tests/reference/fmtToDocX_SaveDocument_settings.xml
+++ b/tests/reference/fmtToDocX_SaveDocument_settings.xml
@@ -4,6 +4,7 @@
     <w:numFmt w:val="decimal" />
   </w:footnotePr>
   <w:compat>
+    <w:doNotExpandShiftReturn />
     <w:compatSetting w:name="compatibilityMode" w:uri="http://schemas.microsoft.com/office/word" w:val="12" />
   </w:compat>
   <w:docVars>


### PR DESCRIPTION
**Summary:**

This PR adds a setting to the DocX export to prevent expansion of short lines when using justified margins.

**Related Issue(s):**

Closes #2690

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
