### PR TITLE
Recursively set active inactive documents in project tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,9 @@
 - Run `uv run ruff format`, `uv run ruff check`, and `uv run pyright` on touched files when making code changes
 - Run the most relevant tests for the changed area when available
 - If tests are missing for the touched path, add focused tests alongside the change when practical
-- Do not run bare `pytest` without `QT_QPA_PLATFORM=offscreen`
+- Always run tests with `QT_QPA_PLATFORM=offscreen` in this repository
+- If a test tool does not allow setting environment variables, run tests in terminal as `QT_QPA_PLATFORM=offscreen uv run pytest ...`
+- Never run GUI tests in this repository without the offscreen environment variable
 - Avoid adding test-specific code to the main code base
 
 ## Documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,66 +3,41 @@
 ## AI Policy
 
 - This repository does not allow large AI-generated contributions. Such PRs will be rejected.
-- Code can be written with AI assistance, but must be concise, performant, and of a comparable
-  quality to existing code.
+- Code can be written with AI assistance, but it must stay concise, performant, and match the existing code quality
 
 ## Scope
 
-- This repository is `novelWriter`, a Python application using PyQt6.
-- Prefer small, targeted changes that match existing patterns in `novelwriter/`.
-- The root import path for all application code is `novelwriter`.
+- This repository is `novelWriter`, a Python application using PyQt6
+- The root import path for application code is `novelwriter`
 
 ## Working Rules
 
-- Follow the existing code style in nearby files; avoid broad refactors.
-- Preserve current behavior unless the task explicitly asks for a change.
-- When editing code, keep diffs minimal and update only the relevant files.
-- Prefer project-local helpers and conventions over introducing new abstractions.
-- The code base should use camelCase style to match the Qt library style.
-- Single-sentence inline comments should not end with punctuation.
-- For Qt enums and related Qt type constants, prefer aliases imported from `novelwriter/types.py`
-  instead of direct enum members from PyQt6 modules where aliases are already available.
-- When connecting Qt signals and passing parameters, prefer `qtLambda` from `novelwriter/common.py`
-  over inline lambdas where it fits existing project patterns.
-- The `i18n/*.ts` files are auto-generated and must never be edited manually.
-- Do not edit files under `sample/` unless explicitly requested.
-- Do not edit files under `tests/lipsum/` unless explicitly requested.
-- Any folder containing `nwProject.nwx` is a novelWriter project storage folder and must not be
-  edited unless explicitly requested.
+- Use camelCase naming to match Qt-style conventions
+- Single-sentence inline comments should not end with punctuation
+- For Qt enums and related Qt constants, prefer aliases from `novelwriter/types.py` when available
+- When connecting Qt signals and passing parameters, prefer `qtLambda` from `novelwriter/common.py` over inline lambdas where it fits the existing pattern
+- The `i18n/*.ts` files are auto-generated and must never be edited manually
+- Do not edit files under `sample/` and `tests/lipsum/` unless explicitly requested
+- Any folder containing `nwProject.nwx` is a novelWriter project storage folder and must not be edited unless explicitly requested
 
 ## Codebase Navigation
 
-- The application code lives under `novelwriter/`. Everything else is supporting code and build
-  scripts that are not published.
-- `novelwriter/core/` contains code that manages the application user's writing project.
-- `novelwriter/dialogs/` contains GUI dialog classes with a smaller scope than full GUI tools.
-- `novelwriter/extensions/` contains GUI classes that modify or extend standard Qt6 classes.
-- `novelwriter/formats/` contains classes used for generating exports for the user's projects.
-- `novelwriter/gui/` contains GUI classes for the main GUI components.
-- `novelwriter/text/` contains various text processing utilities.
-- `novelwriter/tools/` contains larger GUI components that process data.
-- `novelwriter/` root contains shared codes, constants, variables and utility functions.
-- Build getter key strings used with `BuildSettings` are defined in `novelwriter/core/buildsettings.py`.
-- For formats changes, check adjacent format implementations before modifying shared logic.
-- All formats classes are write only, and do not need to read the same file formats.
+- Application code lives under `novelwriter/`; everything else is supporting code and build scripts
+- The `novelwriter/` root contains shared code, constants, variables, and utility functions
+- `novelwriter/{core,dialogs,extensions,formats,gui,text,tools}/` covers project logic, dialog UI, Qt extensions, exports, the main GUI, text utilities, and larger tools
+- Build getter key strings used with `BuildSettings` are defined in `novelwriter/core/buildsettings.py`
+- For format changes, check adjacent implementations before modifying shared logic; format classes are write-only and do not need to read the same file formats
 
 ## Validation
 
