### PR TITLE
Refresh reference list on changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,10 @@
 - Run the most relevant tests for the changed area when available.
 - If tests are missing for the touched path, add focused tests alongside the change when practical.
 - Do not fix unrelated failures unless they block the requested task.
-- When running tests, set `QT_QPA_PLATFORM=offscreen` to disable the Qt GUI. Use `./run_tests.py -o`
-  or `QT_QPA_PLATFORM=offscreen python -m pytest`.
+- Always run tests in offscreen mode, including non-GUI tests.
+- It is acceptable to use the offscreen environment variable for all test commands.
+- Use `./run_tests.py -o` or `QT_QPA_PLATFORM=offscreen python -m pytest ...`.
+- Do not run bare `pytest` without `QT_QPA_PLATFORM=offscreen`.
 - Avoid adding test-specific code to the main code base.
 
 ## Documentation

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -325,6 +325,7 @@ class Index:
         text.
         """
         tItem = self._project.tree[tHandle]
+        oldRefs = self._itemRefHandles(tHandle)
         if tItem is None:
             logger.info("Not indexing unknown item '%s'", tHandle)
             return False
@@ -365,6 +366,8 @@ class Index:
         self._indexChange = nowTime
         self._rootChange[tItem.itemRoot] = nowTime
         if not blockSignal:
+            if changedRefs := sorted(oldRefs | self._itemRefHandles(tHandle)):
+                SHARED.emitIndexChangedRefs(self._project, changedRefs)
             tItem.notifyToRefresh()
 
         return True
@@ -452,7 +455,12 @@ class Index:
         self._itemIndex.setHeadingCounts(tHandle, sTitle, cC, wC, pC)
 
     def _indexKeyword(
-        self, tHandle: str, line: str, sTitle: str, itemClass: nwItemClass, tags: dict[str, bool]
+        self,
+        tHandle: str,
+        line: str,
+        sTitle: str,
+        itemClass: nwItemClass,
+        tags: dict[str, bool],
     ) -> None:
         """Validate and save the information about a reference to a tag
         in another file, or the setting of a tag in the file. A record
@@ -491,6 +499,18 @@ class Index:
         for handle in self._project.tree.subTree(tHandle):
             if (node := self._itemIndex[handle]) and node.item.isDocumentLayout() and node.item.isActive:
                 model.append(node, notify=notify)
+
+    def _itemRefHandles(self, tHandle: str) -> set[str]:
+        """Get the handles referenced by an indexed item."""
+        if iItem := self._itemIndex[tHandle]:
+            return {
+                rHandle
+                for sTitle in iItem.headings()
+                if (hItem := iItem[sTitle])
+                for tTag in hItem.references
+                if (rHandle := self._tagsIndex.tagHandle(tTag))
+            }
+        return set()
 
     ##
     #  Check @ Lines
@@ -638,7 +658,10 @@ class Index:
         return hCount
 
     def getTableOfContents(
-        self, rHandle: str | None, maxDepth: int, activeOnly: bool = True
+        self,
+        rHandle: str | None,
+        maxDepth: int,
+        activeOnly: bool = True,
     ) -> list[tuple[str, int, str, int]]:
         """Generate a table of contents up to a maximum depth."""
         tOrder = []

--- a/novelwriter/gui/docviewerpanel.py
+++ b/novelwriter/gui/docviewerpanel.py
@@ -195,6 +195,12 @@ class GuiDocViewerPanel(QWidget):
                 logger.warning("Could not remove tag '%s' from view panel", key)
         self._updateTabVisibility()
 
+    @pyqtSlot(list)
+    def updateChangedRefs(self, updated: list[str]) -> None:
+        """Refresh back references when a tracked handle has changed."""
+        if self._lastHandle in updated:
+            self.tabBackRefs.refreshContent(self._lastHandle)
+
     @pyqtSlot(str)
     def updateStatusLabels(self, kind: str) -> None:
         """Update the importance labels."""

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -217,6 +217,7 @@ class GuiMain(QMainWindow):
 
         SHARED.focusModeChanged.connect(self._focusModeChanged)
         SHARED.indexAvailable.connect(self.docViewerPanel.indexHasAppeared)
