### PR TITLE
Show active project spell lang in menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - When connecting Qt signals and passing parameters, prefer `qtLambda` from `novelwriter/common.py` over inline lambdas where it fits the existing pattern
 - The `i18n/*.ts` files are auto-generated and must never be edited manually
 - Do not edit files under `sample/` and `tests/lipsum/` unless explicitly requested
+- Treat unstaged changes under `sample/` and `tests/lipsum/` as expected test/runtime churn (timestamps, counters, hashes) and ignore them completely during reviews, status checks, and commit preparation unless explicitly requested
 - Any folder containing `nwProject.nwx` is a novelWriter project storage folder and must not be edited unless explicitly requested
 
 ## Codebase Navigation

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1238,6 +1238,11 @@ class GuiDocEditor(QPlainTextEdit):
         if updated or deleted:
             self._qDocument.syntaxHighlighter.rehighlightByType(BLOCK_META)
 
+    @pyqtSlot(str, str)
+    def processSpellCheckChange(self, language: str, provider: str) -> None:
+        """Process a change in the spell check language or provider."""
+        self.spellCheckDocument()
+
     ##
     #  Private Slots
     ##

--- a/novelwriter/gui/mainmenu.py
+++ b/novelwriter/gui/mainmenu.py
@@ -97,6 +97,14 @@ class GuiMainMenu(QMenuBar):
         self.aSpellCheck.setChecked(state)
 
     @pyqtSlot()
+    def setSelectedProjectSpellCheckLanguage(self) -> None:
+        """Set the selected spell check language in the menu to match
+        the project's setting.
+        """
+        for action in self.mSelectLanguage.actions():
+            action.setChecked(action.data() == (SHARED.project.data.spellLang or "None"))
+
+    @pyqtSlot()
     def updateSpellCheckLanguages(self) -> None:
         """Update the list of available spell check languages."""
         self.mSelectLanguage.clear()
@@ -105,8 +113,11 @@ class GuiMainMenu(QMenuBar):
         for tag, language in languages:
             aSpell = QAction(self.mSelectLanguage)
             aSpell.setText(language)
+            aSpell.setCheckable(True)
+            aSpell.setData(tag)
             aSpell.triggered.connect(qtLambda(self._changeSpelling, tag))
             self.mSelectLanguage.addAction(aSpell)
+        self.setSelectedProjectSpellCheckLanguage()
 
     ##
     #  Private Slots
@@ -131,6 +142,7 @@ class GuiMainMenu(QMenuBar):
         """Change the spell check language."""
         SHARED.project.data.setSpellLang(language)
         SHARED.updateSpellCheckLanguage()
+        self.setSelectedProjectSpellCheckLanguage()
 
     ##
     #  Internal Functions

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1080,6 +1080,7 @@ class GuiMain(QMainWindow):
         logger.debug("Applying new project settings")
         SHARED.updateSpellCheckLanguage()
         self.itemDetails.refreshDetails()
+        self.mainMenu.setSelectedProjectSpellCheckLanguage()
         self._updateWindowTitle(SHARED.project.data.name)
 
     @pyqtSlot()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -232,8 +232,8 @@ class GuiMain(QMainWindow):
         SHARED.rootFolderChanged.connect(self.novelView.updateRootItem)
         SHARED.rootFolderChanged.connect(self.outlineView.updateRootItem)
         SHARED.rootFolderChanged.connect(self.projView.updateRootItem)
-        SHARED.spellLanguageChanged.connect(self.mainStatus.setLanguage)
         SHARED.spellLanguageChanged.connect(self.docEditor.processSpellCheckChange)
+        SHARED.spellLanguageChanged.connect(self.mainStatus.setLanguage)
         SHARED.statusLabelsChanged.connect(self.docViewerPanel.updateStatusLabels)
 
         self.mainMenu.requestDocAction.connect(self._passDocumentAction)

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -233,6 +233,7 @@ class GuiMain(QMainWindow):
         SHARED.rootFolderChanged.connect(self.outlineView.updateRootItem)
         SHARED.rootFolderChanged.connect(self.projView.updateRootItem)
         SHARED.spellLanguageChanged.connect(self.mainStatus.setLanguage)
+        SHARED.spellLanguageChanged.connect(self.docEditor.processSpellCheckChange)
         SHARED.statusLabelsChanged.connect(self.docViewerPanel.updateStatusLabels)
 
         self.mainMenu.requestDocAction.connect(self._passDocumentAction)

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a0" hexVersion="0x260200a0" fileVersion="1.5" fileRevision="6" timeStamp="2026-06-20 17:38:47">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2346" autoCount="428" editTime="109870">
+<novelWriterXML appVersion="26.2a0" hexVersion="0x260200a0" fileVersion="1.5" fileRevision="6" timeStamp="2026-06-27 23:30:50">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2350" autoCount="428" editTime="109920">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -59,7 +59,7 @@
       <name status="sf24ce6" import="ia857f0" active="yes">Basic Formatting</name>
     </item>
     <item handle="636b6aa9b697b" parent="6a2d6d5f4f401" root="7031beac91f75" order="0" type="FILE" class="NOVEL" layout="DOCUMENT">
-      <meta expanded="no" heading="H3" charCount="3003" wordCount="530" paraCount="16" cursorPos="1505" />
+      <meta expanded="no" heading="H3" charCount="3003" wordCount="530" paraCount="16" cursorPos="19" />
       <name status="s90e6c9" import="ia857f0" active="yes">Making a Scene</name>
     </item>
     <item handle="bc0cbd2a407f3" parent="6a2d6d5f4f401" root="7031beac91f75" order="1" type="FILE" class="NOVEL" layout="DOCUMENT">


### PR DESCRIPTION
**Summary:**

This PR adds a check box on the spell check languages in the menu and updates the checked state when the project language changes. It also re-runs the spell checker in the document if the language itself changes.

**Related Issue(s):**

Closes #2311

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
