### PR TITLE
Fix docs typos, ported from main branch

### DIFF
--- a/docs/source/features/story_comments.rst
+++ b/docs/source/features/story_comments.rst
@@ -51,7 +51,7 @@ Other analytical models propose tracking a scene's pace, how it affects the mood
 which element(s) of the story's genre are being satisfied. An author can use this mechanism to
 track any element of a scene. Some examples include time of day, how much time passes in the scene,
 or even the physical form of a shape-shifting character. If a story involves magic, one could track
-which wand a main character has in hand. It's up to tha author.
+which wand a main character has in hand. It's up to the author.
 
 When the story and other scene metadata is extracted into a tabular form, it is possible to get a
 comprehensive overview of the story and to identify possible issues. For example, so many

--- a/docs/source/more/counting.rst
+++ b/docs/source/more/counting.rst
@@ -15,7 +15,7 @@ generated preview.
 Text Word Counts and Stats
 ==========================
 
-These are the rules for the main counts available for for each document in a project.
+These are the rules for the main counts available for each document in a project.
 
 For all counts, the following rules apply.
 
@@ -82,17 +82,17 @@ The following counts are available:
    The number of characters in all lines, including any comments and meta data text. Paragraph
    breaks are not counted, but in-paragraph hard line breaks are.
 
-**Character in Text**
+**Characters in Text**
    The number of characters in body text paragraphs. Paragraph breaks are not counted, but
    in-paragraph hard line breaks are.
 
 **Characters in Headings**
    The number of characters in headings.
 
-**Character in Text, No Spaces**
+**Characters in Text, No Spaces**
    The number of characters in body text paragraphs considered part of a word or punctuation. That
    is, white space characters are not counted.
 
-**Character in Headings, No Spaces**
+**Characters in Headings, No Spaces**
    The number of characters in headings considered part of a word or punctuation. That is, white
    space characters are not counted.

--- a/docs/source/more/dictionaries.rst
+++ b/docs/source/more/dictionaries.rst
@@ -35,7 +35,7 @@ that uses Enchant for spell checking.
 **Manual Install**
 
 If you prefer to do this manually or want to use a different source than the ones mentioned above,
-You need to get compatible dictionary files for your language. You need two files files ending with
+You need to get compatible dictionary files for your language. You need two files ending with
 ``.aff`` and ``.dic``. These files must then be copied to the following location: 
 
 ``C:\Users\<USER>\AppData\Local\enchant\hunspell``

--- a/docs/source/technical/storage.rst
+++ b/docs/source/technical/storage.rst
@@ -190,4 +190,4 @@ Statistics** tool. If this file is lost, the history it contains is also lost, b
 no impact on the project.
 
 Each session is recorded as a JSON object on a single line of the file. Each session record is
-appended tot he file.
+appended to the file.

--- a/docs/source/user_interface/editor_viewer.rst
+++ b/docs/source/user_interface/editor_viewer.rst
@@ -23,7 +23,7 @@ it selected, or drag and drop it onto the editor panel. This will open the docum
 editor.
 
 The editor has a maximise button, which toggles the **Focus Mode**, and a close button in the
-top--right corner. On the top--left side you will find a tools button that opens a toolbar with a
+top-right corner. On the top-left side you will find a tools button that opens a toolbar with a
 few buttons for applying text formatting, a drop down menu for navigating between headings, and a
 search button to open the search dialog.
 
@@ -153,14 +153,14 @@ middle-clicking on the document will also open it in the viewer.
 
 The document viewed does not have to be the same document as the one currently being edited.
 However, If you *are* viewing the same document, pressing :kbd:`Ctrl+R` from the editor will update
-the document with your latest changes. You can also press the reload button in the top--right
+the document with your latest changes. You can also press the reload button in the top-right
 corner of the viewer panel, next to the close button, to achieve the same thing.
 
 In the viewer, references become clickable links. Clicking them will replace the content of the
 viewer with the content of the document the reference points to.
 
 The document viewer keeps a history of viewed documents, which you can navigate with the arrow
-buttons in the top--left corner of the viewer. If your mouse has backward and forward navigation
+buttons in the top-left corner of the viewer. If your mouse has backward and forward navigation
 buttons, these can be used as well. They work just like the backward and forward features in a
 browser. The left-most button is a dropdown menu for quickly navigation between headings in the
 document. The edit button on the right will open the viewed document in the editor.


### PR DESCRIPTION
**Summary:**

Apply typo fixes from #2772 also on release.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
