### PR TITLE
Clarify icon and image format checks in tests

### DIFF
--- a/tests/test_gui/test_theme.py
+++ b/tests/test_gui/test_theme.py
@@ -426,7 +426,11 @@ def testGuiTheme_IconThemes(monkeypatch):
 
 @pytest.mark.gui
 def testGuiTheme_LoadIcons():
-    """Test the icon cache class."""
+    """Test the icon cache class.
+
+    This test requires the SVG library to be installed for PyQt6.
+    It is called python3-pyqt6.qtsvg on Debian/Ubuntu.
+    """
     theme = GuiTheme()
     theme.initThemes()
     iconCache = theme.iconCache
@@ -442,7 +446,7 @@ def testGuiTheme_LoadIcons():
     # Load an icon, it is likely already cached
     qIcon = iconCache.getIcon("add", "tool")
     assert isinstance(qIcon, QIcon)
-    assert qIcon.isNull() is False
+    assert qIcon.isNull() is False, "No image data, SVG library may be missing"
 
     # Load it as a pixmap with a size
     # If this part of the test fails, you may need to set the
@@ -534,7 +538,12 @@ def testGuiTheme_LoadIcons():
 
 @pytest.mark.gui
 def testGuiTheme_LoadDecorations(monkeypatch):
-    """Test the icon cache class."""
+    """Test the icon cache class.
+
+    This test requires the image formats library to be installed for Qt6.
+    It is called qt6-image-formats-plugins on Debian/Ubuntu,
+    and qt6-qtimageformats on Fedora.
+    """
     theme = GuiTheme()
     theme.initThemes()
     iconCache = theme.iconCache
@@ -548,7 +557,7 @@ def testGuiTheme_LoadDecorations(monkeypatch):
 
     # Load an image
     qPix = iconCache.getDecoration("welcome")
-    assert qPix.isNull() is False
+    assert qPix.isNull() is False, "No image data, Qt6 image formats library may be missing"
 
     # Fail finding the file
     with monkeypatch.context() as mp:


### PR DESCRIPTION
**Summary:**

Both SVG support and the Qt image formats plugin are needed for the theme engine. This is covered in tests, but this PR adds a reason message for when the tests fail.

**Related Issue(s):**

See: https://github.com/vkbo/novelWriter/pull/2463#issuecomment-4830717886

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
