### PR TITLE
Improve key press processing in editor completer menu

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -38,6 +38,7 @@ import logging
 
 from enum import Enum, IntFlag
 from time import time
+from typing import NamedTuple
 
 from PyQt6 import sip
 from PyQt6.QtCore import (
@@ -2536,6 +2537,14 @@ class GuiDocEditor(QPlainTextEdit):
                     break
 
 
+class CompleterAction(NamedTuple):
+    """Values needed to complete a completer action."""
+
+    pos: int
+    length: int
+    value: str
+
+
 class CommandCompleter(QMenu):
     """GuiWidget: Command Completer Menu.
 
@@ -2552,6 +2561,7 @@ class CommandCompleter(QMenu):
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
         self._parent = parent
+        self.triggered.connect(self._emitComplete)
 
     def updateMetaText(self, text: str, pos: int) -> bool:
         """Update the menu options based on the line of text."""
@@ -2583,7 +2593,7 @@ class CommandCompleter(QMenu):
         for value in options:
             rep = value + suffix
             action = qtAddAction(self, value)
-            action.triggered.connect(qtLambda(self._emitComplete, offset, length, rep))
+            action.setData(CompleterAction(pos=offset, length=length, value=rep))
 
         return True
 
@@ -2626,7 +2636,7 @@ class CommandCompleter(QMenu):
                 for value in options:
                     rep = value + suffix
                     action = qtAddAction(self, rep.rstrip(":. "))
-                    action.triggered.connect(qtLambda(self._emitComplete, offset, length, rep))
+                    action.setData(CompleterAction(pos=offset, length=length, value=rep))
                 return True
 
         return False
@@ -2639,28 +2649,35 @@ class CommandCompleter(QMenu):
         """Capture keypresses and forward most of them to the editor."""
         match event.key():
             case Qt.Key.Key_Up | Qt.Key.Key_Down:
+                # Let the menu handle navigation
                 super().keyPressEvent(event)
             case Qt.Key.Key_Right | Qt.Key.Key_Return | Qt.Key.Key_Enter | Qt.Key.Key_Tab:
+                # Activate the selection if there is one, otherwise close the completer
                 if action := self.activeAction():
                     action.trigger()
                 else:
                     self.clear()
                     self.close()
             case Qt.Key.Key_Left | Qt.Key.Key_Escape:
+                # Cancel the completer
                 self.clear()
                 self.close()
             case _:
+                # Any other keys, send back to the editor
+                # Also close to release the event lock before forwarding key press (#2510)
                 self.clear()
-                self.close()  # Close to release the event lock before forwarding key press (#2510)
+                self.close()
                 self._parent.keyPressEvent(event)
 
     ##
-    #  Internal Functions
+    #  Internal Slots
     ##
 
-    def _emitComplete(self, pos: int, length: int, value: str) -> None:
+    @pyqtSlot(QAction)
+    def _emitComplete(self, action: QAction) -> None:
         """Emit the signal to indicate a selection has been made."""
-        self.insertText.emit(pos, length, value)
+        if isinstance(data := action.data(), CompleterAction):
+            self.insertText.emit(data.pos, data.length, data.value)
 
 
 class BackgroundWordCounter(QRunnable):

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -2637,14 +2637,22 @@ class CommandCompleter(QMenu):
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Capture keypresses and forward most of them to the editor."""
-        if event.key() in (
-            Qt.Key.Key_Up, Qt.Key.Key_Down, Qt.Key.Key_Return,
-            Qt.Key.Key_Enter, Qt.Key.Key_Escape
-        ):
-            super().keyPressEvent(event)
-        else:
-            self.close()  # Close to release the event lock before forwarding the key press (#2510)
-            self._parent.keyPressEvent(event)
+        match event.key():
+            case Qt.Key.Key_Up | Qt.Key.Key_Down:
+                super().keyPressEvent(event)
+            case Qt.Key.Key_Right | Qt.Key.Key_Return | Qt.Key.Key_Enter | Qt.Key.Key_Tab:
+                if action := self.activeAction():
+                    action.trigger()
+                else:
+                    self.clear()
+                    self.close()
+            case Qt.Key.Key_Left | Qt.Key.Key_Escape:
+                self.clear()
+                self.close()
+            case _:
+                self.clear()
+                self.close()  # Close to release the event lock before forwarding key press (#2510)
+                self._parent.keyPressEvent(event)
 
     ##
     #  Internal Functions

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -2564,7 +2564,7 @@ class CommandCompleter(QMenu):
         self.triggered.connect(self._emitComplete)
 
     def updateMetaText(self, text: str, pos: int) -> bool:
-        """Update the menu options based on the line of text."""
+        """Update the menu options based on the line of meta text."""
         self.clear()
         kw, sep, _ = text.partition(":")
         if pos <= len(kw):
@@ -2598,7 +2598,7 @@ class CommandCompleter(QMenu):
         return True
 
     def updateCommentText(self, text: str, pos: int) -> bool:
-        """Update the menu options based on the line of text."""
+        """Update the menu options based on the line of comment text."""
         self.clear()
         cmd, sep, _ = text.partition(":")
         if pos <= len(cmd):

--- a/tests/test_gui/test_gui_doceditor.py
+++ b/tests/test_gui/test_gui_doceditor.py
@@ -38,7 +38,7 @@ from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.core.item import NWItem
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwDocAction, nwDocInsert, nwItemClass, nwItemLayout, nwState
-from novelwriter.gui.doceditor import GuiDocEditor, TextAutoReplace, _TagAction
+from novelwriter.gui.doceditor import CommandCompleter, GuiDocEditor, TextAutoReplace, _TagAction
 from novelwriter.gui.dochighlight import TextBlockData
 from novelwriter.text.counting import standardCounter
 from novelwriter.types import (
@@ -1964,7 +1964,7 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     nwGUI.saveDocument()
 
     docEditor.replaceText("")
-    completer = docEditor._completer
+    completer: CommandCompleter = docEditor._completer
 
     # Create Scene
     nwGUI.docEditor.setFocus()
@@ -2009,13 +2009,24 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
 
     # Selecting "Jane" should insert it
     completer.actions()[0].trigger()
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     assert docEditor.getText() == (
         "### Scene One\n\n"
-        "@char: Jane\n"
+        "@char: Jane"
     )
 
+    # Adding a comma should reopen it
+    qtbot.keyClick(docEditor, ",", delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, " ", delay=KEY_DELAY)
+    assert [a.text() for a in completer.actions()] == ["Jane", "John"]
+
+    # Pressing return without selecting anything should just close it
+    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
+    assert [a.text() for a in completer.actions()] == []
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+
     # Start a new line with a nonsense keyword, which should be handled
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     for c in "@: ":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
@@ -2074,7 +2085,7 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
         "%Story.Resolution: \n"
     )
 
-    # Auto-complete note comment
+    # Auto-complete note comment, but select with Tab
     SHARED.project.index._itemIndex._cache.note.add("Consistency")
     qtbot.keyClick(docEditor, "%", delay=KEY_DELAY)
     assert len(completer.actions()) == 4
@@ -2082,11 +2093,11 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
     qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
     qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key.Key_Tab, delay=KEY_DELAY)
     qtbot.keyClick(completer, ".", delay=KEY_DELAY)
     assert len(completer.actions()) == 1
     qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, Qt.Key.Key_Tab, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
     assert docEditor.getText() == (
         "### Scene One\n\n"


### PR DESCRIPTION
**Summary:**

This PR improves how the editor completer menu handles keypresses:
* Up and Down navigates up and down in the completer menu.
* Left and Escape closes the completer menu.
* Right, Tab, Enter and Return triggers the active selection, or closes the completer menu if none are active.
* Any other keypress is forwarded to the editor after closing the completer menu.

**Related Issue(s):**

Closes #2742

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
