### PR TITLE
Add horizontal rule format for manuscripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@
 - When editing code, keep diffs minimal and update only the relevant files.
 - Prefer project-local helpers and conventions over introducing new abstractions.
 - The code base should use camelCase style to match the Qt library style.
+- For Qt enums and related Qt type constants, prefer aliases imported from `novelwriter/types.py`
+  instead of direct enum members from PyQt6 modules where aliases are already available.
+- When connecting Qt signals and passing parameters, prefer `qtLambda` from `novelwriter/common.py`
+  over inline lambdas where it fits existing project patterns.
 
 ## Codebase Navigation
 

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -485,6 +485,7 @@ class nwHeadFmt:
     """Manuscript Header Formats."""
 
     BR         = "{BR}"
+    HR         = "{HR}"
     TITLE      = "{Title}"
     CH_NUM     = "{Chapter}"
     CH_WORD    = "{Chapter:Word}"
@@ -497,7 +498,7 @@ class nwHeadFmt:
 
     PAGE_HEADERS: Final[list[str]] = [
         TITLE, CH_NUM, CH_WORD, CH_ROMU, CH_ROML, SC_NUM, SC_ABS,
-        CHAR_POV, CHAR_FOCUS
+        CHAR_POV, CHAR_FOCUS, HR,
     ]
 
     # Document Page Header

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -485,7 +485,6 @@ class nwHeadFmt:
     """Manuscript Header Formats."""
 
     BR         = "{BR}"
-    HR         = "{HR}"
     TITLE      = "{Title}"
     CH_NUM     = "{Chapter}"
     CH_WORD    = "{Chapter:Word}"
@@ -495,10 +494,11 @@ class nwHeadFmt:
     SC_ABS     = "{Scene:Abs}"
     CHAR_POV   = "{Char:POV}"
     CHAR_FOCUS = "{Char:Focus}"
+    HRULE      = "----"
 
     PAGE_HEADERS: Final[list[str]] = [
         TITLE, CH_NUM, CH_WORD, CH_ROMU, CH_ROML, SC_NUM, SC_ABS,
-        CHAR_POV, CHAR_FOCUS, HR,
+        CHAR_POV, CHAR_FOCUS,
     ]
 
     # Document Page Header

--- a/novelwriter/formats/shared.py
+++ b/novelwriter/formats/shared.py
@@ -119,11 +119,12 @@ class BlockTyp(IntEnum):
     HEAD4   = 7   # Heading 4
     TEXT    = 8   # Text line
     SEP     = 9   # Scene separator
-    SKIP    = 10  # Paragraph break
-    SUMMARY = 11  # Synopsis/short comment
-    NOTE    = 12  # Note
-    COMMENT = 13  # Comment
-    KEYWORD = 14  # Tag/reference keywords
+    HRULE   = 10  # Horizontal rule
+    SKIP    = 11  # Paragraph break
+    SUMMARY = 12  # Synopsis/short comment
+    NOTE    = 13  # Note
+    COMMENT = 14  # Comment
+    KEYWORD = 15  # Tag/reference keywords
 
 
 class BlockFmt(Flag):

--- a/novelwriter/formats/todocx.py
+++ b/novelwriter/formats/todocx.py
@@ -29,7 +29,7 @@ import re
 import xml.etree.ElementTree as ET
 
 from datetime import datetime
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from PyQt6.QtCore import QMargins, QSize
@@ -39,7 +39,7 @@ from novelwriter.common import firstFloat, xmlElement, xmlSubElem
 from novelwriter.constants import nwHeadFmt, nwStyles
 from novelwriter.formats.shared import BlockFmt, BlockTyp, T_Formats, TextFmt, stripEscape
 from novelwriter.formats.tokenizer import COMMENT_BLOCKS, Tokenizer
-from novelwriter.types import QtHexRgb
+from novelwriter.types import QtBlack, QtHexRgb
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -178,6 +178,16 @@ class DocXParStyle(NamedTuple):
     bold: bool = False
 
 
+class DocXBorder(NamedTuple):
+    """DocX Border Data."""
+
+    line: Literal["single", "double", "dashed", "dotted"] = "single"
+    color: QColor = QtBlack
+    size: int = 6
+    space: int = 1
+    margin: int = 0
+
+
 class ToDocX(Tokenizer):
     """Core: DocX Document Writer.
 
@@ -196,6 +206,7 @@ class ToDocX(Tokenizer):
         self._fontSize    = 12.0
         self._pageSize    = QSize(_mmToSz(210.0), _mmToSz(297.0))
         self._pageMargins = QMargins(_mmToSz(20.0), _mmToSz(20.0), _mmToSz(20.0), _mmToSz(20.0))
+        self._mHorLine = _mmToSz(42.5/20.0)
 
         # Data Variables
         self._pars: list[DocXParagraph] = []
@@ -215,6 +226,7 @@ class ToDocX(Tokenizer):
         """Set the document page size and margins in millimetres."""
         self._pageSize = QSize(_mmToSz(width), _mmToSz(height))
         self._pageMargins = QMargins(_mmToSz(left), _mmToSz(top), _mmToSz(right), _mmToSz(bottom))
+        self._mHorLine = _mmToSz((width - left - right)/80.0)
 
     def setHeaderFormat(self, value: str, offset: int) -> None:
         """Set the document header format."""
@@ -290,6 +302,12 @@ class ToDocX(Tokenizer):
 
             elif tType == BlockTyp.SEP:
                 self._processFragments(par, S_SEP, tText)
+
+            elif tType == BlockTyp.HRULE:
+                par.setBorder("bottom", DocXBorder(line="single", color=self._theme.comment))
+                par.setMarginLeft(self._mHorLine)
+                par.setMarginRight(self._mHorLine)
+                self._processFragments(par, S_NORM, "")
 
             elif tType == BlockTyp.SKIP:
                 self._processFragments(par, S_NORM, "")
@@ -1049,7 +1067,7 @@ class DocXParagraph:
     """
 
     __slots__ = (
-        "_bottomMargin", "_breakAfter", "_breakBefore", "_content",
+        "_borders", "_bottomMargin", "_breakAfter", "_breakBefore", "_content",
         "_footnoteRef", "_indentFirst", "_leftMargin", "_rightMargin",
         "_style", "_textAlign", "_topMargin",
     )
@@ -1066,6 +1084,7 @@ class DocXParagraph:
         self._breakBefore = False
         self._breakAfter = False
         self._footnoteRef = False
+        self._borders: dict[str, DocXBorder] = {}
 
     ##
     #  Properties
@@ -1104,6 +1123,10 @@ class DocXParagraph:
     def setMarginRight(self, value: float) -> None:
         """Set margin right in pt."""
         self._rightMargin = value
+
+    def setBorder(self, position: str, value: DocXBorder) -> None:
+        """Set border for a specific position."""
+        self._borders[position] = value
 
     def setIndentFirst(self, state: bool) -> None:
         """Set first line indent."""
@@ -1153,6 +1176,15 @@ class DocXParagraph:
                     _wTag("line"): str(int(20.0 * firstFloat(style.line, style.size))),
                     _wTag("lineRule"): "auto",
                 })
+            if self._borders:
+                pBdr = xmlSubElem(pPr, _wTag("pBdr"))
+                for position, border in self._borders.items():
+                    xmlSubElem(pBdr, _wTag(position), attrib={
+                        _wTag("val"): border.line,
+                        _wTag("color"): _docXCol(border.color),
+                        _wTag("sz"): str(border.size),
+                        _wTag("space"): str(border.space),
+                    })
             if indent:
                 xmlSubElem(pPr, _wTag("ind"), attrib=indent)
             if self._textAlign:

--- a/novelwriter/formats/tohtml.py
+++ b/novelwriter/formats/tohtml.py
@@ -316,9 +316,10 @@ class ToHtml(Tokenizer):
             return []
 
         tColor = self._theme.text.name(QtHexRgb)
-        hColor = self._theme.head.name(QtHexRgb) if self._colorHeads else tColor
         lColor = self._theme.head.name(QtHexRgb)
         mColor = self._theme.highlight.name(QtHexRgb)
+        cColor = self._theme.comment.name(QtHexRgb)
+        hColor = lColor if self._colorHeads else tColor
 
         mtH0 = self._marginTitle[0]
         mbH0 = self._marginTitle[1]
@@ -361,6 +362,10 @@ class ToHtml(Tokenizer):
         )
         styles.append(f"a {{color: {lColor};}}")
         styles.append(f"mark {{background: {mColor};}}")