-- When making code changes, run `uv run ruff format`.
-- When making code changes, run `uv run ruff check` and address relevant issues in touched files.
-- When making code changes, run `uv run pyright` and address relevant issues in touched files.
-- Run the most relevant tests for the changed area when available.
-- If tests are missing for the touched path, add focused tests alongside the change when practical.
-- Do not fix unrelated failures unless they block the requested task.
-- Always run tests in offscreen mode, including non-GUI tests.
-- It is acceptable to use the offscreen environment variable for all test commands.
-- Use `./run_tests.py -o` or `QT_QPA_PLATFORM=offscreen python -m pytest ...`.
-- Do not run bare `pytest` without `QT_QPA_PLATFORM=offscreen`.
-- Avoid adding test-specific code to the main code base.
+- Run `uv run ruff format`, `uv run ruff check`, and `uv run pyright` on touched files when making code changes
+- Run the most relevant tests for the changed area when available
+- If tests are missing for the touched path, add focused tests alongside the change when practical
+- Do not run bare `pytest` without `QT_QPA_PLATFORM=offscreen`
+- Avoid adding test-specific code to the main code base
 
 ## Documentation
 
-- Link to existing docs instead of duplicating them.
-- Keep agent guidance concise and specific to repository conventions.
-- All titles should be in title case.
-- All text should be written with British English spelling.
+- Link to existing docs instead of duplicating them
+- Keep agent guidance concise and specific to repository conventions
+- Use title case for headings and British English spelling throughout

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -1178,6 +1178,14 @@ class _TreeContextMenu(QMenu):
         else:
             action = qtAddAction(self, self.tr("Toggle Active"))
             action.triggered.connect(self._toggleItemActive)
+            if self._children > 0:
+                mSub = qtAddMenu(self, self.tr("Set Children to ..."))
+                aOne = qtAddAction(mSub, self._tree.trActive)
+                aOne.setIcon(SHARED.theme.getIcon("checked", "accept"))
+                aOne.triggered.connect(qtLambda(self._recurseItemActive, True))
+                aTwo = qtAddAction(mSub, self._tree.trInactive)
+                aTwo.setIcon(SHARED.theme.getIcon("unchecked", "reject"))
+                aTwo.triggered.connect(qtLambda(self._recurseItemActive, False))
 
     def _itemStatusImport(self, multi: bool) -> None:
         """Add actions for changing status or importance."""
@@ -1293,6 +1301,18 @@ class _TreeContextMenu(QMenu):
             if node.item.isFileType():
                 node.item.setActive(state)
                 refresh.append(node.item.itemHandle)
+        SHARED.project.tree.refreshItems(refresh)
+
+    def _recurseItemActive(self, state: bool) -> None:
+        """Set the active status of an item and all its children."""
+        refresh = []
+        if self._item.isFileType():
+            self._item.setActive(state)
+            refresh.append(self._item.itemHandle)
+        for child in self._node.allChildren():
+            if child.item.isFileType():
+                child.item.setActive(state)
+                refresh.append(child.item.itemHandle)
         SHARED.project.tree.refreshItems(refresh)
 
     def _changeItemStatus(self, key: str) -> None:

--- a/tests/test_gui/test_projtree.py
+++ b/tests/test_gui/test_projtree.py
@@ -1650,6 +1650,14 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
                 return [x.text() for x in submenu.actions() if x.text()]
         return []
 
+    def getChildrenActiveSubMenu(menu: QMenu) -> list[str]:
+        for action in menu.actions():
+            if action.text() == "Set Children to ...":
+                submenu = action.menu()
+                assert submenu is not None
+                return [x.text() for x in submenu.actions() if x.text()]
+        return []
+
     # Context Menu on Document File Item
     node = tree.nodes[C.hChapterDoc]
     indices = [model.indexFromHandle(C.hChapterDoc)]
@@ -1708,12 +1716,17 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
         "Rename",
         "Rename to Heading",
         "Toggle Active",
+        "Set Children to ...",
         "Set Status to ...",
         "Transform ...",
         "Expand All",
         "Collapse All",
         "Duplicate",
         "Move to Trash",
+    ]
+    assert getChildrenActiveSubMenu(ctxMenu) == [
+        projTree.trActive,
+        projTree.trInactive,
     ]
     assert getTransformSubMenu(ctxMenu) == [
         "Convert to Novel Document",
@@ -1766,6 +1779,22 @@ def testGuiProjTree_ContextMenu(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     assert node.item.isActive is True
     ctxMenu._toggleItemActive()
     assert node.item.isActive is False
+
+    # Set active flag recursively
+    nodeSub = tree.nodes[hSubNote]
+    nodeCNote = tree.nodes[hCharNote]
+    node.item.setActive(False)
+    nodeSub.item.setActive(True)
+    nodeCNote.item.setActive(True)
+    ctxMenu._recurseItemActive(False)
+    assert node.item.isActive is False
+    assert nodeSub.item.isActive is False
+    assert nodeCNote.item.isActive is True
+    ctxMenu._recurseItemActive(True)
+    assert node.item.isActive is True
+    assert nodeSub.item.isActive is True
+    assert nodeCNote.item.isActive is True
+    node.item.setActive(False)
 
     # Change item status
     assert node.item.itemStatus == "s000000"


### PR DESCRIPTION
**Summary:**

This PR adds a menu option in the project tree to recursively set active/inactive state on all documents under a selected node (including itself).

**Related Issue(s):**

Closes #2188

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
