### PR TITLE
Forward search race condition fix

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1570,19 +1570,17 @@ class GuiDocEditor(QPlainTextEdit):
 
     def _openNextFindDocument(self, prevFocus: QWidget, goBack: bool) -> None:
         """Open the adjacent document and select its edge-most match."""
-        if self._docHandle is None:
-            return
+        if self._docHandle:
+            self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop, goBack)
+            QApplication.processEvents()
+            self.beginSearch()
+            prevFocus.setFocus()
 
-        self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop, goBack)
-        QApplication.processEvents()
-        self.beginSearch()
-        prevFocus.setFocus()
+            resS, resE = self.findAllOccurences()
+            if len(resS) == 0:
+                return
 
-        resS, resE = self.findAllOccurences()
-        if len(resS) == 0:
-            return
-
-        self._setFindSelection(resS, resE, len(resS) - 1 if goBack else 0)
+            self._setFindSelection(resS, resE, len(resS) - 1 if goBack else 0)
 
     def _setFindSelection(self, resS: list[int], resE: list[int], resIdx: int) -> None:
         """Select one search result and update the search state."""

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1541,10 +1541,7 @@ class GuiDocEditor(QPlainTextEdit):
             self.docSearch.setResultCount(0, 0)
             self._lastFind = None
             if CONFIG.searchNextFile:
-                self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop, goBack)
-                QApplication.processEvents()
-                self.beginSearch()
-                prevFocus.setFocus()
+                self._openNextFindDocument(prevFocus, goBack)
             return
 
         cursor = self.textCursor()
@@ -1556,26 +1553,46 @@ class GuiDocEditor(QPlainTextEdit):
         if goBack:
             resIdx -= 2
 
-        if ((resIdx < 0 and goBack) or (resIdx > maxIdx and not goBack)) and self._docHandle:
-            if CONFIG.searchNextFile:
-                self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop, goBack)
-                QApplication.processEvents()
-                self.beginSearch()
-                prevFocus.setFocus()
+        if (resIdx < 0 and goBack) or (resIdx > maxIdx and not goBack):
+            if self._docHandle and CONFIG.searchNextFile:
+                self._openNextFindDocument(prevFocus, goBack)
                 return
             elif goBack:
                 resIdx = maxIdx if doLoop else 0
             else:
                 resIdx = 0 if doLoop else maxIdx
 
+            resIdx = max(0, min(resIdx, maxIdx))
+
+        self._setFindSelection(resS, resE, resIdx)
+
+        return
+
+    def _openNextFindDocument(self, prevFocus: QWidget, goBack: bool) -> None:
+        """Open the adjacent document and select its edge-most match."""
+        if self._docHandle is None:
+            return
+
+        self.requestNextDocument.emit(self._docHandle, CONFIG.searchLoop, goBack)
+        QApplication.processEvents()
+        self.beginSearch()
+        prevFocus.setFocus()
+
+        resS, resE = self.findAllOccurences()
+        if len(resS) == 0:
+            return
+
+        self._setFindSelection(resS, resE, len(resS) - 1 if goBack else 0)
+
+    def _setFindSelection(self, resS: list[int], resE: list[int], resIdx: int) -> None:
+        """Select one search result and update the search state."""
+        cursor = self.textCursor()
         cursor.setPosition(resS[resIdx], QtMoveAnchor)
         cursor.setPosition(resE[resIdx], QtKeepAnchor)
         self.setTextCursor(cursor)
 
         self.docSearch.setResultCount(resIdx + 1, len(resS))
         self._lastFind = (resS[resIdx], resE[resIdx])
-
-        return
 
     def findAllOccurences(self) -> tuple[list[int], list[int]]:
         """Create a list of all search results of the current search

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -2822,6 +2822,10 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
         docEditor.findNext(goBack=True)
         assert abs(docEditor.getCursorPosition() - 665) < 3
 
+        cursorPos = docEditor.getCursorPosition()
+        docEditor._openNextFindDocument(docEditor, False)
+        assert docEditor.getCursorPosition() == cursorPos
+
     # Enable next doc search
     docSearch.toggleProject.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleProject.isChecked()

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -2812,6 +2812,16 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 665) < 3
 
+    with monkeypatch.context() as mp:
+        mp.setattr(docEditor, "_docHandle", None)
+        docEditor.setCursorPosition(len(docEditor.getText()))
+        docEditor.findNext()
+        assert abs(docEditor.getCursorPosition() - 665) < 3
+
+        docEditor.setCursorPosition(0)
+        docEditor.findNext(goBack=True)
+        assert abs(docEditor.getCursorPosition() - 665) < 3
+
     # Enable next doc search
     docSearch.toggleProject.activate(QAction.ActionEvent.Trigger)
     assert docSearch.toggleProject.isChecked()
@@ -2820,7 +2830,12 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
     # Next match
     nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert docEditor.docHandle == "2426c6f0ca922"  # Next document
+    assert abs(docEditor.getCursorPosition() - 651) < 3
+    nwGUI.mainMenu.aFindPrev.activate(QAction.ActionEvent.Trigger)
+    assert docEditor.docHandle == "4c4f28287af27"
+    assert abs(docEditor.getCursorPosition() - 665) < 3
     nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
+    assert docEditor.docHandle == "2426c6f0ca922"
     assert abs(docEditor.getCursorPosition() - 651) < 3
     nwGUI.mainMenu.aFindNext.activate(QAction.ActionEvent.Trigger)
     assert abs(docEditor.getCursorPosition() - 1157) < 3


### PR DESCRIPTION
**Summary:**

Fix doc search race across document boundaries. Clamp stale search result indexes in the editor search flow and select the first or last match immediately after jumping to the next document. Add regression coverage for the no-handle edge case and forward/backward cross-document search.

**Related Issue(s):**

Closes #2809

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