+        styles.append(
+            f"hr {{width: 50%; color: {cColor}; "
+            f"margin: {mtSP:.2f}em auto {mbSP:.2f}em auto;}}"
+        )
         styles.append(f"h1, h2, h3, h4 {{color: {hColor}; page-break-after: avoid;}}")
         styles.append(
             f"h1 {{font-size: {fSz1:.2f}em; font-weight: {hW}; "

--- a/novelwriter/formats/tohtml.py
+++ b/novelwriter/formats/tohtml.py
@@ -221,6 +221,9 @@ class ToHtml(Tokenizer):
             elif tType == BlockTyp.SEP:
                 lines.append(f"<p class='sep'{hStyle}>{tText}</p>\n")
 
+            elif tType == BlockTyp.HRULE:
+                lines.append(f"<hr{hStyle}>\n")
+
             elif tType == BlockTyp.SKIP:
                 lines.append(f"<p{hStyle}>&nbsp;</p>\n")
 

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -735,10 +735,13 @@ class Tokenizer(ABC):
                         tStyle |= self._sceneStyle
                         if tText == "":  # Empty Format
                             tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SKIP
-                        elif tText == tFormat:  # Static Format
+                        elif tFormat == nwHeadFmt.HRULE:  # Horizontal Rule Format
+                            tText = ""
+                            tType = BlockTyp.EMPTY if self._noSep else BlockTyp.HRULE
+                            tStyle = BlockFmt.NONE
+                        elif tText == tFormat:  # Separator Format
                             tText = "" if self._noSep else tText
-                            tType = BlockTyp.HRULE if tFormat == nwHeadFmt.HRULE else BlockTyp.SEP
-                            tType = BlockTyp.EMPTY if self._noSep else tType
+                            tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SEP
                             tStyle |= BlockFmt.NONE if self._noSep else BlockFmt.CENTRE
 
                     self._noSep = False
@@ -768,8 +771,12 @@ class Tokenizer(ABC):
                         tText = self._hFormatter.apply(tFormat, tText, nHead)
                         if tText == "":  # Empty Format
                             tType = BlockTyp.SKIP
-                        elif tText == tFormat:  # Static Format
-                            tType = BlockTyp.HRULE if tFormat == nwHeadFmt.HRULE else BlockTyp.SEP
+                        elif tFormat == nwHeadFmt.HRULE:  # Horizontal Rule Format
+                            tText = ""
+                            tType = BlockTyp.HRULE
+                            tStyle = BlockFmt.NONE
+                        elif tText == tFormat:  # Separator Format
+                            tType = BlockTyp.SEP
                             tStyle |= BlockFmt.CENTRE
 
                 tBlocks.append((

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -663,10 +663,17 @@ class Tokenizer(ABC):
                     elif isPlain:
                         tText = self._hFormatter.apply(self._fmtPart, tText, nHead)
                         tStyle |= self._partStyle
+                        if self._hFormatter.hrule:
+                            tBlocks.append((
+                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
+                            ))
+                            tType = tType if tText else BlockTyp.EMPTY
+
                     if isPlain:
                         self._hFormatter.resetScene()
                     else:
                         self._hFormatter.resetAll()
+
                     self._noSep = True
 
                 tBlocks.append((
@@ -693,12 +700,19 @@ class Tokenizer(ABC):
                     tType = BlockTyp.HEAD1  # Promote
                     if isPlain:
                         self._hFormatter.incChapter()
+
                     if sHide:
                         tText = ""
                         tType = BlockTyp.EMPTY
                     else:
                         tText = self._hFormatter.apply(tFormat, tText, nHead)
                         tStyle |= self._chapterStyle
+                        if self._hFormatter.hrule:
+                            tBlocks.append((
+                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
+                            ))
+                            tType = tType if tText else BlockTyp.EMPTY
+
                     self._hFormatter.resetScene()
                     self._noSep = True
 
@@ -739,6 +753,12 @@ class Tokenizer(ABC):
                             tText = "" if self._noSep else tText
                             tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SEP
                             tStyle |= BlockFmt.NONE if self._noSep else BlockFmt.CENTRE
+                        if self._hFormatter.hrule:
+                            tBlocks.append((
+                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
+                            ))
+                            tType = tType if tText else BlockTyp.EMPTY
+
                     self._noSep = False
 
                 tBlocks.append((
@@ -768,6 +788,12 @@ class Tokenizer(ABC):
                         elif tText == self._fmtSection:  # Static Format
                             tType = BlockTyp.SEP
                             tStyle |= BlockFmt.CENTRE
+
+                        if self._hFormatter.hrule:
+                            tBlocks.append((
+                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
+                            ))
+                            tType = tType if tText else BlockTyp.EMPTY
 
                 tBlocks.append((
                     tType, f"{tHandle}:T{nHead:04d}", tText, [], tStyle
@@ -1202,6 +1228,12 @@ class HeadingFormatter:
         self._scene = scene
         self._absolute = absolute
         self._upper = False
+        self._hrule = False
+
+    @property
+    def hrule(self) -> bool:
+        """Return current horizontal rule state."""
+        return self._hrule
 
     def setHandle(self, tHandle: str | None) -> None:
         """Set the handle currently being processed."""
@@ -1232,8 +1264,11 @@ class HeadingFormatter:
 
     def apply(self, template: str, text: str, nHead: int) -> str:
         """Apply formatting to a specific heading."""
+        self._hrule = nwHeadFmt.HR in template
+
         template = template.replace(nwHeadFmt.TITLE, text)
         template = template.replace(nwHeadFmt.BR, "\n")
+        template = template.replace(nwHeadFmt.HR, "")
         template = template.replace(nwHeadFmt.CH_NUM, str(self._chapter))
         template = template.replace(nwHeadFmt.SC_NUM, str(self._scene))
         template = template.replace(nwHeadFmt.SC_ABS, str(self._absolute))
@@ -1263,4 +1298,4 @@ class HeadingFormatter:
         if self._upper:
             template = template.upper()
 
-        return template
+        return template.strip()

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -747,17 +747,18 @@ class Tokenizer(ABC):
                     else:
                         tText = self._hFormatter.apply(tFormat, tText, nHead)
                         tStyle |= self._sceneStyle
-                        if tText == "":  # Empty Format
-                            tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SKIP
-                        elif tText == tFormat:  # Static Format
-                            tText = "" if self._noSep else tText
-                            tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SEP
-                            tStyle |= BlockFmt.NONE if self._noSep else BlockFmt.CENTRE
-                        if self._hFormatter.hrule:
+                        if self._hFormatter.hrule and not self._noSep:
                             tBlocks.append((
                                 BlockTyp.HRULE, "", "", [], BlockFmt.NONE
                             ))
                             tType = tType if tText else BlockTyp.EMPTY
+
+                        if self._hFormatter.empty:
+                            tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SKIP
+                        elif self._hFormatter.static:
+                            tText = "" if self._noSep else tText
+                            tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SEP
+                            tStyle |= BlockFmt.NONE if self._noSep else BlockFmt.CENTRE
 
                     self._noSep = False
 
@@ -783,17 +784,17 @@ class Tokenizer(ABC):
                         tType = BlockTyp.EMPTY
                     else:
                         tText = self._hFormatter.apply(self._fmtSection, tText, nHead)
-                        if tText == "":  # Empty Format
-                            tType = BlockTyp.SKIP
-                        elif tText == self._fmtSection:  # Static Format
-                            tType = BlockTyp.SEP
-                            tStyle |= BlockFmt.CENTRE
-
                         if self._hFormatter.hrule:
                             tBlocks.append((
                                 BlockTyp.HRULE, "", "", [], BlockFmt.NONE
                             ))
                             tType = tType if tText else BlockTyp.EMPTY
+
+                        if self._hFormatter.empty:
+                            tType = BlockTyp.SKIP
+                        elif self._hFormatter.static:
+                            tType = BlockTyp.SEP
+                            tStyle |= BlockFmt.CENTRE
 
                 tBlocks.append((
                     tType, f"{tHandle}:T{nHead:04d}", tText, [], tStyle
@@ -1229,11 +1230,23 @@ class HeadingFormatter:
         self._absolute = absolute
         self._upper = False
         self._hrule = False
+        self._empty = False
+        self._static = False
 
     @property
     def hrule(self) -> bool:
         """Return current horizontal rule state."""
         return self._hrule
+
+    @property
+    def empty(self) -> bool:
+        """Return whether the current header is empty."""
+        return self._empty
+
+    @property
+    def static(self) -> bool:
+        """Return whether the current header is static."""
+        return self._static
 
     def setHandle(self, tHandle: str | None) -> None:
         """Set the handle currently being processed."""
@@ -1264,11 +1277,15 @@ class HeadingFormatter:
 
     def apply(self, template: str, text: str, nHead: int) -> str:
         """Apply formatting to a specific heading."""
+        # Check for horizontal rule and remove from template, and transform line breaks
         self._hrule = nwHeadFmt.HR in template
-
-        template = template.replace(nwHeadFmt.TITLE, text)
-        template = template.replace(nwHeadFmt.BR, "\n")
         template = template.replace(nwHeadFmt.HR, "")
+        template = template.replace(nwHeadFmt.BR, "\n")
+        template = template.strip("\n")
+        compare = template
+
+        # Process template variables.
+        template = template.replace(nwHeadFmt.TITLE, text)
         template = template.replace(nwHeadFmt.CH_NUM, str(self._chapter))
         template = template.replace(nwHeadFmt.SC_NUM, str(self._scene))
         template = template.replace(nwHeadFmt.SC_ABS, str(self._absolute))
@@ -1295,7 +1312,12 @@ class HeadingFormatter:
             template = template.replace(nwHeadFmt.CHAR_POV, pText)
             template = template.replace(nwHeadFmt.CHAR_FOCUS, fText)
 
+        # If nothing was replaced, we can treat this as a static header
+        # If there is nothing at all, we have an empty header
+        self._static = (compare == template)
+        self._empty = (template == "")
+
         if self._upper:
             template = template.upper()
 
-        return template.strip()
+        return template

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -663,17 +663,10 @@ class Tokenizer(ABC):
                     elif isPlain:
                         tText = self._hFormatter.apply(self._fmtPart, tText, nHead)
                         tStyle |= self._partStyle
-                        if self._hFormatter.hrule:
-                            tBlocks.append((
-                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
-                            ))
-                            tType = tType if tText else BlockTyp.EMPTY
-
                     if isPlain:
                         self._hFormatter.resetScene()
                     else:
                         self._hFormatter.resetAll()
-
                     self._noSep = True
 
                 tBlocks.append((
@@ -700,19 +693,12 @@ class Tokenizer(ABC):
                     tType = BlockTyp.HEAD1  # Promote
                     if isPlain:
                         self._hFormatter.incChapter()
-
                     if sHide:
                         tText = ""
                         tType = BlockTyp.EMPTY
                     else:
                         tText = self._hFormatter.apply(tFormat, tText, nHead)
                         tStyle |= self._chapterStyle
-                        if self._hFormatter.hrule:
-                            tBlocks.append((
-                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
-                            ))
-                            tType = tType if tText else BlockTyp.EMPTY
-
                     self._hFormatter.resetScene()
                     self._noSep = True
 
@@ -747,17 +733,12 @@ class Tokenizer(ABC):
                     else:
                         tText = self._hFormatter.apply(tFormat, tText, nHead)
                         tStyle |= self._sceneStyle
-                        if self._hFormatter.hrule and not self._noSep:
-                            tBlocks.append((
-                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
-                            ))
-                            tType = tType if tText else BlockTyp.EMPTY
-
-                        if self._hFormatter.empty:
+                        if tText == "":  # Empty Format
                             tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SKIP
-                        elif self._hFormatter.static:
+                        elif tText == tFormat:  # Static Format
                             tText = "" if self._noSep else tText
-                            tType = BlockTyp.EMPTY if self._noSep else BlockTyp.SEP
+                            tType = BlockTyp.HRULE if tFormat == nwHeadFmt.HRULE else BlockTyp.SEP
+                            tType = BlockTyp.EMPTY if self._noSep else tType
                             tStyle |= BlockFmt.NONE if self._noSep else BlockFmt.CENTRE
 
                     self._noSep = False
@@ -777,23 +758,18 @@ class Tokenizer(ABC):
                 nHead += 1
                 tText = aLine[5:].strip()
                 tType = BlockTyp.HEAD4
+                tFormat = self._fmtSection
                 if isNovel:
                     tType = BlockTyp.HEAD3  # Promote
                     if self._hideSection:
                         tText = ""
                         tType = BlockTyp.EMPTY
                     else:
-                        tText = self._hFormatter.apply(self._fmtSection, tText, nHead)
-                        if self._hFormatter.hrule:
-                            tBlocks.append((
-                                BlockTyp.HRULE, "", "", [], BlockFmt.NONE
-                            ))
-                            tType = tType if tText else BlockTyp.EMPTY
-
-                        if self._hFormatter.empty:
+                        tText = self._hFormatter.apply(tFormat, tText, nHead)
+                        if tText == "":  # Empty Format
                             tType = BlockTyp.SKIP
-                        elif self._hFormatter.static:
-                            tType = BlockTyp.SEP
+                        elif tText == tFormat:  # Static Format
+                            tType = BlockTyp.HRULE if tFormat == nwHeadFmt.HRULE else BlockTyp.SEP
                             tStyle |= BlockFmt.CENTRE
 
                 tBlocks.append((
@@ -1229,24 +1205,6 @@ class HeadingFormatter:
         self._scene = scene
         self._absolute = absolute
         self._upper = False
-        self._hrule = False
-        self._empty = False
-        self._static = False
-
-    @property
-    def hrule(self) -> bool:
-        """Return current horizontal rule state."""
-        return self._hrule
-
-    @property
-    def empty(self) -> bool:
-        """Return whether the current header is empty."""
-        return self._empty
-
-    @property
-    def static(self) -> bool:
-        """Return whether the current header is static."""
-        return self._static
 
     def setHandle(self, tHandle: str | None) -> None:
         """Set the handle currently being processed."""
@@ -1277,15 +1235,8 @@ class HeadingFormatter:
 
     def apply(self, template: str, text: str, nHead: int) -> str:
         """Apply formatting to a specific heading."""
-        # Check for horizontal rule and remove from template, and transform line breaks
-        self._hrule = nwHeadFmt.HR in template
-        template = template.replace(nwHeadFmt.HR, "")
-        template = template.replace(nwHeadFmt.BR, "\n")
-        template = template.strip("\n")
-        compare = template
-
-        # Process template variables.
         template = template.replace(nwHeadFmt.TITLE, text)
+        template = template.replace(nwHeadFmt.BR, "\n")
         template = template.replace(nwHeadFmt.CH_NUM, str(self._chapter))
         template = template.replace(nwHeadFmt.SC_NUM, str(self._scene))
         template = template.replace(nwHeadFmt.SC_ABS, str(self._absolute))
@@ -1311,11 +1262,6 @@ class HeadingFormatter:
                 fText = trConst(nwLabels.KEY_NAME[nwKeyWords.FOCUS_KEY])
             template = template.replace(nwHeadFmt.CHAR_POV, pText)
             template = template.replace(nwHeadFmt.CHAR_FOCUS, fText)
-
-        # If nothing was replaced, we can treat this as a static header
-        # If there is nothing at all, we have an empty header
-        self._static = (compare == template)
-        self._empty = (template == "")
 
         if self._upper:
             template = template.upper()

--- a/novelwriter/formats/tomarkdown.py
+++ b/novelwriter/formats/tomarkdown.py
@@ -140,6 +140,9 @@ class ToMarkdown(Tokenizer):
             elif tType == BlockTyp.SEP:
                 lines.append(f"{tText}\n\n")
 
+            elif tType == BlockTyp.HRULE:
+                lines.append("----\n\n")
+
             elif tType == BlockTyp.SKIP:
                 lines.append(f"{cSkip}\n\n")
 

--- a/novelwriter/formats/toodt.py
+++ b/novelwriter/formats/toodt.py
@@ -31,7 +31,7 @@ import xml.etree.ElementTree as ET
 
 from datetime import datetime
 from hashlib import sha256
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Literal, NamedTuple
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from PyQt6.QtGui import QColor, QFont
@@ -123,6 +123,7 @@ S_HEAD2 = "Heading_20_2"
 S_HEAD3 = "Heading_20_3"
 S_HEAD4 = "Heading_20_4"
 S_SEP   = "Separator"
+S_HLINE = "Horizontal_20_Line"
 S_FIND  = "First_20_line_20_indent"
 S_TEXT  = "Text_20_body"
 S_META  = "Text_20_Meta"
@@ -198,6 +199,9 @@ class ToOdt(Tokenizer):
         self._mDocLeft   = "2.000cm"
         self._mDocRight  = "2.000cm"
 
+        # Horizontal Line Margin
+        self._mHorLine = "4.250cm"  # Quarter of the text width
+
     ##
     #  Setters
     ##
@@ -212,6 +216,7 @@ class ToOdt(Tokenizer):
         self._mDocBtm    = f"{bottom/10.0:.3f}cm"
         self._mDocLeft   = f"{left/10.0:.3f}cm"
         self._mDocRight  = f"{right/10.0:.3f}cm"
+        self._mHorLine   = f"{(width - left - right)/40.0:.3f}cm"  # Quarter of the text width
 
     def setHeaderFormat(self, value: str, offset: int) -> None:
         """Set the document header format."""
@@ -410,6 +415,9 @@ class ToOdt(Tokenizer):
 
             elif tType == BlockTyp.SEP:
                 self._addTextPar(xText, S_SEP, oStyle, tText)
+
+            elif tType == BlockTyp.HRULE:
+                self._addTextPar(xText, S_HLINE, oStyle, tText)
 
             elif tType == BlockTyp.SKIP:
                 self._addTextPar(xText, S_TEXT, oStyle, "")
@@ -876,6 +884,23 @@ class ToOdt(Tokenizer):
         style.packXML(self._xStyl)
         self._mainPara[style.name] = style
 
+        # Add Horizontal Line Style
+        style = ODTParagraphStyle(S_HLINE)
+        style.setDisplayName("Horizontal Line")
+        style.setParentStyleName("Standard")
+        style.setNextStyleName(S_TEXT)
+        style.setClass("html")
+        style.setMarginTop(self._emToCm(0))
+        style.setMarginBottom(self._emToCm(self._marginSep[1]))
+        style.setMarginLeft(self._mHorLine)
+        style.setMarginRight(self._mHorLine)
+        style.setBorderLeft(ODTBorderStyle("none"))
+        style.setBorderRight(ODTBorderStyle("none"))
+        style.setBorderTop(ODTBorderStyle("none"))
+        style.setBorderBottom(ODTBorderStyle("solid", 0.75, self._theme.comment))
+        style.packXML(self._xStyl)
+        self._mainPara[style.name] = style
+
         # Add Heading 1 Style
         style = ODTParagraphStyle(S_HEAD1)
         style.setDisplayName("Heading 1")
@@ -1014,7 +1039,7 @@ class ODTParagraphStyle:
     VALID_ALIGN: Final[list[str]]  = ["start", "center", "end", "justify", "left", "right"]
     VALID_BREAK: Final[list[str]]  = ["auto", "page", "even-page", "odd-page", "inherit"]
     VALID_LEVEL: Final[list[str]]  = ["1", "2", "3", "4"]
-    VALID_CLASS: Final[list[str]]  = ["text", "chapter", "extra"]
+    VALID_CLASS: Final[list[str]]  = ["text", "chapter", "extra", "html"]
     VALID_WEIGHT: Final[list[str]] = ["normal", "bold", *FONT_WEIGHT_NUM]
 
     def __init__(self, name: str) -> None:
@@ -1036,6 +1061,10 @@ class ODTParagraphStyle:
             "margin-bottom": ["fo", None],
             "margin-left":   ["fo", None],
             "margin-right":  ["fo", None],
+            "border-left":   ["fo", None],
+            "border-right":  ["fo", None],
+            "border-top":    ["fo", None],
+            "border-bottom": ["fo", None],
             "text-indent":   ["fo", None],
             "line-height":   ["fo", None],
             "text-align":    ["fo", None],
@@ -1114,6 +1143,22 @@ class ODTParagraphStyle:
     def setMarginRight(self, value: str | None) -> None:
         """Set paragraph right margin."""
         self._pAttr["margin-right"][1] = value
+
+    def setBorderLeft(self, value: ODTBorderStyle | None) -> None:
+        """Set paragraph left border."""
+        self._pAttr["border-left"][1] = None if value is None else str(value)
+
+    def setBorderRight(self, value: ODTBorderStyle | None) -> None:
+        """Set paragraph right border."""
+        self._pAttr["border-right"][1] = None if value is None else str(value)
+
+    def setBorderTop(self, value: ODTBorderStyle | None) -> None:
+        """Set paragraph top border."""
+        self._pAttr["border-top"][1] = None if value is None else str(value)
+
+    def setBorderBottom(self, value: ODTBorderStyle | None) -> None:
+        """Set paragraph bottom border."""
+        self._pAttr["border-bottom"][1] = None if value is None else str(value)
 
     def setTextIndent(self, value: str | None) -> None:
         """Set text indentation."""
@@ -1217,6 +1262,23 @@ class ODTParagraphStyle:
 
         if attr := {_mkTag(n, m): v for m, (n, v) in self._tAttr.items() if v}:
             ET.SubElement(xEntry, _mkTag("style", "text-properties"), attrib=attr)
+
+
+class ODTBorderStyle(NamedTuple):
+    """Named tuple for border styles."""
+
+    style: Literal["none", "solid", "dashed", "dotted", "double"] = "none"
+    width: float | None = None
+    color: QColor | None = None
+
+    def __str__(self) -> str:
+        """Convert the border style to a string that can be used in ODT XML."""
+        values = [self.style]
+        if self.width is not None:
+            values.insert(0, f"{self.width:.2f}pt")
+        if self.color is not None:
+            values.append(self.color.name(QtHexRgb))
+        return " ".join(values)
 
 
 class ODTTextStyle:

--- a/novelwriter/formats/toodt.py
+++ b/novelwriter/formats/toodt.py
@@ -417,7 +417,7 @@ class ToOdt(Tokenizer):
                 self._addTextPar(xText, S_SEP, oStyle, tText)
 
             elif tType == BlockTyp.HRULE:
-                self._addTextPar(xText, S_HLINE, oStyle, tText)
+                self._addTextPar(xText, S_HLINE, oStyle, "")
 
             elif tType == BlockTyp.SKIP:
                 self._addTextPar(xText, S_TEXT, oStyle, "")

--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -29,8 +29,8 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QMarginsF, QSizeF
 from PyQt6.QtGui import (
-    QColor, QFont, QPageLayout, QPageSize, QTextBlockFormat, QTextCharFormat,
-    QTextCursor, QTextDocument, QTextFrameFormat
+    QBrush, QColor, QFont, QPageLayout, QPageSize, QTextBlockFormat,
+    QTextCharFormat, QTextCursor, QTextDocument, QTextFrameFormat, QTextLength
 )
 from PyQt6.QtPrintSupport import QPrinter
 
@@ -272,6 +272,9 @@ class ToQTextDocument(Tokenizer):
                 newBlock(cursor, bFmt)
                 cursor.insertText(tText, self._charFmt)
 
+            elif tType == BlockTyp.HRULE:
+                self._insertHorizontalRule(cursor)
+
             elif tType == BlockTyp.SKIP:
                 newBlock(cursor, bFmt)
                 cursor.insertText(nwUnicode.U_NBSP, self._charFmt)
@@ -465,6 +468,21 @@ class ToQTextDocument(Tokenizer):
             cursor.insertText(self._project.localLookup("New Page"), cFmt)
             if root := self._document.rootFrame():
                 cursor.swap(root.lastCursorPosition())
+
+    def _insertHorizontalRule(self, cursor: QTextCursor) -> None:
+        """Insert a horizontal rule marker."""
+        bFmt = QTextBlockFormat(self._blockFmt)
+        bFmt.setAlignment(QtAlignCenter)
+        bFmt.setTopMargin(self._mSep[0])
+        bFmt.setBottomMargin(self._mSep[1])
+        bFmt.setLineHeight(100.0, QtPropLineHeight)
+        bFmt.setProperty(
+            QTextBlockFormat.Property.BlockTrailingHorizontalRulerWidth,
+            QTextLength(QTextLength.Type.PercentageLength, 50.0)
+        )
+        bFmt.setProperty(QTextBlockFormat.Property.BackgroundBrush, QBrush(self._theme.text))
+
+        newBlock(cursor, bFmt)
 
     def _genHeadStyle(self, hType: BlockTyp, hKey: str, rFmt: QTextBlockFormat) -> T_TextStyle:
         """Generate a heading style set."""

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -55,7 +55,8 @@ from novelwriter.extensions.switch import NSwitch
 from novelwriter.extensions.switchbox import NSwitchBox
 from novelwriter.types import (
     QtAlignCenter, QtAlignLeft, QtAlignRightMiddle, QtHeaderFixed,
-    QtHeaderStretch, QtRoleAccept, QtRoleApply, QtRoleDestruct, QtUserRole
+    QtHeaderStretch, QtRoleAccept, QtRoleApply, QtRoleDestruct,
+    QtSelectDocument, QtUserRole
 )
 
 if TYPE_CHECKING:
@@ -732,7 +733,7 @@ class _HeadingsTab(NScrollablePage):
         self.aInsScAbs.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.SC_ABS))
         self.aInsCharPOV.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.CHAR_POV))
         self.aInsCharFocus.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.CHAR_FOCUS))
-        self.aInsHRule.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.HR))
+        self.aInsHRule.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.HRULE, True))
 
         self.btnInsert = QPushButton(self.tr("Insert"), self)
         self.btnInsert.setMenu(self.mInsert)
@@ -893,10 +894,13 @@ class _HeadingsTab(NScrollablePage):
     #  Internal Functions
     ##
 
-    def _insertIntoForm(self, text: str) -> None:
+    def _insertIntoForm(self, text: str, replace: bool = False) -> None:
         """Insert formatting text from the dropdown menu."""
         if self._editing > 0:
             cursor = self.editTextBox.textCursor()
+            if replace:
+                cursor.select(QtSelectDocument)
+                cursor.removeSelectedText()
             cursor.insertText(text)
             self.editTextBox.setFocus()
 
@@ -984,15 +988,19 @@ class _HeadingSyntaxHighlighter(QSyntaxHighlighter):
 
     def highlightBlock(self, text: str) -> None:
         """Add syntax highlighting to the text block."""
-        for heading in nwHeadFmt.PAGE_HEADERS:
-            if (chars := len(heading)) > 0:
-                offset = 0
-                while (pos := text.find(heading, offset)) >= 0:
-                    offset = pos + chars
-                    self.setFormat(pos, chars, self._fmtSymbol)
-                    self.setFormat(pos + 1, chars - 2, self._fmtFormat)
-                    if (ddots := heading.find(":")) > 0:
-                        self.setFormat(pos + ddots, 1, self._fmtSymbol)
+        if text == nwHeadFmt.HRULE:
+            # Special case for horizontal rule, which is a single symbol
+            self.setFormat(0, len(text), self._fmtSymbol)
+        else:
+            for heading in nwHeadFmt.PAGE_HEADERS:
+                if (chars := len(heading)) > 0:
+                    offset = 0
+                    while (pos := text.find(heading, offset)) >= 0:
+                        offset = pos + chars
+                        self.setFormat(pos, chars, self._fmtSymbol)
+                        self.setFormat(pos + 1, chars - 2, self._fmtFormat)
+                        if (ddots := heading.find(":")) > 0:
+                            self.setFormat(pos + ddots, 1, self._fmtSymbol)
 
 
 class _FormattingTab(NScrollableForm):

--- a/novelwriter/tools/manussettings.py
+++ b/novelwriter/tools/manussettings.py
@@ -721,6 +721,7 @@ class _HeadingsTab(NScrollablePage):
         self.aInsScAbs = qtAddAction(self.mInsert, self.tr("Scene Number (Absolute)"))
         self.aInsCharPOV = qtAddAction(self.mInsert, self.tr("Point of View Character"))
         self.aInsCharFocus = qtAddAction(self.mInsert, self.tr("Focus Character"))
+        self.aInsHRule = qtAddAction(self.mInsert, self.tr("Horizontal Rule"))
 
         self.aInsTitle.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.TITLE))
         self.aInsChNum.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.CH_NUM))
@@ -731,6 +732,7 @@ class _HeadingsTab(NScrollablePage):
         self.aInsScAbs.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.SC_ABS))
         self.aInsCharPOV.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.CHAR_POV))
         self.aInsCharFocus.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.CHAR_FOCUS))
