### PR TITLE
Shorten the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,118 +1,49 @@
-# Contributor Covenant 3.0 Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+## Purpose
 
-We pledge to make our community welcoming, safe, and equitable for all.
+This repository should be welcoming and safe for everyone participating in good faith.
 
-We are committed to fostering an environment that respects and promotes the dignity, rights, and
-contributions of all individuals, regardless of characteristics including race, ethnicity, caste,
-color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or
-expression, sexual orientation, language, philosophy or religion, national or social origin,
-socio-economic position, level of education, or other status. The same privileges of participation
-are extended to everyone who participates in good faith and in accordance with this Covenant.
+All contributors and participants must be treated with respect, regardless of characteristics such
+as race, ethnicity, caste, colour, age, physical characteristics, neurodiversity, disability, sex
+or gender, gender identity or expression, sexual orientation, language, philosophy or religion,
+national or social origin, socio-economic position, level of education, or other status.
 
-## Encouraged Behaviors
+## Expected Behaviour
 
-While acknowledging differences in social norms, we all strive to meet our community's expectations
-for positive behavior. We also understand that our words and actions may be interpreted differently
-than we intend based on culture, background, or native language.
+1. Be respectful and constructive in pull requests, issues, discussions, and comments
+2. Focus critique on ideas and code, not people
+3. Assume good faith, and communicate clearly and honestly
+4. Accept feedback gracefully and take responsibility for your contributions
 
-With these considerations in mind, we agree to behave mindfully toward each other and act in ways
-that center our shared values, including:
+## Unacceptable Behaviour
 
-1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
-2. Engaging **kindly and honestly** with others.
-3. Respecting **different viewpoints** and experiences.
-4. **Taking responsibility** for our actions and contributions.
-5. Gracefully giving and accepting **constructive feedback**.
-6. Committing to **repairing harm** when it occurs.
-7. Behaving in other ways that promote and sustain the **well-being of our community**.
-
-
-## Restricted Behaviors
-
-We agree to restrict the following behaviors in our community. Instances, threats, and promotion of
-these behaviors are violations of this Code of Conduct.
-
-1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal
-   attention after any clear request to stop.
-2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a
-   community member or group of people.
-3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis
-   of immutable identities or traits.
-4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate
-   in the context or purpose of the community.
-5. **Violating confidentiality**. Sharing or acting on someone's personal or private information
-   without their permission.
-6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person
-   or group.
-7. Behaving in other ways that **threaten the well-being** of our community.
-
-### Other Restrictions
-
-1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone
-   else to evade enforcement actions.
-2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
-3. **Promotional materials**. Sharing marketing or other commercial content in a way that is
-   outside the norms of the community.
-4. **Irresponsible communication.** Failing to responsibly present content which includes, links or
-   describes any other restricted behaviors.
-
-
-## Reporting an Issue
-
-Tensions can occur between community members even when they are trying their best to collaborate.
-Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces
-encouraged behaviors and norms that can help avoid conflicts and minimize harm.
-
-When an incident does occur, it is important to report it promptly. To report a possible violation,
-**contact the owner**. Contact details can be found at [github.com/vkbo](https://github.com/vkbo).
-
-Community Moderators take reports of violations seriously and will make every effort to respond in
-a timely manner. They will investigate all reports of code of conduct violations, reviewing
-messages, logs, and recordings, or interviewing witnesses and other participants. Community
-Moderators will keep investigation and enforcement actions as transparent as possible while
-prioritizing safety and confidentiality. In order to honor these values, enforcement actions are
-carried out in private with the involved parties, but communicating to the whole community may be
-part of a mutually agreed upon resolution.
-
-
-## Addressing and Repairing Harm
-
-Given the tools available on the project's GitHub repository, the following reactions may be
-applied to violations when using the public pull request, issues and discussions features:
-
-* Minor violations may result in a public warning and/or the comment being hidden or closed.
-* More severe violations may result in the content being deleted without warning.
-* Repeated violations or major violations will result in the account being blocked from
-  participating in the future, and the content deleted.
-* Content that may violate GitHub community polices will be reported to GitHub.
-
-On other platforms related to this project, similar steps will apply. Private communication will be
-used when possible.
-
+1. Harassment, abuse, intimidation, or threats
+2. Insults, personal attacks, or demeaning language
+3. Discrimination, stereotyping, or hateful conduct
+4. Sexualised or otherwise inappropriate conduct
+5. Sharing private or identifying information without permission
+6. Impersonation, deliberate misrepresentation, or other deceptive behaviour
+7. Spam or promotional content unrelated to the project
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is
-officially representing the community in public or other spaces. Examples of representing our
-community include using an official email address, posting via an official social media account, or
-acting as an appointed representative at an online or offline event.
+This Code of Conduct applies to interactions in this GitHub repository, including pull requests,
+issues, discussions, reviews, and comments.
 
+## Reporting
+
+If you believe this Code of Conduct has been violated, contact the repository owner via
+[github.com/vkbo](https://github.com/vkbo).
+
+## Enforcement
+
+Moderation options on GitHub are limited. Depending on severity and pattern of behaviour, the owner
+may edit or delete content, close or lock threads, and block users from further participation.
+
+Content that may violate GitHub platform rules may also be reported to GitHub for review.
 
 ## Attribution
 
-This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available
-at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
-
-Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under
-CC BY-SA 4.0. To view a copy of this license, visit
-[https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
-
-For answers to common questions about Contributor Covenant, see the FAQ at
-[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).
-Translations are provided at
-[https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
-Additional enforcement and community guideline resources can be found at
-[https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources).
-The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
+This document is adapted from the Contributor Covenant 3.0:
+[https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).


### PR DESCRIPTION
**Summary:**

Trim the code of conduct file and, scope it down to the current repo. Everything else is mainly intended for communities, and is mostly out of scope.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
