### PR TITLE
Remove Ubuntu 25.10 and add 26.10

### DIFF
--- a/utils/build_debian.py
+++ b/utils/build_debian.py
@@ -248,8 +248,8 @@ def launchpad(args: argparse.Namespace) -> None:
 
     distLoop = [
         ("24.04", "noble", 12, True),
-        ("25.10", "questing", 13, False),
         ("26.04", "resolute", 13, False),
+        ("26.10", "stonking", 13, False),
     ]
 
     print("Building Ubuntu packages for:")


### PR DESCRIPTION
**Summary:**

Change in active Ubuntu releases.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