+        self.aInsHRule.triggered.connect(qtLambda(self._insertIntoForm, nwHeadFmt.HR))
 
         self.btnInsert = QPushButton(self.tr("Insert"), self)
         self.btnInsert.setMenu(self.mInsert)
@@ -983,14 +985,14 @@ class _HeadingSyntaxHighlighter(QSyntaxHighlighter):
     def highlightBlock(self, text: str) -> None:
         """Add syntax highlighting to the text block."""
         for heading in nwHeadFmt.PAGE_HEADERS:
-            pos = text.find(heading)
-            if pos >= 0:
-                chars = len(heading)
-                self.setFormat(pos, chars, self._fmtSymbol)
-                self.setFormat(pos + 1, chars - 2, self._fmtFormat)
-                ddots = heading.find(":")
-                if ddots > 0:
-                    self.setFormat(pos + ddots, 1, self._fmtSymbol)
+            if (chars := len(heading)) > 0:
+                offset = 0
+                while (pos := text.find(heading, offset)) >= 0:
+                    offset = pos + chars
+                    self.setFormat(pos, chars, self._fmtSymbol)
+                    self.setFormat(pos + 1, chars - 2, self._fmtFormat)
+                    if (ddots := heading.find(":")) > 0:
+                        self.setFormat(pos + ddots, 1, self._fmtSymbol)
 
 
 class _FormattingTab(NScrollableForm):

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a0" hexVersion="0x260200a0" fileVersion="1.5" fileRevision="6" timeStamp="2026-04-13 22:31:38">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2318" autoCount="428" editTime="109434">
+<novelWriterXML appVersion="26.2a0" hexVersion="0x260200a0" fileVersion="1.5" fileRevision="6" timeStamp="2026-06-20 17:38:47">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2346" autoCount="428" editTime="109870">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -59,7 +59,7 @@
       <name status="sf24ce6" import="ia857f0" active="yes">Basic Formatting</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3003" wordCount="530" paraCount="16" cursorPos="732" />
