### PR TITLE
Spell check word caching

### DIFF
--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+MAX_CACHE_SIZE = 100_000
+
 
 class NWSpellEnchant:
     """Core: Enchant Spell Checking Wrapper.
@@ -50,6 +52,7 @@ class NWSpellEnchant:
         self._project = project
         self._enchant = FakeEnchant()
         self._userDict = UserDictionary(project)
+        self._cache: dict[str, bool] = {}
         self._language = None
         self._requested = None
         self._broker = None
@@ -87,6 +90,7 @@ class NWSpellEnchant:
         self._broker = None
         self._language = None
         self._requested = language or None
+        self._cache.clear()
 
         try:
             import enchant
@@ -114,11 +118,18 @@ class NWSpellEnchant:
     ##
 
     def checkWord(self, word: str) -> bool:
-        """Forward check to pyenchant."""
-        try:
-            return bool(self._enchant.check(word))
-        except Exception:
-            return True
+        """Forward check to pyenchant. The results are cached, since the
+        same words tend to be checked over and over again.
+        """
+        if (result := self._cache.get(word)) is None:
+            try:
+                result = bool(self._enchant.check(word))
+            except Exception:
+                result = True
+            if len(self._cache) >= MAX_CACHE_SIZE:
+                self._cache.clear()
+            self._cache[word] = result
+        return result
 
     def suggestWords(self, word: str) -> list[str]:
         """Ask pyenchant for suggestions."""
@@ -134,6 +145,7 @@ class NWSpellEnchant:
                 self._enchant.add_to_session(word)
             except Exception:
                 return
+            self._cache[word] = True
             if save and self._userDict.add(word):
                 self._userDict.save()
         return

--- a/tests/test_core/test_spellcheck.py
+++ b/tests/test_core/test_spellcheck.py
@@ -193,3 +193,41 @@ def testCoreSpell_Enchant(monkeypatch, mockGUI, fncPath):
         mp.setattr("enchant.Broker.request_dict", lambda *a: None)
         spChk.setLanguage("en_US")
         assert isinstance(spChk._enchant, FakeEnchant)
+
+
+@pytest.mark.core
+def testCoreSpell_Cache(monkeypatch, mockGUI, fncPath):
+    """Test the spell checker word cache."""
+    project = NWProject()
+    buildTestProject(project, fncPath)
+
+    spChk = NWSpellEnchant(project)
+    spChk.setLanguage("en_US")
+    assert spChk._cache == {}
+
+    # Checked words should be cached with their result
+    assert spChk.checkWord("word") is True
+    assert spChk.checkWord("wrod") is False
+    assert spChk._cache == {"word": True, "wrod": False}
+
+    # Cached results should be returned without calling enchant,
+    # which we check by swapping in FakeEnchant, which always says True
+    spChk._enchant = FakeEnchant()
+    assert spChk.checkWord("wrod") is False  # Cached result
+    assert spChk.checkWord("wrodd") is True  # New word, hits FakeEnchant
+    assert spChk._cache == {"word": True, "wrod": False, "wrodd": True}
+
+    # When the cache is full, it should be cleared before the next add
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.core.spellcheck.MAX_CACHE_SIZE", 2)
+        assert spChk.checkWord("stuff") is True
+        assert spChk._cache == {"stuff": True}
+
+    # Adding a word to the dictionary should also add it to the cache
+    spChk.addWord("zpqxy", save=False)
+    assert spChk._cache == {"stuff": True, "zpqxy": True}
+    assert spChk.checkWord("zpqxy") is True
+
+    # Changing the language should clear the cache
+    spChk.setLanguage("en_US")
+    assert spChk._cache == {}

--- a/tests/test_core/test_spellcheck.py
+++ b/tests/test_core/test_spellcheck.py
@@ -201,8 +201,12 @@ def testCoreSpell_Cache(monkeypatch, mockGUI, fncPath):
     project = NWProject()
     buildTestProject(project, fncPath)
 
+    class MockEnchant(FakeEnchant):
+        def check(self, word: str) -> bool:
+            return word != "wrod"
+
     spChk = NWSpellEnchant(project)
-    spChk.setLanguage("en_US")
+    spChk._enchant = MockEnchant()
     assert spChk._cache == {}
 
     # Checked words should be cached with their result
@@ -210,8 +214,8 @@ def testCoreSpell_Cache(monkeypatch, mockGUI, fncPath):
     assert spChk.checkWord("wrod") is False
     assert spChk._cache == {"word": True, "wrod": False}
 
-    # Cached results should be returned without calling enchant,
-    # which we check by swapping in FakeEnchant, which always says True
+    # Cached results should be returned without calling the checker,
+    # which we verify by swapping in FakeEnchant, which always says True
     spChk._enchant = FakeEnchant()
     assert spChk.checkWord("wrod") is False  # Cached result
     assert spChk.checkWord("wrodd") is True  # New word, hits FakeEnchant
@@ -229,5 +233,5 @@ def testCoreSpell_Cache(monkeypatch, mockGUI, fncPath):
     assert spChk.checkWord("zpqxy") is True
 
     # Changing the language should clear the cache
-    spChk.setLanguage("en_US")
+    spChk.setLanguage(None)
     assert spChk._cache == {}


### PR DESCRIPTION
**Summary:**

This PR adds a simple cache dictionary in the spell checker to avoid calling the enchant library for the same words over and over.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