+        SHARED.indexChangedRefs.connect(self.docViewerPanel.updateChangedRefs)
         SHARED.indexChangedTags.connect(self.docEditor.updateChangedTags)
         SHARED.indexChangedTags.connect(self.docViewerPanel.updateChangedTags)
         SHARED.indexCleared.connect(self.docViewerPanel.indexWasCleared)

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -68,6 +68,7 @@ class SharedData(QObject):
 
     focusModeChanged = pyqtSignal(bool)
     indexAvailable = pyqtSignal()
+    indexChangedRefs = pyqtSignal(list)
     indexChangedTags = pyqtSignal(list, list)
     indexCleared = pyqtSignal()
     mainClockTick = pyqtSignal()
@@ -350,6 +351,11 @@ class SharedData(QObject):
         """Emit the indexChangedTags signal."""
         if self._project and self._project.data.uuid == project.data.uuid:
             self.indexChangedTags.emit(updated, deleted)
+
+    def emitIndexChangedRefs(self, project: NWProject, updated: list[str]) -> None:
+        """Emit the indexChangedRefs signal."""
+        if self._project and self._project.data.uuid == project.data.uuid:
+            self.indexChangedRefs.emit(updated)
 
     def emitIndexCleared(self, project: NWProject) -> None:
         """Emit the indexCleared signal."""

--- a/tests/test_core/test_index.py
+++ b/tests/test_core/test_index.py
@@ -602,6 +602,38 @@ def testCoreIndex_ScanText(monkeypatch, nwGUI, fncPath, mockRnd):
 
 
 @pytest.mark.core
+def testCoreIndex_ChangedRefsSignal(qtbot, nwGUI, fncPath, mockRnd):
+    """Check that scanning emits updated backreference handles."""
+    project = NWProject()
+    mockRnd.reset()
+    buildTestProject(project, fncPath)
+    index = project.index
+
+    # The SharedData signal proxy only emits for the active project
+    SHARED._project = project
+
+    nHandle = project.newFile("Hello", C.hNovelRoot)
+    cHandle = project.newFile("Jane", C.hCharRoot)
+    wHandle = project.newFile("Earth", C.hWorldRoot)
+    assert isinstance(nHandle, str)
+    assert isinstance(cHandle, str)
+    assert isinstance(wHandle, str)
+
+    assert index.scanText(cHandle, "# Jane Smith\n@tag: Jane\n")
+    assert index.scanText(wHandle, "# Earth\n@tag: Earth\n")
+
+    with qtbot.waitSignal(SHARED.indexChangedRefs, timeout=1000) as blocker:
+        assert index.scanText(nHandle, "# Hello\n@char: Jane\n@location: Earth\n")
+    assert blocker.args == [[cHandle, wHandle]]
+
+    with qtbot.waitSignal(SHARED.indexChangedRefs, timeout=1000) as blocker:
+        assert index.scanText(nHandle, "# Hello\n@char: Jane\n")
+    assert blocker.args == [[cHandle, wHandle]]
+
+    project.closeProject()
+
+
+@pytest.mark.core
 def testCoreIndex_CommentKeys(monkeypatch, nwGUI, fncPath, mockRnd):
     """Check the index comment key generator."""
     project = NWProject()

--- a/tests/test_gui/test_docviewerpanel.py
+++ b/tests/test_gui/test_docviewerpanel.py
@@ -118,6 +118,20 @@ def testGuiViewerPanel_BackRefs(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     tabBackRefs._treeItemDoubleClicked(tabBackRefs.model().index(0, tabBackRefs.C_DOC))
     assert nwGUI.docViewer.docHandle == C.hSceneDoc
 
+    # Regression: Adding/removing references while viewing target should refresh panel
+    nwGUI.viewDocument(hJane)
+    assert nwGUI.docViewer.docHandle == hJane
+    assert tabBackRefs.topLevelItemCount() == 1
+
+    nwGUI.openDocument(C.hSceneDoc)
+    nwGUI.docEditor.setPlainText("### Scene One\n\nNo references in this section.\n")
+    nwGUI.saveDocument()
+    assert tabBackRefs.topLevelItemCount() == 0
+
+    nwGUI.docEditor.setPlainText("### Scene One\n\n@char: Jane\n")
+    nwGUI.saveDocument()
+    assert tabBackRefs.topLevelItemCount() == 1
+
     # qtbot.stop()
 
 


### PR DESCRIPTION
**Summary:**

Emit a signal from the index when the references from a document changes, and hook the reference panel into this.

**Related Issue(s):**

Closes #2124

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