+      <meta expanded="no" heading="H3" charCount="3003" wordCount="530" paraCount="16" cursorPos="1505" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">

--- a/tests/reference/fmtToOdt_SaveFlatWithEmptyLines_document.fodt
+++ b/tests/reference/fmtToOdt_SaveFlatWithEmptyLines_document.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2026-06-20T00:42:55</meta:creation-date>
+    <meta:creation-date>2026-06-20T16:21:19</meta:creation-date>
     <meta:generator>novelWriter/26.2a0</meta:generator>
     <meta:initial-creator>Jane Smith</meta:initial-creator>
     <meta:editing-cycles>1234</meta:editing-cycles>
     <meta:editing-duration>P42DT12H34M56S</meta:editing-duration>
     <dc:title>Test Project</dc:title>
-    <dc:date>2026-06-20T00:42:55</dc:date>
+    <dc:date>2026-06-20T16:21:19</dc:date>
     <dc:creator>Jane Smith</dc:creator>
   </office:meta>
   <office:settings>
@@ -53,6 +53,9 @@
     <style:style style:name="Separator" style:family="paragraph" style:display-name="Separator" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
       <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm" fo:line-height="115%" fo:text-align="center" />
       <style:text-properties style:font-name="Liberation Serif" fo:font-family="Liberation Serif" fo:font-size="12pt" fo:font-weight="normal" />
+    </style:style>
+    <style:style style:name="Horizontal_20_Line" style:family="paragraph" style:display-name="Horizontal Line" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="html">
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm" fo:margin-left="2.900cm" fo:margin-right="2.900cm" fo:border-left="none" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.75pt solid #646464" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
       <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm" />

