### PR TITLE
Update default Python to 3.14

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           architecture: x64
 
       - name: Checkout Source

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,9 +1,12 @@
 name: i18n
 
 on:
-  push:
+  pull_request:
     branches:
-      - i18n*
+      - main
+      - release
+    paths:
+      - i18n/*.ts
 
 jobs:
   buildI18n:

--- a/.github/workflows/part_appimage.yml
+++ b/.github/workflows/part_appimage.yml
@@ -11,14 +11,14 @@ jobs:
     permissions:
       contents: read
     env:
-      PYTHON_VERSION: "3.13"
+      PYTHON_VERSION: "3.14"
       LINUX_TAG: "manylinux_2_28"
       LINUX_ARCH: "x86_64"
     steps:
       - name: Python Setup
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           architecture: x64
 
       - name: Install Packages (apt)

--- a/.github/workflows/part_assets.yml
+++ b/.github/workflows/part_assets.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install UV and Python
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           enable-cache: true
 
       - name: Install Dependencies

--- a/.github/workflows/part_win_x64.yml
+++ b/.github/workflows/part_win_x64.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           architecture: x64
 
       - name: Checkout Source

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   testMac:
     runs-on: macos-latest
-    name: Test Python 3.13
+    name: Test Python 3.14
     permissions:
       contents: read
     steps:
@@ -27,7 +27,7 @@ jobs:
       - name: Install UV and Python
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.14"
           enable-cache: true
 
       - name: Install Dependencies

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   testWin:
     runs-on: windows-latest
-    name: Test Python 3.13
+    name: Test Python 3.14
     permissions:
       contents: read
     steps:
@@ -23,7 +23,7 @@ jobs:
       - name: Install UV and Python
         uses: astral-sh/setup-uv@v8.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.14"
           enable-cache: true
 
       - name: Install Dependencies


### PR DESCRIPTION
**Summary:**

* Changes default Python for testing and embedding in builds to 3.14
* Fixes the i18n workflow to trigger on translation file changes

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