--- a/tests/reference/fmtToOdt_SaveFlat_document.fodt
+++ b/tests/reference/fmtToOdt_SaveFlat_document.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2026-06-19T23:51:56</meta:creation-date>
+    <meta:creation-date>2026-06-20T16:21:19</meta:creation-date>
     <meta:generator>novelWriter/26.2a0</meta:generator>
     <meta:initial-creator>Jane Smith</meta:initial-creator>
     <meta:editing-cycles>1234</meta:editing-cycles>
     <meta:editing-duration>P42DT12H34M56S</meta:editing-duration>
     <dc:title>Test Project</dc:title>
-    <dc:date>2026-06-19T23:51:56</dc:date>
+    <dc:date>2026-06-20T16:21:19</dc:date>
     <dc:creator>Jane Smith</dc:creator>
   </office:meta>
   <office:settings>
@@ -53,6 +53,9 @@
     <style:style style:name="Separator" style:family="paragraph" style:display-name="Separator" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
       <style:paragraph-properties fo:margin-top="0.508cm" fo:margin-bottom="0.508cm" fo:line-height="115%" fo:text-align="center" />
       <style:text-properties style:font-name="Liberation Serif" fo:font-family="Liberation Serif" fo:font-size="12pt" fo:font-weight="normal" />
+    </style:style>
+    <style:style style:name="Horizontal_20_Line" style:family="paragraph" style:display-name="Horizontal Line" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="html">
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.508cm" fo:margin-left="2.900cm" fo:margin-right="2.900cm" fo:border-left="none" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.75pt solid #646464" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
       <style:paragraph-properties fo:margin-top="0.635cm" fo:margin-bottom="0.254cm" />

--- a/tests/reference/fmtToOdt_SaveFull_styles.xml
+++ b/tests/reference/fmtToOdt_SaveFull_styles.xml
@@ -38,6 +38,9 @@
       <style:paragraph-properties fo:margin-top="0.508cm" fo:margin-bottom="0.508cm" fo:line-height="115%" fo:text-align="center" />
       <style:text-properties style:font-name="Liberation Serif" fo:font-family="Liberation Serif" fo:font-size="12pt" fo:font-weight="normal" />
     </style:style>
+    <style:style style:name="Horizontal_20_Line" style:family="paragraph" style:display-name="Horizontal Line" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="html">
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.508cm" fo:margin-left="4.250cm" fo:margin-right="4.250cm" fo:border-left="none" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.75pt solid #646464" />
+    </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
       <style:paragraph-properties fo:margin-top="0.635cm" fo:margin-bottom="0.254cm" />
       <style:text-properties style:font-name="Liberation Serif" fo:font-family="Liberation Serif" fo:font-size="24pt" fo:font-weight="bold" fo:color="#4271ae" loext:opacity="100%" />

--- a/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.htm
+++ b/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.htm
@@ -9,6 +9,7 @@ body {color: #000000; font-family: 'Arial'; font-size: 12pt; font-weight: 400; f
 p {text-align: left; line-height: 150%; margin-top: 0.00em; margin-bottom: 0.60em;}
 a {color: #4271ae;}
 mark {background: #ffffa6;}
+hr {width: 50%; color: #646464; margin: 1.20em auto 1.20em auto;}
 h1, h2, h3, h4 {color: #4271ae; page-break-after: avoid;}
 h1 {font-size: 2.00em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}
 h2 {font-size: 1.75em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}

--- a/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.json
+++ b/tests/reference/mBuildDocBuild_HTML5_Lorem_Ipsum.json
@@ -2,8 +2,8 @@
   "meta": {
     "projectName": "Lorem Ipsum",
     "novelAuthor": "lipsum.com",
-    "buildTime": 1769342696,
-    "buildTimeStr": "2026-01-25 13:04:56"
+    "buildTime": 1781972667,
+    "buildTimeStr": "2026-06-20 18:24:27"
   },
   "text": {
     "css": [
@@ -11,6 +11,7 @@
       "p {text-align: left; line-height: 150%; margin-top: 0.00em; margin-bottom: 0.60em;}",
       "a {color: #4271ae;}",
       "mark {background: #ffffa6;}",
+      "hr {width: 50%; color: #646464; margin: 1.20em auto 1.20em auto;}",
       "h1, h2, h3, h4 {color: #4271ae; page-break-after: avoid;}",
       "h1 {font-size: 2.00em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}",
       "h2 {font-size: 1.75em; font-weight: 700; margin-top: 1.50em; margin-bottom: 0.60em;}",

--- a/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
+++ b/tests/reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='utf-8'?>
 <office:document xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
   <office:meta>
-    <meta:creation-date>2026-06-19T23:51:50</meta:creation-date>
+    <meta:creation-date>2026-06-20T16:21:13</meta:creation-date>
     <meta:generator>novelWriter/26.2a0</meta:generator>
     <meta:initial-creator>lipsum.com</meta:initial-creator>
     <meta:editing-cycles>55</meta:editing-cycles>
     <meta:editing-duration>P0DT0H45M46S</meta:editing-duration>
     <dc:title>Lorem Ipsum</dc:title>
-    <dc:date>2026-06-19T23:51:50</dc:date>
+    <dc:date>2026-06-20T16:21:13</dc:date>
     <dc:creator>lipsum.com</dc:creator>
   </office:meta>
   <office:settings>
@@ -53,6 +53,9 @@
     <style:style style:name="Separator" style:family="paragraph" style:display-name="Separator" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
       <style:paragraph-properties fo:margin-top="0.508cm" fo:margin-bottom="0.508cm" fo:line-height="150%" fo:text-align="center" />
       <style:text-properties style:font-name="Arial" fo:font-family="Arial" fo:font-size="12pt" fo:font-weight="normal" />
+    </style:style>
+    <style:style style:name="Horizontal_20_Line" style:family="paragraph" style:display-name="Horizontal Line" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="html">
+      <style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.508cm" fo:margin-left="4.250cm" fo:margin-right="4.250cm" fo:border-left="none" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.75pt solid #646464" />
     </style:style>
     <style:style style:name="Heading_20_1" style:family="paragraph" style:display-name="Heading 1" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
       <style:paragraph-properties fo:margin-top="0.635cm" fo:margin-bottom="0.254cm" />

--- a/tests/test_formats/test_fmt_todocx.py
+++ b/tests/test_formats/test_fmt_todocx.py
@@ -58,11 +58,8 @@ def testFmtToDocX_NovelHeadingStyles(mockGUI):
         '<w:r><w:rPr /><w:t>Hello World</w:t></w:r></w:p></w:body>'
     )
 
-    # Partition
-    # =========
+    # Plain Partition
     doc._text = "# Hello World"
-
-    # Plain
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
     doc.doConvert()
@@ -73,7 +70,8 @@ def testFmtToDocX_NovelHeadingStyles(mockGUI):
         '<w:r><w:rPr /><w:t>Hello World</w:t></w:r></w:p></w:body>'
     )
 
-    # Formatted
+    # Formatted Partition
+    doc._text = "# Hello World"
     xTest = ET.Element(_wTag("body"))
     doc.setPartitionFormat(f"Part{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     doc.tokenizeText()
@@ -85,11 +83,8 @@ def testFmtToDocX_NovelHeadingStyles(mockGUI):
         '<w:r><w:rPr /><w:t>Part</w:t><w:br /><w:t>Hello World</w:t></w:r></w:p></w:body>'
     )
 
-    # Chapter
-    # =======
+    # Plain Chapter
     doc._text = "## Hello World"
-
-    # Plain
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
     doc.doConvert()
@@ -100,7 +95,8 @@ def testFmtToDocX_NovelHeadingStyles(mockGUI):
         '<w:r><w:rPr /><w:t>Hello World</w:t></w:r></w:p></w:body>'
     )
 
-    # Formatted
+    # Formatted Chapter
+    doc._text = "## Hello World"
     xTest = ET.Element(_wTag("body"))
     doc.setChapterFormat(f"Chapter {nwHeadFmt.CH_NUM}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     doc.tokenizeText()
@@ -112,11 +108,8 @@ def testFmtToDocX_NovelHeadingStyles(mockGUI):
         '<w:r><w:rPr /><w:t>Chapter 2</w:t><w:br /><w:t>Hello World</w:t></w:r></w:p></w:body>'
     )
 
-    # Scene
-    # =====
+    # Plain Scene
     doc._text = "### Hello World"
-
-    # Plain
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
     doc.doConvert()
@@ -126,7 +119,8 @@ def testFmtToDocX_NovelHeadingStyles(mockGUI):
         '<w:t>Hello World</w:t></w:r></w:p></w:body>'
     )
 
-    # Formatted
+    # Formatted Scene
+    doc._text = "### Hello World"
     xTest = ET.Element(_wTag("body"))
     doc.setSceneFormat(f"Scene {nwHeadFmt.SC_ABS}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     doc.tokenizeText()
@@ -138,9 +132,7 @@ def testFmtToDocX_NovelHeadingStyles(mockGUI):
     )
 
     # Section
-    # =======
     doc._text = "#### Hello World"
-
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
     doc.doConvert()
@@ -160,8 +152,6 @@ def testFmtToDocX_NotesHeadingStyles(mockGUI):
     doc.initDocument()
 
     # Title
-    # =====
-
     xTest = ET.Element(_wTag("body"))
     doc._text = "#! Hello World"
     doc.tokenizeText()
@@ -173,7 +163,6 @@ def testFmtToDocX_NotesHeadingStyles(mockGUI):
     )
 
     # Heading 1
-    # =========
     doc._text = "# Hello World"
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
@@ -185,7 +174,6 @@ def testFmtToDocX_NotesHeadingStyles(mockGUI):
     )
 
     # Heading 2
-    # =========
     doc._text = "## Hello World"
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
@@ -197,7 +185,6 @@ def testFmtToDocX_NotesHeadingStyles(mockGUI):
     )
 
     # Heading 3
-    # =========
     doc._text = "### Hello World"
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
@@ -209,7 +196,6 @@ def testFmtToDocX_NotesHeadingStyles(mockGUI):
     )
 
     # Heading 4
-    # =========
     doc._text = "#### Hello World"
     xTest = ET.Element(_wTag("body"))
     doc.tokenizeText()
@@ -251,6 +237,17 @@ def testFmtToDocX_ParagraphStyles(mockGUI):
     assert xmlToText(xTest) == (
         '<w:body><w:p><w:pPr><w:pStyle w:val="Separator" /></w:pPr><w:r><w:rPr />'
         '<w:t>* * *</w:t></w:r></w:p></w:body>'
+    )
+
+    # Horizontal Rule
+    xTest = ET.Element(_wTag("body"))
+    doc._blocks = [(BlockTyp.HRULE, "", "", [], BlockFmt.NONE)]
+    doc.doConvert()
+    doc._pars[-1].toXml(xTest)
+    assert xmlToText(xTest) == (
+        '<w:body><w:p><w:pPr><w:pStyle w:val="Normal" />'
+        '<w:pBdr><w:bottom w:val="single" w:color="646464" w:sz="6" w:space="1" /></w:pBdr>'
+        '<w:ind w:left="2400" w:right="2400" /></w:pPr></w:p></w:body>'
     )
 
     # Empty Paragraph

--- a/tests/test_formats/test_fmt_tohtml.py
+++ b/tests/test_formats/test_fmt_tohtml.py
@@ -33,19 +33,16 @@ from novelwriter.formats.tohtml import ToHtml
 
 
 @pytest.mark.core
-def testFmtToHtml_ConvertHeaders(mockGUI):
+def testFmtToHtml_ConvertNovelHeaders(mockGUI):
     """Test header formats in the ToHtml class."""
     project = NWProject()
     html = ToHtml(project)
     html.initDocument()
 
-    # Novel Files Headers
-    # ===================
-
     html._isNovel = True
     html._isFirst = True
 
-    # Header 1
+    # Partition
     html._text = "# Title\n"
     html.setPartitionFormat(f"Part{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     html.tokenizeText()
@@ -54,7 +51,7 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
         "<p class='title' style='text-align: center;'>Part<br>Title</p>\n"
     )
 
-    # Header 2
+    # Chapter
     html._text = "## Title\n"
     html.setChapterFormat(f"Chapter {nwHeadFmt.CH_NUM}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     html.tokenizeText()
@@ -63,14 +60,14 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
         "<h1 style='page-break-before: always;'>Chapter 1<br>Title</h1>\n"
     )
 
-    # Header 3
+    # Scene
     html._text = "### Title\n"
     html.setSceneFormat(f"Scene {nwHeadFmt.SC_ABS}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == "<h2>Scene 1<br>Title</h2>\n"
 
-    # Header 4
+    # Section
     html._text = "#### Title\n"
     html.tokenizeText()
     html.doConvert()
@@ -90,33 +87,45 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
     html.doConvert()
     assert html._pages[-1] == "<h1 style='page-break-before: always;'>Prologue</h1>\n"
 
-    # Note Files Headers
-    # ==================
+    # Alt Scene
+    html._text = "###! Title\n"
+    html.setHardSceneFormat(f"Scene {nwHeadFmt.SC_ABS}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
+    html.tokenizeText()
+    html.doConvert()
+    assert html._pages[-1] == "<h2>Scene 1<br>Title</h2>\n"
+
+
+@pytest.mark.core
+def testFmtToHtml_ConvertNotesHeaders(mockGUI):
+    """Test header formats in the ToHtml class."""
+    project = NWProject()
+    html = ToHtml(project)
+    html.initDocument()
 
     html._isNovel = False
     html._isFirst = True
     html._handle = "0000000000000"
     html.setLinkHeadings(True)
 
-    # Header 1
+    # Heading 1
     html._text = "# Heading One\n"
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == "<h1><a name='0000000000000:T0001'></a>Heading One</h1>\n"
 
-    # Header 2
+    # Heading 2
     html._text = "## Heading Two\n"
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == "<h2><a name='0000000000000:T0001'></a>Heading Two</h2>\n"
 
-    # Header 3
+    # Heading 3
     html._text = "### Heading Three\n"
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == "<h3><a name='0000000000000:T0001'></a>Heading Three</h3>\n"
 
-    # Header 4
+    # Heading 4
     html._text = "#### Heading Four\n"
     html.tokenizeText()
     html.doConvert()
@@ -131,11 +140,17 @@ def testFmtToHtml_ConvertHeaders(mockGUI):
         "<a name='0000000000000:T0001'></a>Heading One</p>\n"
     )
 
-    # Unnumbered
+    # Alt Heading 2
     html._text = "##! Heading Two\n"
     html.tokenizeText()
     html.doConvert()
     assert html._pages[-1] == "<h2><a name='0000000000000:T0001'></a>Heading Two</h2>\n"
+
+    # Alt Heading 3
+    html._text = "###! Heading Three\n"
+    html.tokenizeText()
+    html.doConvert()
+    assert html._pages[-1] == "<h3><a name='0000000000000:T0001'></a>Heading Three</h3>\n"
 
 
 @pytest.mark.core
@@ -521,6 +536,13 @@ def testFmtToHtml_ConvertDirect(mockGUI):
     ]
     html.doConvert()
     assert html._pages[-1] == "<p class='sep' style='text-align: center;'>* * *</p>\n"
+
+    # Horizontal Rule
+    html._blocks = [
+        (BlockTyp.HRULE, tMeta, "", [], BlockFmt.CENTRE),
+    ]
+    html.doConvert()
+    assert html._pages[-1] == "<hr style='text-align: center;'>\n"
 
     # Skip
     html._blocks = [

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -755,6 +755,81 @@ def testFmtToken_HeaderStyleSeparation(mockGUI):
 
 
 @pytest.mark.core
+def testFmtToken_HeaderStyleHorizontalRule(mockGUI):
+    """Test header style processing with horizontal rule marker."""
+    project = NWProject()
+    tokens = BareTokenizer(project)
+
+    tokens._isNovel = True
+    tokens._handle = TMH
+
+    # Title with horizontal rule
+    tokens.setPartitionFormat(nwHeadFmt.HR, False)
+    tokens._text = "# Title\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE)
+    ]
+
+    # Chapter heading with horizontal rule
+    tokens.setChapterFormat(nwHeadFmt.HR, False)
+    tokens._text = "## Chapter One\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE)
+    ]
+
+    # Scene separator with HR marker inserts both blocks when not after chapter
+    tokens.setSceneFormat(f"{nwHeadFmt.HR}{nwHeadFmt.BR}* * *{nwHeadFmt.BR}", False)
+    tokens._noSep = False
+    tokens._text = "### Scene One\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
+        (BlockTyp.SEP, TM1, "* * *", [], BlockFmt.CENTRE),
+    ]
+
+    # Immediately after chapter, both static separator and HR are suppressed
+    tokens.setSceneFormat(f"{nwHeadFmt.HR}{nwHeadFmt.BR}* * *{nwHeadFmt.BR}", False)
+    tokens._noSep = True
+    tokens._text = "### Scene Two\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == []
+
+    # Scene text with HR marker keeps heading text and strips markers/newlines
+    tokens.setSceneFormat(
+        f"{nwHeadFmt.HR}{nwHeadFmt.BR}Scene: {nwHeadFmt.TITLE}{nwHeadFmt.BR}", False
+    )
+    tokens._noSep = False
+    tokens._text = "### Scene Three\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
+        (BlockTyp.HEAD2, TM1, "Scene: Scene Three", [], BlockFmt.NONE),
+    ]
+
+    # The same HR behaviour also applies to hard scenes
+    tokens.setHardSceneFormat(f"{nwHeadFmt.HR}{nwHeadFmt.TITLE}", False)
+    tokens._noSep = False
+    tokens._text = "###! Scene Four\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
+        (BlockTyp.HEAD2, TM1, "Scene Four", [], BlockFmt.NONE),
+    ]
+
+    # Sections always process HR and static separators, independent of _noSep
+    tokens.setSectionFormat(f"{nwHeadFmt.HR}{nwHeadFmt.BR}* * *{nwHeadFmt.BR}", False)
+    tokens._noSep = True
+    tokens._text = "#### Section\n"
+    tokens.tokenizeText()
+    assert tokens._blocks == [
+        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
+        (BlockTyp.SEP, TM1, "* * *", [], BlockFmt.CENTRE),
+    ]
+
+
+@pytest.mark.core
 def testFmtToken_MetaFormat(mockGUI):
     """Test the tokenization of meta formats in the Tokenizer class."""
     project = NWProject()

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -769,7 +769,7 @@ def testFmtToken_HeaderStyleHorizontalRule(mockGUI):
     tokens._text = "### Scene One\n"
     tokens.tokenizeText()
     assert tokens._blocks == [
-        (BlockTyp.HRULE, TM1, nwHeadFmt.HRULE, [], BlockFmt.CENTRE),
+        (BlockTyp.HRULE, TM1, "", [], BlockFmt.NONE),
     ]
 
     # Immediately after chapter, scene separators and HRULE are suppressed
@@ -794,7 +794,7 @@ def testFmtToken_HeaderStyleHorizontalRule(mockGUI):
     tokens._text = "###! Scene Four\n"
     tokens.tokenizeText()
     assert tokens._blocks == [
-        (BlockTyp.HRULE, TM1, nwHeadFmt.HRULE, [], BlockFmt.CENTRE),
+        (BlockTyp.HRULE, TM1, "", [], BlockFmt.NONE),
     ]
 
     # Sections still treat static four hyphens as a centred HRULE block
@@ -803,7 +803,7 @@ def testFmtToken_HeaderStyleHorizontalRule(mockGUI):
     tokens._text = "#### Section\n"
     tokens.tokenizeText()
     assert tokens._blocks == [
-        (BlockTyp.HRULE, TM1, nwHeadFmt.HRULE, [], BlockFmt.CENTRE),
+        (BlockTyp.HRULE, TM1, "", [], BlockFmt.NONE),
     ]
 
 

--- a/tests/test_formats/test_fmt_tokenizer.py
+++ b/tests/test_formats/test_fmt_tokenizer.py
@@ -756,76 +756,54 @@ def testFmtToken_HeaderStyleSeparation(mockGUI):
 
 @pytest.mark.core
 def testFmtToken_HeaderStyleHorizontalRule(mockGUI):
-    """Test header style processing with horizontal rule marker."""
+    """Test header style processing with static horizontal rule format."""
     project = NWProject()
     tokens = BareTokenizer(project)
 
     tokens._isNovel = True
     tokens._handle = TMH
 
-    # Title with horizontal rule
-    tokens.setPartitionFormat(nwHeadFmt.HR, False)
-    tokens._text = "# Title\n"
-    tokens.tokenizeText()
-    assert tokens._blocks == [
-        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE)
-    ]
-
-    # Chapter heading with horizontal rule
-    tokens.setChapterFormat(nwHeadFmt.HR, False)
-    tokens._text = "## Chapter One\n"
-    tokens.tokenizeText()
-    assert tokens._blocks == [
-        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE)
-    ]
-
-    # Scene separator with HR marker inserts both blocks when not after chapter
-    tokens.setSceneFormat(f"{nwHeadFmt.HR}{nwHeadFmt.BR}* * *{nwHeadFmt.BR}", False)
+    # Scene rule as static four hyphens emits a centred HRULE block
+    tokens.setSceneFormat(nwHeadFmt.HRULE, False)
     tokens._noSep = False
     tokens._text = "### Scene One\n"
     tokens.tokenizeText()
     assert tokens._blocks == [
-        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
-        (BlockTyp.SEP, TM1, "* * *", [], BlockFmt.CENTRE),
+        (BlockTyp.HRULE, TM1, nwHeadFmt.HRULE, [], BlockFmt.CENTRE),
     ]
 
-    # Immediately after chapter, both static separator and HR are suppressed
-    tokens.setSceneFormat(f"{nwHeadFmt.HR}{nwHeadFmt.BR}* * *{nwHeadFmt.BR}", False)
+    # Immediately after chapter, scene separators and HRULE are suppressed
+    tokens.setSceneFormat(nwHeadFmt.HRULE, False)
     tokens._noSep = True
     tokens._text = "### Scene Two\n"
     tokens.tokenizeText()
     assert tokens._blocks == []
 
-    # Scene text with HR marker keeps heading text and strips markers/newlines
-    tokens.setSceneFormat(
-        f"{nwHeadFmt.HR}{nwHeadFmt.BR}Scene: {nwHeadFmt.TITLE}{nwHeadFmt.BR}", False
-    )
+    # Mixed format is not allowed and treated as a normal header
+    tokens.setSceneFormat(f"{nwHeadFmt.HRULE}{nwHeadFmt.BR}{nwHeadFmt.TITLE}", False)
     tokens._noSep = False
     tokens._text = "### Scene Three\n"
     tokens.tokenizeText()
     assert tokens._blocks == [
-        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
-        (BlockTyp.HEAD2, TM1, "Scene: Scene Three", [], BlockFmt.NONE),
+        (BlockTyp.HEAD2, TM1, f"{nwHeadFmt.HRULE}\nScene Three", [], BlockFmt.NONE),
     ]
 
-    # The same HR behaviour also applies to hard scenes
-    tokens.setHardSceneFormat(f"{nwHeadFmt.HR}{nwHeadFmt.TITLE}", False)
+    # The same static four hyphens rule applies to hard scenes
+    tokens.setHardSceneFormat(nwHeadFmt.HRULE, False)
     tokens._noSep = False
     tokens._text = "###! Scene Four\n"
     tokens.tokenizeText()
     assert tokens._blocks == [
-        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
-        (BlockTyp.HEAD2, TM1, "Scene Four", [], BlockFmt.NONE),
+        (BlockTyp.HRULE, TM1, nwHeadFmt.HRULE, [], BlockFmt.CENTRE),
     ]
 
-    # Sections always process HR and static separators, independent of _noSep
-    tokens.setSectionFormat(f"{nwHeadFmt.HR}{nwHeadFmt.BR}* * *{nwHeadFmt.BR}", False)
+    # Sections still treat static four hyphens as a centred HRULE block
+    tokens.setSectionFormat(nwHeadFmt.HRULE, False)
     tokens._noSep = True
     tokens._text = "#### Section\n"
     tokens.tokenizeText()
     assert tokens._blocks == [
-        (BlockTyp.HRULE, "", "", [], BlockFmt.NONE),
-        (BlockTyp.SEP, TM1, "* * *", [], BlockFmt.CENTRE),
+        (BlockTyp.HRULE, TM1, nwHeadFmt.HRULE, [], BlockFmt.CENTRE),
     ]
 
 

--- a/tests/test_formats/test_fmt_tomarkdown.py
+++ b/tests/test_formats/test_fmt_tomarkdown.py
@@ -30,7 +30,7 @@ from novelwriter.formats.tomarkdown import ToMarkdown
 
 
 @pytest.mark.core
-def testFmtToMarkdown_ConvertHeaders(mockGUI):
+def testFmtToMarkdown_ConvertNovelHeaders(mockGUI):
     """Test header formats in the ToMarkdown class."""
     project = NWProject()
     md = ToMarkdown(project, False)
@@ -38,28 +38,28 @@ def testFmtToMarkdown_ConvertHeaders(mockGUI):
     md._isNovel = True
     md._isFirst = True
 
-    # Header 1
+    # Partition
     md._text = "# Title\n"
     md.setPartitionFormat(f"Part{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     md.tokenizeText()
     md.doConvert()
     assert md._pages[-1] == "Part - Title\n============\n\n"
 
-    # Header 2
+    # Chapter
     md._text = "## Title\n"
     md.setChapterFormat(f"Chapter {nwHeadFmt.CH_NUM}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     md.tokenizeText()
     md.doConvert()
     assert md._pages[-1] == "# Chapter 1 - Title\n\n"
 
-    # Header 3
+    # Scene
     md._text = "### Title\n"
     md.setSceneFormat(f"Scene {nwHeadFmt.SC_ABS}{nwHeadFmt.BR}{nwHeadFmt.TITLE}")
     md.tokenizeText()
     md.doConvert()
     assert md._pages[-1] == "## Scene 1 - Title\n\n"
 
-    # Header 4
+    # Section
     md._text = "#### Section Title\n"
     md.tokenizeText()
     md.doConvert()
@@ -76,6 +76,64 @@ def testFmtToMarkdown_ConvertHeaders(mockGUI):
     md.tokenizeText()
     md.doConvert()
     assert md._pages[-1] == "# Prologue\n\n"
+
+    # Alt Scene
+    md._text = "###! Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "## Title\n\n"
+
+
+@pytest.mark.core
+def testFmtToMarkdown_ConvertNotesHeaders(mockGUI):
+    """Test header formats in the ToMarkdown class."""
+    project = NWProject()
+    md = ToMarkdown(project, False)
+
+    md._isNovel = False
+    md._isFirst = True
+
+    # Heading 1
+    md._text = "# Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "# Title\n\n"
+
+    # Heading 2
+    md._text = "## Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "## Title\n\n"
+
+    # Heading 3
+    md._text = "### Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "### Title\n\n"
+
+    # Heading 4
+    md._text = "#### Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "#### Title\n\n"
+
+    # Title
+    md._text = "#! Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "Title\n=====\n\n"
+
+    # Alt Heading 2
+    md._text = "##! Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "## Title\n\n"
+
+    # Alt Heading 3
+    md._text = "###! Title\n"
+    md.tokenizeText()
+    md.doConvert()
+    assert md._pages[-1] == "### Title\n\n"
 
 
 @pytest.mark.core
@@ -242,6 +300,13 @@ def testFmtToMarkdown_ConvertDirect(mockGUI):
     ]
     md.doConvert()
     assert md._pages[-1] == "* * *\n\n"
+
+    # Horizontal Rule
+    md._blocks = [
+        (BlockTyp.HRULE, "", "", [], BlockFmt.CENTRE),
+    ]
+    md.doConvert()
+    assert md._pages[-1] == "----\n\n"
 
     # Skip
     md._blocks = [

--- a/tests/test_formats/test_fmt_toodt.py
+++ b/tests/test_formats/test_fmt_toodt.py
@@ -413,7 +413,7 @@ def testFmtToOdt_ConvertNotesHeadings(mockGUI):
     odt = ToOdt(project, isFlat=True)
     odt._isNovel = False
 
-    # Header 1
+    # Heading 1
     odt._text = "# Title\n"
     odt.tokenizeText()
     odt.initDocument()
@@ -426,7 +426,7 @@ def testFmtToOdt_ConvertNotesHeadings(mockGUI):
         '</office:text>'
     )
 
-    # Header 2
+    # Heading 2
     odt._text = "## Title\n"
     odt.tokenizeText()
     odt.initDocument()
@@ -439,7 +439,7 @@ def testFmtToOdt_ConvertNotesHeadings(mockGUI):
         '</office:text>'
     )
 
-    # Header 3
+    # Heading 3
     odt._text = "### Title\n"
     odt.tokenizeText()
     odt.initDocument()
@@ -452,7 +452,7 @@ def testFmtToOdt_ConvertNotesHeadings(mockGUI):
         '</office:text>'
     )
 
-    # Header 4
+    # Heading 4
     odt._text = "#### Title\n"
     odt.tokenizeText()
     odt.initDocument()
@@ -655,6 +655,23 @@ def testFmtToOdt_ConvertParagraphs(mockGUI):
         '<text:p text:style-name="Separator">* * *</text:p>'
         '<text:p text:style-name="Text_20_body">Text</text:p>'
         '<text:p text:style-name="Separator">* * *</text:p>'
+        '<text:p text:style-name="Text_20_body">Text</text:p>'
+        '</office:text>'
+    )
+
+    # Horizontal Line
+    odt._text = "### Scene One\n\nText\n\n### Scene Two\n\nText"
+    odt.setSceneFormat(nwHeadFmt.HRULE, False)
+    odt.tokenizeText()
+    odt.initDocument()
+    odt.doConvert()
+    odt.closeDocument()
+    assert odt.errData == []
+    assert xmlToText(odt._xText) == (
+        '<office:text>'
+        '<text:p text:style-name="Horizontal_20_Line" />'
+        '<text:p text:style-name="Text_20_body">Text</text:p>'
+        '<text:p text:style-name="Horizontal_20_Line" />'
         '<text:p text:style-name="Text_20_body">Text</text:p>'
         '</office:text>'
     )

--- a/tests/test_formats/test_fmt_toodt.py
+++ b/tests/test_formats/test_fmt_toodt.py
@@ -34,7 +34,10 @@ from novelwriter.constants import nwHeadFmt
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwComment
 from novelwriter.formats.shared import BlockFmt, BlockTyp, TextFmt
-from novelwriter.formats.toodt import ODTParagraphStyle, ODTTextStyle, ToOdt, XMLParagraph, _mkTag
+from novelwriter.formats.toodt import (
+    ODTBorderStyle, ODTParagraphStyle, ODTTextStyle, ToOdt, XMLParagraph,
+    _mkTag
+)
 
 from tests.tools import ODT_IGNORE, cmpFiles, xmlToText
 
@@ -116,10 +119,11 @@ def testFmtToOdt_TextFormatting(mockGUI):
 
     assert list(odt._mainPara.keys()) == [
         "Text_20_body", "First_20_line_20_indent", "Text_20_Meta", "Title", "Separator",
-        "Heading_20_1", "Heading_20_2", "Heading_20_3", "Heading_20_4", "Header", "Footnote",
+        "Horizontal_20_Line", "Heading_20_1", "Heading_20_2", "Heading_20_3",
+        "Heading_20_4", "Header", "Footnote",
     ]
 
-    key = "55db6c1d22ff5aba93f0f67c8d4a857a26e2d3813dfbcba1ef7c0d424f501be5"
+    key = "3cf442c88e0f5e263fdf225fa4763d6e5d7a1d78e611c24f5e9befef1b7646c9"
     assert key in odt._autoPara
     assert isinstance(odt._autoPara[key], ODTParagraphStyle)
     assert odt._autoPara[key].name == "P1"
@@ -1107,6 +1111,10 @@ def testFmtToOdt_ODTParagraphStyle():
     assert parStyle._pAttr["margin-bottom"] == ["fo", None]
     assert parStyle._pAttr["margin-left"]   == ["fo", None]
     assert parStyle._pAttr["margin-right"]  == ["fo", None]
+    assert parStyle._pAttr["border-left"]   == ["fo", None]
+    assert parStyle._pAttr["border-right"]  == ["fo", None]
+    assert parStyle._pAttr["border-top"]    == ["fo", None]
+    assert parStyle._pAttr["border-bottom"] == ["fo", None]
     assert parStyle._pAttr["text-indent"]   == ["fo", None]
     assert parStyle._pAttr["line-height"]   == ["fo", None]
 
@@ -1114,6 +1122,10 @@ def testFmtToOdt_ODTParagraphStyle():
     parStyle.setMarginBottom("0.000cm")
     parStyle.setMarginLeft("0.000cm")
     parStyle.setMarginRight("0.000cm")
+    parStyle.setBorderLeft(ODTBorderStyle("none"))
+    parStyle.setBorderRight(ODTBorderStyle("none"))
+    parStyle.setBorderTop(ODTBorderStyle("none"))
+    parStyle.setBorderBottom(ODTBorderStyle("double", 0.14, QColor(128, 128, 128)))
     parStyle.setTextIndent("0.000cm")
     parStyle.setLineHeight("1.15")
 
@@ -1121,6 +1133,10 @@ def testFmtToOdt_ODTParagraphStyle():
     assert parStyle._pAttr["margin-bottom"] == ["fo", "0.000cm"]
     assert parStyle._pAttr["margin-left"]   == ["fo", "0.000cm"]
     assert parStyle._pAttr["margin-right"]  == ["fo", "0.000cm"]
+    assert parStyle._pAttr["border-left"]   == ["fo", "none"]
+    assert parStyle._pAttr["border-right"]  == ["fo", "none"]
+    assert parStyle._pAttr["border-top"]    == ["fo", "none"]
+    assert parStyle._pAttr["border-bottom"] == ["fo", "0.14pt double #808080"]
     assert parStyle._pAttr["text-indent"]   == ["fo", "0.000cm"]
     assert parStyle._pAttr["line-height"]   == ["fo", "1.15"]
 
@@ -1245,7 +1261,9 @@ def testFmtToOdt_ODTParagraphStyle():
         '<style:style style:name="test" style:family="paragraph" style:display-name="Name" '
         'style:parent-style-name="Name" style:next-style-name="Name">'
         '<style:paragraph-properties fo:margin-top="0.000cm" fo:margin-bottom="0.000cm" '
-        'fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:text-indent="0.000cm" '
+        'fo:margin-left="0.000cm" fo:margin-right="0.000cm" fo:border-left="none" '
+        'fo:border-right="none" fo:border-top="none" '
+        'fo:border-bottom="0.14pt double #808080" fo:text-indent="0.000cm" '
         'fo:line-height="1.15" />'
         '<style:text-properties style:font-name="Verdana" fo:font-family="Verdana" '
         'fo:font-size="12pt" />'
@@ -1279,6 +1297,14 @@ def testFmtToOdt_ODTParagraphStyle():
     oStyle.setColor(QColor(42, 42, 42))
     assert aStyle.checkNew(oStyle) is True
     assert aStyle.getID() != oStyle.getID()
+
+
+@pytest.mark.core
+def testFmtToOdt_ODTBorderStyle():
+    """Test the ODTBorderStyle class."""
+    assert str(ODTBorderStyle("none")) == "none"
+    assert str(ODTBorderStyle("dashed", 0.50)) == "0.50pt dashed"
+    assert str(ODTBorderStyle("solid", 0.75, QColor(100, 100, 100))) == "0.75pt solid #646464"
 
 
 @pytest.mark.core

--- a/tests/test_formats/test_fmt_toqdoc.py
+++ b/tests/test_formats/test_fmt_toqdoc.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import pytest
 
-from PyQt6.QtGui import QTextBlock, QTextCharFormat, QTextCursor
+from PyQt6.QtGui import QTextBlock, QTextCharFormat, QTextCursor, QTextFormat, QTextLength
 
 from novelwriter import CONFIG
 from novelwriter.constants import nwHeadFmt, nwUnicode
@@ -32,8 +32,9 @@ from novelwriter.formats.shared import BlockFmt, BlockTyp, TextDocumentTheme
 from novelwriter.formats.toqdoc import ToQTextDocument
 from novelwriter.types import (
     QtAlignAbsolute, QtAlignCenter, QtAlignJustify, QtAlignLeft, QtAlignRight,
-    QtFontBold, QtPageBreakAfter, QtPageBreakAuto, QtPageBreakBefore,
-    QtTransparent, QtVAlignNormal, QtVAlignSub, QtVAlignSuper
+    QtFontBold, QtMoveEnd, QtPageBreakAfter, QtPageBreakAuto,
+    QtPageBreakBefore, QtTransparent, QtVAlignNormal, QtVAlignSub,
+    QtVAlignSuper
 )
 
 THEME = TextDocumentTheme()
@@ -207,6 +208,27 @@ def testFmtToQTextDocument_SeparatorSkip(mockGUI):
     # 6: Text 3
     block = doc.document.findBlockByNumber(6)
     assert block.text() == "Text 3"
+
+
+@pytest.mark.core
+def testFmtToQTextDocument_HorizontalRule(mockGUI):
+    """Test horizontal rule helper in the ToQTextDocument class."""
+    project = NWProject()
+    doc = ToQTextDocument(project)
+    doc.initDocument()
+
+    cursor = QTextCursor(doc.document)
+    cursor.movePosition(QtMoveEnd)
+    doc._insertHorizontalRule(cursor)
+
+    block = doc.document.findBlockByNumber(0)
+    bFmt = block.blockFormat()
+    assert bFmt.alignment() == QtAlignCenter
+    assert bFmt.hasProperty(QTextFormat.Property.BlockTrailingHorizontalRulerWidth)
+
+    width = bFmt.lengthProperty(QTextFormat.Property.BlockTrailingHorizontalRulerWidth)
+    assert width.type() == QTextLength.Type.PercentageLength
+    assert width.rawValue() == pytest.approx(50.0)
 
 
 @pytest.mark.core

--- a/tests/test_formats/test_fmt_toqdoc.py
+++ b/tests/test_formats/test_fmt_toqdoc.py
@@ -217,11 +217,29 @@ def testFmtToQTextDocument_HorizontalRule(mockGUI):
     doc = ToQTextDocument(project)
     doc.initDocument()
 
+    doc._isNovel = True
+    doc._isFirst = True
+    doc._text = (
+        "#! Title\n"
+        "## Chapter\n"
+        "### Scene 1\n"
+        "Text 1\n"
+        "### Scene 2\n"
+        "Text 2\n"
+        "#### Section\n"
+        "Text 3\n"
+    )
+    doc.setSceneFormat(nwHeadFmt.HRULE, False)
+    doc.setSectionFormat("", False)
+    doc.tokenizeText()
+    doc.doConvert()
+    assert doc.document.blockCount() == 7
+
     cursor = QTextCursor(doc.document)
     cursor.movePosition(QtMoveEnd)
     doc._insertHorizontalRule(cursor)
 
-    block = doc.document.findBlockByNumber(0)
+    block = doc.document.findBlockByNumber(3)
     bFmt = block.blockFormat()
     assert bFmt.alignment() == QtAlignCenter
     assert bFmt.hasProperty(QTextFormat.Property.BlockTrailingHorizontalRulerWidth)

--- a/tests/test_tools/test_tools_manussettings.py
+++ b/tests/test_tools/test_tools_manussettings.py
@@ -485,14 +485,29 @@ def testToolBuildSettings_Headings(qtbot, nwGUI):
     headTab.btnApply.click()
     assert sBuild.getStr("headings.fmtSection") == nwHeadFmt.TITLE
 
+    # Check that horizontal rule replaces all
+    headTab.btnScene.click()
+    headTab.aInsTitle.trigger()
+    headTab.aInsHRule.trigger()
+    headTab.btnApply.click()
+    assert sBuild.getStr("headings.fmtScene") == nwHeadFmt.HRULE
+
     # Check hide switches
+    headTab.swtPart.setChecked(True)
+    headTab.swtChapter.setChecked(True)
+    headTab.swtUnnumbered.setChecked(True)
     headTab.swtScene.setChecked(True)
+    headTab.swtAScene.setChecked(True)
     headTab.swtSection.setChecked(True)
     headTab.saveContent()
     sBuild = bSettings._build
     assert sBuild.buildID == build.buildID
 
+    assert sBuild.getBool("headings.hidePart") is True
+    assert sBuild.getBool("headings.hideChapter") is True
+    assert sBuild.getBool("headings.hideUnnumbered") is True
     assert sBuild.getBool("headings.hideScene") is True
+    assert sBuild.getBool("headings.hideAltScene") is True
     assert sBuild.getBool("headings.hideSection") is True
 
     # Finish


### PR DESCRIPTION
**Summary:**

This PR introduces a special instance of the separator format for manuscript headings, using four hyphens "----" to indicate a horizontal rule. It is applied to all output formats. For markdown it's a simple "----" line. For Open Document, Word Document, HTML, and QTextDocument (and thus also PDF), it's a horizontal line half the size of the text width.

**Related Issue(s):**

Closes #2755

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
