### PR TITLE
Move spell checking out of the syntax highlighter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - Never run GUI tests in this repository without the offscreen environment variable
 - Avoid adding test-specific code to the main code base
 - `CONFIG` is fully reset before every test by the autouse `functionFixture` fixture in `tests/conftest.py`; never save/restore `CONFIG.*` values in a test, just set them directly
+- Both line and branch test coverage should be complete and at 100%
 
 ## Documentation
 

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -45,9 +45,11 @@ MAX_CACHE_SIZE = 100_000
 class NWSpellEnchant:
     """Core: Enchant Spell Checking Wrapper.
 
-    This is a rapper class for Enchant to keep the API consistent
+    This is a wrapper class for Enchant to keep the API consistent
     between spell check tools.
     """
+
+    __slots__ = ("_broker", "_cache", "_enchant", "_language", "_lock", "_project", "_requested", "_userDict")
 
     def __init__(self, project: NWProject) -> None:
         self._project = project
@@ -85,10 +87,14 @@ class NWSpellEnchant:
     def setLanguage(self, language: str | None) -> None:
         """Load a dictionary for the language specified in the config.
         If that fails, we load a mock dictionary so that lookups don't
-        crash. Note that enchant will allow loading an empty string as
-        a tag, but this will fail later on. See issue #1096. The whole
-        swap is locked so that a worker thread never sees a partially
-        loaded dictionary.
+        crash.
+
+        Note:
+        * Enchant will allow loading an empty string as a tag, but this
+          will fail later on. See issue #1096.
+        * The whole swap is locked so that a worker thread never sees a
+          partially loaded dictionary.
+
         """
         with self._lock:
             self._enchant = FakeEnchant()
@@ -123,10 +129,14 @@ class NWSpellEnchant:
     ##
 
     def checkWord(self, word: str) -> bool:
-        """Forward check to pyenchant. The results are cached, since the
-        same words tend to be checked over and over again. The enchant
-        call is locked as the library is not guaranteed thread safe, but
-        cache hits are lock-free.
+        """Forward check to pyenchant.
+
+        Note:
+        * The results are cached, since the same words tend to be
+          checked over and over again.
+        * The enchant call is locked as the library is not guaranteed thread safe, but
+          cache hits are lock-free.
+
         """
         if (result := self._cache.get(word)) is None:
             with self._lock:
@@ -188,6 +198,8 @@ class NWSpellEnchant:
 class FakeEnchant:
     """Fallback for when Enchant is selected, but not installed."""
 
+    __slots__ = ("provider", "tag")
+
     def __init__(self) -> None:
 
         class FakeProvider:
@@ -215,6 +227,8 @@ class UserDictionary:
     This class holds all the user's own words for spell checking
     purposes. The dictionary is per-project.
     """
+
+    __slots__ = ("_project", "_words")
 
     def __init__(self, project: NWProject) -> None:
         self._project = project

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -25,6 +25,7 @@ import json
 import logging
 
 from pathlib import Path
+from threading import Lock
 from typing import TYPE_CHECKING
 
 from novelwriter.common import languageName
@@ -53,6 +54,7 @@ class NWSpellEnchant:
         self._enchant = FakeEnchant()
         self._userDict = UserDictionary(project)
         self._cache: dict[str, bool] = {}
+        self._lock = Lock()
         self._language = None
         self._requested = None
         self._broker = None
@@ -84,34 +86,37 @@ class NWSpellEnchant:
         """Load a dictionary for the language specified in the config.
         If that fails, we load a mock dictionary so that lookups don't
         crash. Note that enchant will allow loading an empty string as
-        a tag, but this will fail later on. See issue #1096.
+        a tag, but this will fail later on. See issue #1096. The whole
+        swap is locked so that a worker thread never sees a partially
+        loaded dictionary.
         """
-        self._enchant = FakeEnchant()
-        self._broker = None
-        self._language = None
-        self._requested = language or None
-        self._cache.clear()
-
-        try:
-            import enchant
-
-            if language and enchant.dict_exists(language):
-                self._broker = enchant.Broker()
-                self._enchant = self._broker.request_dict(language)
-                self._language = language
-                logger.debug("Enchant spell checking for language '%s' loaded", language)
-            else:
-                logger.warning("Enchant found no dictionary for language '%s'", language)
-
-        except Exception:
-            logger.error("Failed to load enchant spell checking for language '%s'", language)
-
-        if self._enchant is None:
+        with self._lock:
             self._enchant = FakeEnchant()
-        else:
-            self._userDict.load()
-            for word in self._userDict:
-                self._enchant.add_to_session(word)
+            self._broker = None
+            self._language = None
+            self._requested = language or None
+            self._cache.clear()
+
+            try:
+                import enchant
+
+                if language and enchant.dict_exists(language):
+                    self._broker = enchant.Broker()
+                    self._enchant = self._broker.request_dict(language)
+                    self._language = language
+                    logger.debug("Enchant spell checking for language '%s' loaded", language)
+                else:
+                    logger.warning("Enchant found no dictionary for language '%s'", language)
+
+            except Exception:
+                logger.error("Failed to load enchant spell checking for language '%s'", language)
+
+            if self._enchant is None:
+                self._enchant = FakeEnchant()
+            else:
+                self._userDict.load()
+                for word in self._userDict:
+                    self._enchant.add_to_session(word)
 
     ##
     #  Methods
@@ -119,13 +124,16 @@ class NWSpellEnchant:
 
     def checkWord(self, word: str) -> bool:
         """Forward check to pyenchant. The results are cached, since the
-        same words tend to be checked over and over again.
+        same words tend to be checked over and over again. The enchant
+        call is locked as the library is not guaranteed thread safe, but
+        cache hits are lock-free.
         """
         if (result := self._cache.get(word)) is None:
-            try:
-                result = bool(self._enchant.check(word))
-            except Exception:
-                result = True
+            with self._lock:
+                try:
+                    result = bool(self._enchant.check(word))
+                except Exception:
+                    result = True
             if len(self._cache) >= MAX_CACHE_SIZE:
                 self._cache.clear()
             self._cache[word] = result
@@ -133,18 +141,20 @@ class NWSpellEnchant:
 
     def suggestWords(self, word: str) -> list[str]:
         """Ask pyenchant for suggestions."""
-        try:
-            return self._enchant.suggest(word)
-        except Exception:
-            return []
+        with self._lock:
+            try:
+                return self._enchant.suggest(word)
+            except Exception:
+                return []
 
     def addWord(self, word: str, save: bool = True) -> None:
         """Add a word to the project dictionary."""
         if word := word.strip():
-            try:
-                self._enchant.add_to_session(word)
-            except Exception:
-                return
+            with self._lock:
+                try:
+                    self._enchant.add_to_session(word)
+                except Exception:
+                    return
             self._cache[word] = True
             if save and self._userDict.add(word):
                 self._userDict.save()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -97,8 +97,8 @@ from novelwriter.enum import (
 from novelwriter.extensions.configlayout import NPathColorLabel
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton
-from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, TextBlockData
-from novelwriter.gui.doctextblock import spellCheckText
+from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE
+from novelwriter.gui.doctextblock import TextBlockData, spellCheckText
 from novelwriter.gui.editordocument import GuiTextDocument
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.text.counting import standardCounter

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -161,6 +161,7 @@ class GuiDocEditor(QPlainTextEdit):
     __slots__ = (
         "_autoReplace",
         "_completer",
+        "_dirtySpell",
         "_doReplace",
         "_docChanged",
         "_docHandle",
@@ -175,9 +176,11 @@ class GuiDocEditor(QPlainTextEdit):
         "_qDocument",
         "_spellFormat",
         "_spellSelections",
+        "_suppressed",
         "_timerDoc",
         "_timerSel",
         "_timerSpell",
+        "_timerSpellCheck",
         "_trActions",
         "_trAddWord",
         "_trCopy",
@@ -248,6 +251,8 @@ class GuiDocEditor(QPlainTextEdit):
         self._selection = QTextEdit.ExtraSelection()
         self._spellFormat = QTextCharFormat()
         self._spellSelections: list[QTextEdit.ExtraSelection] = []
+        self._dirtySpell: dict[int, QTextBlock] = {}
+        self._suppressed = False
 
         # Context Menu Translation
         self._trSetName = self.tr("Set as Document Name")
@@ -284,7 +289,6 @@ class GuiDocEditor(QPlainTextEdit):
         self._qDocument.contentsChange.connect(self._docChange)
         self.selectionChanged.connect(self._updateSelectedStatus)
         self.cursorPositionChanged.connect(self._cursorMoved)
-        self.spellCheckStateChanged.connect(self._qDocument.setSpellCheckState)
 
         # Document Title
         self.docHeader = GuiDocEditHeader(self)
@@ -360,6 +364,12 @@ class GuiDocEditor(QPlainTextEdit):
         if vBar := self.verticalScrollBar():  # pragma: no branch
             vBar.valueChanged.connect(qtLambda(self._timerSpell.start))
 
+        # Set Up Spell Check Debounce
+        self._timerSpellCheck = QTimer(self)
+        self._timerSpellCheck.timeout.connect(self._runSpellCheck)
+        self._timerSpellCheck.setSingleShot(True)
+        self._timerSpellCheck.setInterval(300)
+
         # Install Event Filter for Mouse Wheel
         self.wheelEventFilter = WheelEventFilter(self)
         self.installEventFilter(self.wheelEventFilter)
@@ -427,6 +437,8 @@ class GuiDocEditor(QPlainTextEdit):
         self.docFooter.setHandle(self._docHandle)
         self.docToolBar.setVisible(False)
         self._timerSpell.stop()
+        self._timerSpellCheck.stop()
+        self._dirtySpell.clear()
         self._spellSelections.clear()
         self.setExtraSelections([])
 
@@ -532,6 +544,7 @@ class GuiDocEditor(QPlainTextEdit):
         # which makes it read only.
         if self._docHandle:
             self._qDocument.syntaxHighlighter.rehighlight()
+            self._spellCheckAll()
             self.docHeader.setHandle(self._docHandle)
         else:
             self.clearEditor()
@@ -566,6 +579,7 @@ class GuiDocEditor(QPlainTextEdit):
         self._allowAutoReplace(False)
         self._qDocument.setTextContent(text, tHandle)
         self._allowAutoReplace(True)
+        self._spellCheckAll()
         QApplication.processEvents()
 
         self._lastEdit = time()
@@ -831,16 +845,15 @@ class GuiDocEditor(QPlainTextEdit):
         logger.debug("Spell check is set to '%s'", state)
 
     def spellCheckDocument(self) -> None:
-        """Rerun the highlighter to update spell checking status of the
+        """Spell check the entire document, and update the status of the
         currently loaded text.
         """
         start = time()
         logger.debug("Running spell checker")
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
-        self._qDocument.syntaxHighlighter.rehighlight()
-        self._updateSpellSelections()
+        self._spellCheckAll()
         QApplication.restoreOverrideCursor()
-        logger.debug("Document highlighted in %.3f ms", 1000 * (time() - start))
+        logger.debug("Document spell checked in %.3f ms", 1000 * (time() - start))
         SHARED.newStatusMessage(self.tr("Spell check complete"))
 
     ##
@@ -1284,6 +1297,14 @@ class GuiDocEditor(QPlainTextEdit):
         if not self._timerDoc.isActive():
             self._timerDoc.start()
 
+        if SHARED.project.data.spellCheck:
+            # Flag the affected blocks for the debounced spell check
+            block = self._qDocument.findBlock(pos)
+            while block.isValid() and block.position() <= pos + added:
+                self._dirtySpell[block.blockNumber()] = block
+                block = block.next()
+            self._timerSpellCheck.start()
+
         self._timerSpell.start()
 
         if (block := self._qDocument.findBlock(pos)).isValid():
@@ -1312,6 +1333,10 @@ class GuiDocEditor(QPlainTextEdit):
     def _cursorMoved(self) -> None:
         """Triggered when the cursor moved in the editor."""
         self.docFooter.updateLineCount(self.textCursor())
+        if self._suppressed:
+            # An underline was suppressed at the previous cursor
+            # position, so the underlines must be refreshed
+            self._timerSpell.start()
         if CONFIG.lineHighlight:
             self._selection.cursor = self.textCursor()
             self._selection.cursor.clearSelection()
@@ -1321,13 +1346,19 @@ class GuiDocEditor(QPlainTextEdit):
     def _updateSpellSelections(self) -> None:
         """Rebuild the spell error underlines for all visible blocks."""
         selections = []
+        suppressed = False
         if SHARED.project.data.spellCheck and (viewport := self.viewport()):
+            cPos = self.textCursor().position()
             last = self.cursorForPosition(viewport.rect().bottomLeft()).blockNumber()
             block = self.firstVisibleBlock()
             while block.isValid() and block.blockNumber() <= last:
                 if isinstance(data := block.userData(), TextBlockData):
                     position = block.position()
                     for start, end, _ in data.spellErrors:
+                        if position + start < cPos <= position + end:
+                            # Don't underline the word under the caret
+                            suppressed = True
+                            continue
                         cursor = QTextCursor(self._qDocument)
                         cursor.setPosition(position + start)
                         cursor.setPosition(position + end, QtKeepAnchor)
@@ -1336,8 +1367,18 @@ class GuiDocEditor(QPlainTextEdit):
                         selection.cursor = cursor
                         selections.append(selection)
                 block = block.next()
+        self._suppressed = suppressed
         self._spellSelections = selections
         self._applyExtraSelections()
+
+    @pyqtSlot()
+    def _runSpellCheck(self) -> None:
+        """Spell check the text blocks that have been modified."""
+        for block in self._dirtySpell.values():
+            if block.isValid() and isinstance(data := block.userData(), TextBlockData):
+                data.spellCheck()
+        self._dirtySpell.clear()
+        self._updateSpellSelections()
 
     @pyqtSlot(int, int, str)
     def _insertCompletion(self, pos: int, length: int, text: str) -> None:
@@ -2487,6 +2528,20 @@ class GuiDocEditor(QPlainTextEdit):
         selections.extend(self._spellSelections)
         self.setExtraSelections(selections)
 
+    def _spellCheckAll(self) -> None:
+        """Spell check all text blocks and update the underlines. If
+        spell checking is disabled, only the underlines are updated.
+        """
+        self._timerSpellCheck.stop()
+        self._dirtySpell.clear()
+        if SHARED.project.data.spellCheck:
+            block = self._qDocument.begin()
+            while block.isValid():
+                if isinstance(data := block.userData(), TextBlockData):
+                    data.spellCheck()
+                block = block.next()
+        self._updateSpellSelections()
+
     def _completerToCursor(self) -> None:
         """Make sure the completer menu is positioned by the cursor."""
         if self._completer.isVisible() and (viewport := self.viewport()):
@@ -2511,7 +2566,9 @@ class GuiDocEditor(QPlainTextEdit):
         """
         logger.debug("Added '%s' to project dictionary, %s", word, "saved" if save else "unsaved")
         SHARED.spelling.addWord(word, save=save)
-        self._qDocument.syntaxHighlighter.rehighlightBlock(block)
+        if isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
+            data.spellCheck()
+        self._updateSpellSelections()
 
     def _processTag(
         self,

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -257,6 +257,8 @@ class GuiDocEditor(QPlainTextEdit):
         self._doReplace = False  # Switch to temporarily disable auto-replace
         self._lineColor = QtTransparent
         self._selection = QTextEdit.ExtraSelection()
+
+        # Spell Check Variables
         self._spellFormat = QTextCharFormat()
         self._spellSelections: list[QTextEdit.ExtraSelection] = []
         self._dirtySpell: dict[int, QTextBlock] = {}
@@ -448,6 +450,7 @@ class GuiDocEditor(QPlainTextEdit):
         self.docHeader.clearHeader()
         self.docFooter.setHandle(self._docHandle)
         self.docToolBar.setVisible(False)
+
         self._timerSpell.stop()
         self._timerSpellCheck.stop()
         self._spellPassNo = -1

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -149,6 +149,9 @@ class _SelectAction(Enum):
     MOVE_AFTER = 3
 
 
+SPELL_PASS_CHUNK = 100
+
+
 class _TagAction(IntFlag):
     NONE = 0b00
     FOLLOW = 0b01
@@ -175,12 +178,15 @@ class GuiDocEditor(QPlainTextEdit):
         "_nwItem",
         "_qDocument",
         "_spellFormat",
+        "_spellPassNo",
+        "_spellPassNotify",
         "_spellSelections",
         "_suppressed",
         "_timerDoc",
         "_timerSel",
         "_timerSpell",
         "_timerSpellCheck",
+        "_timerSpellPass",
         "_trActions",
         "_trAddWord",
         "_trCopy",
@@ -253,6 +259,8 @@ class GuiDocEditor(QPlainTextEdit):
         self._spellSelections: list[QTextEdit.ExtraSelection] = []
         self._dirtySpell: dict[int, QTextBlock] = {}
         self._suppressed = False
+        self._spellPassNo = -1
+        self._spellPassNotify = False
 
         # Context Menu Translation
         self._trSetName = self.tr("Set as Document Name")
@@ -370,6 +378,11 @@ class GuiDocEditor(QPlainTextEdit):
         self._timerSpellCheck.setSingleShot(True)
         self._timerSpellCheck.setInterval(300)
 
+        # Set Up Background Spell Check Pass
+        self._timerSpellPass = QTimer(self)
+        self._timerSpellPass.timeout.connect(self._runSpellPass)
+        self._timerSpellPass.setInterval(0)
+
         # Install Event Filter for Mouse Wheel
         self.wheelEventFilter = WheelEventFilter(self)
         self.installEventFilter(self.wheelEventFilter)
@@ -438,6 +451,8 @@ class GuiDocEditor(QPlainTextEdit):
         self.docToolBar.setVisible(False)
         self._timerSpell.stop()
         self._timerSpellCheck.stop()
+        self._timerSpellPass.stop()
+        self._spellPassNo = -1
         self._dirtySpell.clear()
         self._spellSelections.clear()
         self.setExtraSelections([])
@@ -544,7 +559,7 @@ class GuiDocEditor(QPlainTextEdit):
         # which makes it read only.
         if self._docHandle:
             self._qDocument.syntaxHighlighter.rehighlight()
-            self._spellCheckAll()
+            self._beginSpellPass()
             self.docHeader.setHandle(self._docHandle)
         else:
             self.clearEditor()
@@ -579,7 +594,7 @@ class GuiDocEditor(QPlainTextEdit):
         self._allowAutoReplace(False)
         self._qDocument.setTextContent(text, tHandle)
         self._allowAutoReplace(True)
-        self._spellCheckAll()
+        self._beginSpellPass()
         QApplication.processEvents()
 
         self._lastEdit = time()
@@ -848,13 +863,9 @@ class GuiDocEditor(QPlainTextEdit):
         """Spell check the entire document, and update the status of the
         currently loaded text.
         """
-        start = time()
         logger.debug("Running spell checker")
-        QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
-        self._spellCheckAll()
-        QApplication.restoreOverrideCursor()
-        logger.debug("Document spell checked in %.3f ms", 1000 * (time() - start))
-        SHARED.newStatusMessage(self.tr("Spell check complete"))
+        self._beginSpellPass()
+        self._spellPassNotify = self._spellPassNo >= 0
 
     ##
     #  General Class Methods
@@ -1379,6 +1390,30 @@ class GuiDocEditor(QPlainTextEdit):
                 data.spellCheck()
         self._dirtySpell.clear()
         self._updateSpellSelections()
+
+    @pyqtSlot()
+    def _runSpellPass(self) -> None:
+        """Process a chunk of the background document spell check. The
+        position is tracked by block number, which may drift when the
+        document is edited during the pass, but modified blocks are
+        covered by the debounced spell check anyway.
+        """
+        block = self._qDocument.findBlockByNumber(self._spellPassNo)
+        count = 0
+        while block.isValid() and count < SPELL_PASS_CHUNK:
+            if isinstance(data := block.userData(), TextBlockData):
+                data.spellCheck()
+            block = block.next()
+            count += 1
+        if block.isValid():
+            self._spellPassNo += count
+        else:
+            self._timerSpellPass.stop()
+            self._spellPassNo = -1
+            self._updateSpellSelections()
+            if self._spellPassNotify:
+                self._spellPassNotify = False
+                SHARED.newStatusMessage(self.tr("Spell check complete"))
 
     @pyqtSlot(int, int, str)
     def _insertCompletion(self, pos: int, length: int, text: str) -> None:
@@ -2528,18 +2563,27 @@ class GuiDocEditor(QPlainTextEdit):
         selections.extend(self._spellSelections)
         self.setExtraSelections(selections)
 
-    def _spellCheckAll(self) -> None:
-        """Spell check all text blocks and update the underlines. If
-        spell checking is disabled, only the underlines are updated.
+    def _beginSpellPass(self) -> None:
+        """Spell check the visible blocks, and start a chunked check of
+        the entire document in the background. If spell checking is
+        disabled, only the underlines are updated.
         """
         self._timerSpellCheck.stop()
+        self._timerSpellPass.stop()
         self._dirtySpell.clear()
+        self._spellPassNo = -1
         if SHARED.project.data.spellCheck:
-            block = self._qDocument.begin()
-            while block.isValid():
-                if isinstance(data := block.userData(), TextBlockData):
-                    data.spellCheck()
-                block = block.next()
+            if viewport := self.viewport():  # pragma: no branch
+                # Check the visible blocks first so that their result
+                # is available immediately
+                last = self.cursorForPosition(viewport.rect().bottomLeft()).blockNumber()
+                block = self.firstVisibleBlock()
+                while block.isValid() and block.blockNumber() <= last:
+                    if isinstance(data := block.userData(), TextBlockData):
+                        data.spellCheck()
+                    block = block.next()
+            self._spellPassNo = 0
+            self._timerSpellPass.start()
         self._updateSpellSelections()
 
     def _completerToCursor(self) -> None:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -97,7 +97,7 @@ from novelwriter.enum import (
 from novelwriter.extensions.configlayout import NPathColorLabel
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton
-from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, TextBlockData
+from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, TextBlockData, spellCheckText
 from novelwriter.gui.editordocument import GuiTextDocument
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.text.counting import standardCounter
@@ -178,6 +178,8 @@ class GuiDocEditor(QPlainTextEdit):
         "_nwItem",
         "_qDocument",
         "_spellFormat",
+        "_spellJob",
+        "_spellJobId",
         "_spellPassNo",
         "_spellPassNotify",
         "_spellSelections",
@@ -186,7 +188,6 @@ class GuiDocEditor(QPlainTextEdit):
         "_timerSel",
         "_timerSpell",
         "_timerSpellCheck",
-        "_timerSpellPass",
         "_trActions",
         "_trAddWord",
         "_trCopy",
@@ -261,6 +262,8 @@ class GuiDocEditor(QPlainTextEdit):
         self._suppressed = False
         self._spellPassNo = -1
         self._spellPassNotify = False
+        self._spellJob: tuple[int, list[tuple[QTextBlock, TextBlockData, int]]] | None = None
+        self._spellJobId = 0
 
         # Context Menu Translation
         self._trSetName = self.tr("Set as Document Name")
@@ -374,14 +377,9 @@ class GuiDocEditor(QPlainTextEdit):
 
         # Set Up Spell Check Debounce
         self._timerSpellCheck = QTimer(self)
-        self._timerSpellCheck.timeout.connect(self._runSpellCheck)
+        self._timerSpellCheck.timeout.connect(self._dispatchSpellCheck)
         self._timerSpellCheck.setSingleShot(True)
         self._timerSpellCheck.setInterval(300)
-
-        # Set Up Background Spell Check Pass
-        self._timerSpellPass = QTimer(self)
-        self._timerSpellPass.timeout.connect(self._runSpellPass)
-        self._timerSpellPass.setInterval(0)
 
         # Install Event Filter for Mouse Wheel
         self.wheelEventFilter = WheelEventFilter(self)
@@ -451,8 +449,9 @@ class GuiDocEditor(QPlainTextEdit):
         self.docToolBar.setVisible(False)
         self._timerSpell.stop()
         self._timerSpellCheck.stop()
-        self._timerSpellPass.stop()
         self._spellPassNo = -1
+        self._spellPassNotify = False
+        self._spellJob = None
         self._dirtySpell.clear()
         self._spellSelections.clear()
         self.setExtraSelections([])
@@ -864,8 +863,8 @@ class GuiDocEditor(QPlainTextEdit):
         currently loaded text.
         """
         logger.debug("Running spell checker")
+        self._spellPassNotify = SHARED.project.data.spellCheck
         self._beginSpellPass()
-        self._spellPassNotify = self._spellPassNo >= 0
 
     ##
     #  General Class Methods
@@ -1383,37 +1382,61 @@ class GuiDocEditor(QPlainTextEdit):
         self._applyExtraSelections()
 
     @pyqtSlot()
-    def _runSpellCheck(self) -> None:
-        """Spell check the text blocks that have been modified."""
-        for block in self._dirtySpell.values():
-            if block.isValid() and isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
-                data.spellCheck()
-        self._dirtySpell.clear()
-        self._updateSpellSelections()
-
-    @pyqtSlot()
-    def _runSpellPass(self) -> None:
-        """Process a chunk of the background document spell check. The
-        position is tracked by block number, which may drift when the
-        document is edited during the pass, but modified blocks are
-        covered by the debounced spell check anyway.
+    def _dispatchSpellCheck(self) -> None:
+        """Send the next batch of text blocks to the spell check worker.
+        Modified blocks are prioritised, then the blocks queued for the
+        background document pass. The pass position is tracked by block
+        number, which may drift when the document is edited during the
+        pass, but modified blocks are covered by the debounce anyway.
         """
-        block = self._qDocument.findBlockByNumber(self._spellPassNo)
-        count = 0
-        while block.isValid() and count < SPELL_PASS_CHUNK:
-            if isinstance(data := block.userData(), TextBlockData):
-                data.spellCheck()
-            block = block.next()
-            count += 1
-        if block.isValid():
-            self._spellPassNo += count
-        else:
-            self._timerSpellPass.stop()
-            self._spellPassNo = -1
-            self._updateSpellSelections()
-            if self._spellPassNotify:
-                self._spellPassNotify = False
-                SHARED.newStatusMessage(self.tr("Spell check complete"))
+        if self._spellJob is not None:
+            # There is already a job running, and a new dispatch is
+            # made when its results come in
+            return
+
+        job = []
+        payload = []
+        while self._dirtySpell and len(job) < SPELL_PASS_CHUNK:
+            _, block = self._dirtySpell.popitem()
+            if block.isValid() and isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
+                payload.append((len(job), *data.spellData()))
+                job.append((block, data, data.revision))
+
+        while self._spellPassNo >= 0 and len(job) < SPELL_PASS_CHUNK:
+            block = self._qDocument.findBlockByNumber(self._spellPassNo)
+            if block.isValid():
+                if isinstance(data := block.userData(), TextBlockData):
+                    payload.append((len(job), *data.spellData()))
+                    job.append((block, data, data.revision))
+                self._spellPassNo += 1
+            else:
+                self._spellPassNo = -1
+
+        if job:
+            self._spellJobId += 1
+            self._spellJob = (self._spellJobId, job)
+            runnable = BackgroundSpellCheck(self._spellJobId, payload)
+            runnable.signals.resultsReady.connect(self._spellCheckResults)
+            SHARED.runInThreadPool(runnable)
+        elif self._spellPassNotify:
+            self._spellPassNotify = False
+            SHARED.newStatusMessage(self.tr("Spell check complete"))
+
+    @pyqtSlot(int, object)
+    def _spellCheckResults(self, jobId: int, results: list[tuple[int, list[tuple[int, int, str]]]]) -> None:
+        """Process the results from the spell check worker. Results are
+        discarded if the job was cancelled, or per block if the block
+        was modified or removed while the worker was running.
+        """
+        if self._spellJob and self._spellJob[0] == jobId:
+            job = self._spellJob[1]
+            self._spellJob = None
+            for index, errors in results:
+                block, data, revision = job[index]
+                if block.isValid() and block.userData() is data and data.revision == revision:
+                    data.setSpellErrors(errors)
+            self._timerSpell.start()
+            self._dispatchSpellCheck()
 
     @pyqtSlot(int, int, str)
     def _insertCompletion(self, pos: int, length: int, text: str) -> None:
@@ -2565,12 +2588,12 @@ class GuiDocEditor(QPlainTextEdit):
 
     def _beginSpellPass(self) -> None:
         """Spell check the visible blocks, and start a chunked check of
-        the entire document in the background. If spell checking is
+        the entire document on the worker thread. If spell checking is
         disabled, only the underlines are updated.
         """
         self._timerSpellCheck.stop()
-        self._timerSpellPass.stop()
         self._dirtySpell.clear()
+        self._spellJob = None
         self._spellPassNo = -1
         if SHARED.project.data.spellCheck:
             if viewport := self.viewport():  # pragma: no branch
@@ -2583,7 +2606,7 @@ class GuiDocEditor(QPlainTextEdit):
                         data.spellCheck()
                     block = block.next()
             self._spellPassNo = 0
-            self._timerSpellPass.start()
+            self._dispatchSpellCheck()
         self._updateSpellSelections()
 
     def _completerToCursor(self) -> None:
@@ -2964,6 +2987,37 @@ class BackgroundWordCounterSignals(QObject):
     """
 
     countsReady = pyqtSignal(int, int, int)
+
+
+class BackgroundSpellCheck(QRunnable):
+    """The Off-GUI Thread Spell Checker.
+
+    A runnable that spell checks a batch of text block snapshots in the
+    thread pool off the main GUI thread. It only receives plain text
+    snapshots, and never touches the text document itself.
+    """
+
+    def __init__(self, jobId: int, payload: list[tuple[int, str, int, list[int] | None]]) -> None:
+        super().__init__()
+        self._jobId = jobId
+        self._payload = payload
+        self.signals = BackgroundSpellCheckSignals()
+
+    @pyqtSlot()
+    def run(self) -> None:
+        """Spell check the text snapshots and emit the results."""
+        self.signals.resultsReady.emit(
+            self._jobId,
+            [(index, spellCheckText(text, offset, utf16Map)) for index, text, offset, utf16Map in self._payload],
+        )
+
+
+class BackgroundSpellCheckSignals(QObject):
+    """The QRunnable cannot emit a signal, so we need a simple QObject
+    to hold the spell check result signal.
+    """
+
+    resultsReady = pyqtSignal(int, object)
 
 
 class TextAutoReplace:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1386,7 +1386,7 @@ class GuiDocEditor(QPlainTextEdit):
     def _runSpellCheck(self) -> None:
         """Spell check the text blocks that have been modified."""
         for block in self._dirtySpell.values():
-            if block.isValid() and isinstance(data := block.userData(), TextBlockData):
+            if block.isValid() and isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
                 data.spellCheck()
         self._dirtySpell.clear()
         self._updateSpellSelections()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1367,13 +1367,14 @@ class GuiDocEditor(QPlainTextEdit):
 
         # Spell Checking
         if SHARED.project.data.spellCheck:
-            word, offset, suggest = self._qDocument.spellErrorAtPos(pCursor.position())
-            if word and offset >= 0:
+            word, sPos, ePos, suggest = self._qDocument.spellErrorAtPos(pCursor.position())
+            if word and sPos >= 0:
                 logger.debug("Word '%s' is misspelled", word)
                 block = pCursor.block()
+                bPos = block.position()
                 sCursor = self.textCursor()
-                sCursor.setPosition(block.position() + offset)
-                sCursor.movePosition(QtMoveRight, QtKeepAnchor, len(word))
+                sCursor.setPosition(bPos + sPos)
+                sCursor.setPosition(bPos + ePos, QtKeepAnchor)
                 if suggest:
                     ctxMenu.addSeparator()
                     qtAddAction(ctxMenu, self._trSpellSuggest)

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -57,6 +57,7 @@ from PyQt6.QtGui import (
     QResizeEvent,
     QShortcut,
     QTextBlock,
+    QTextCharFormat,
     QTextCursor,
     QTextDocument,
     QTextFormat,
@@ -96,7 +97,7 @@ from novelwriter.enum import (
 from novelwriter.extensions.configlayout import NPathColorLabel
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton
-from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE
+from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, TextBlockData
 from novelwriter.gui.editordocument import GuiTextDocument
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.text.counting import standardCounter
@@ -172,8 +173,11 @@ class GuiDocEditor(QPlainTextEdit):
         "_nwDocument",
         "_nwItem",
         "_qDocument",
+        "_spellFormat",
+        "_spellSelections",
         "_timerDoc",
         "_timerSel",
+        "_timerSpell",
         "_trActions",
         "_trAddWord",
         "_trCopy",
@@ -242,6 +246,8 @@ class GuiDocEditor(QPlainTextEdit):
         self._doReplace = False  # Switch to temporarily disable auto-replace
         self._lineColor = QtTransparent
         self._selection = QTextEdit.ExtraSelection()
+        self._spellFormat = QTextCharFormat()
+        self._spellSelections: list[QTextEdit.ExtraSelection] = []
 
         # Context Menu Translation
         self._trSetName = self.tr("Set as Document Name")
@@ -345,6 +351,15 @@ class GuiDocEditor(QPlainTextEdit):
         self._wCounterSel.setAutoDelete(False)
         self._wCounterSel.signals.countsReady.connect(self._updateSelCounts)
 
+        # Set Up Spell Underline Refresh
+        self._timerSpell = QTimer(self)
+        self._timerSpell.timeout.connect(self._updateSpellSelections)
+        self._timerSpell.setSingleShot(True)
+        self._timerSpell.setInterval(0)
+
+        if vBar := self.verticalScrollBar():  # pragma: no branch
+            vBar.valueChanged.connect(qtLambda(self._timerSpell.start))
+
         # Install Event Filter for Mouse Wheel
         self.wheelEventFilter = WheelEventFilter(self)
         self.installEventFilter(self.wheelEventFilter)
@@ -411,6 +426,8 @@ class GuiDocEditor(QPlainTextEdit):
         self.docHeader.clearHeader()
         self.docFooter.setHandle(self._docHandle)
         self.docToolBar.setVisible(False)
+        self._timerSpell.stop()
+        self._spellSelections.clear()
         self.setExtraSelections([])
 
         self.itemHandleChanged.emit("")
@@ -446,6 +463,10 @@ class GuiDocEditor(QPlainTextEdit):
         self._lineColor = syntax.line
         self._selection.format.setBackground(self._lineColor)
         self._selection.format.setProperty(QTextFormat.Property.FullWidthSelection, True)
+
+        self._spellFormat = QTextCharFormat()
+        self._spellFormat.setUnderlineColor(syntax.spell)
+        self._spellFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)
 
     def initEditor(self) -> None:
         """Initialise or re-initialise the editor with the user's
@@ -502,6 +523,7 @@ class GuiDocEditor(QPlainTextEdit):
         # Refresh sizes
         self.setTabStopDistance(CONFIG.tabWidth)
         self.setCursorWidth(CONFIG.cursorWidth)
+        self._spellSelections.clear()
         self.setExtraSelections([])
         self._cursorMoved()
 
@@ -816,6 +838,7 @@ class GuiDocEditor(QPlainTextEdit):
         logger.debug("Running spell checker")
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         self._qDocument.syntaxHighlighter.rehighlight()
+        self._updateSpellSelections()
         QApplication.restoreOverrideCursor()
         logger.debug("Document highlighted in %.3f ms", 1000 * (time() - start))
         SHARED.newStatusMessage(self.tr("Spell check complete"))
@@ -1163,6 +1186,7 @@ class GuiDocEditor(QPlainTextEdit):
         has its margins adjusted according to user preferences.
         """
         self.updateDocMargins()
+        self._timerSpell.start()
         super().resizeEvent(event)
 
     def inputMethodEvent(self, event: QInputMethodEvent) -> None:
@@ -1260,6 +1284,8 @@ class GuiDocEditor(QPlainTextEdit):
         if not self._timerDoc.isActive():
             self._timerDoc.start()
 
+        self._timerSpell.start()
+
         if (block := self._qDocument.findBlock(pos)).isValid():
             text = block.text()
 
@@ -1289,7 +1315,29 @@ class GuiDocEditor(QPlainTextEdit):
         if CONFIG.lineHighlight:
             self._selection.cursor = self.textCursor()
             self._selection.cursor.clearSelection()
-            self.setExtraSelections([self._selection])
+            self._applyExtraSelections()
+
+    @pyqtSlot()
+    def _updateSpellSelections(self) -> None:
+        """Rebuild the spell error underlines for all visible blocks."""
+        selections = []
+        if SHARED.project.data.spellCheck and (viewport := self.viewport()):
+            last = self.cursorForPosition(viewport.rect().bottomLeft()).blockNumber()
+            block = self.firstVisibleBlock()
+            while block.isValid() and block.blockNumber() <= last:
+                if isinstance(data := block.userData(), TextBlockData):
+                    position = block.position()
+                    for start, end, _ in data.spellErrors:
+                        cursor = QTextCursor(self._qDocument)
+                        cursor.setPosition(position + start)
+                        cursor.setPosition(position + end, QtKeepAnchor)
+                        selection = QTextEdit.ExtraSelection()
+                        selection.format = self._spellFormat
+                        selection.cursor = cursor
+                        selections.append(selection)
+                block = block.next()
+        self._spellSelections = selections
+        self._applyExtraSelections()
 
     @pyqtSlot(int, int, str)
     def _insertCompletion(self, pos: int, length: int, text: str) -> None:
@@ -2428,6 +2476,16 @@ class GuiDocEditor(QPlainTextEdit):
     ##
     #  Internal Functions
     ##
+
+    def _applyExtraSelections(self) -> None:
+        """Set the editor's extra selections from the line highlight
+        and the cached spell error underlines.
+        """
+        selections = []
+        if CONFIG.lineHighlight:
+            selections.append(self._selection)
+        selections.extend(self._spellSelections)
+        self.setExtraSelections(selections)
 
     def _completerToCursor(self) -> None:
         """Make sure the completer menu is positioned by the cursor."""

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -97,7 +97,8 @@ from novelwriter.enum import (
 from novelwriter.extensions.configlayout import NPathColorLabel
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton
-from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, TextBlockData, spellCheckText
+from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, TextBlockData
+from novelwriter.gui.doctextblock import spellCheckText
 from novelwriter.gui.editordocument import GuiTextDocument
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.text.counting import standardCounter

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -461,9 +461,9 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             data = TextBlockData()
             self.setCurrentBlockUserData(data)
 
-        data.processText(text, offset)
+        data.processText(text, offset, utf16Map)
         if self._spellCheck:
-            for pos, end, _ in data.spellCheck(utf16Map):
+            for pos, end, _ in data.spellCheck():
                 for x in range(pos, end):
                     cFmt = self.format(x)
                     cFmt.merge(self._spellErr)
@@ -519,15 +519,17 @@ class TextBlockData(QTextBlockUserData):
     """Custom QTextBlock Data.
 
     Custom data stored in a single text block. The spell check state is
-    cached here and used when correcting misspelled text.
+    cached here and used when correcting misspelled text. All cached
+    positions are in UTF-16 units, matching Qt document positions.
     """
 
-    __slots__ = ("_metaData", "_offset", "_spellErrors", "_text")
+    __slots__ = ("_metaData", "_offset", "_spellErrors", "_text", "_utf16Map")
 
     def __init__(self) -> None:
         super().__init__()
         self._text = ""
         self._offset = 0
+        self._utf16Map: list[int] | None = None
         self._metaData: list[tuple[int, int, str, str]] = []
         self._spellErrors: list[tuple[int, int, str]] = []
 
@@ -541,8 +543,10 @@ class TextBlockData(QTextBlockUserData):
         """Return spell error data from last check."""
         return self._spellErrors
 
-    def processText(self, text: str, offset: int) -> None:
-        """Extract meta data from the text."""
+    def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
+        """Extract meta data from the text. The map, when set, converts
+        cached positions to UTF-16 units.
+        """
         self._metaData = []
         if "[" in text:
             # Strip shortcodes
@@ -558,17 +562,21 @@ class TextBlockData(QTextBlockUserData):
                 if (s := res.start(0)) >= 0 and (e := res.end(0)) >= 0:  # pragma: no branch
                     pad = " " * (e - s)
                     text = f"{text[:s]}{pad}{text[e:]}"
+                    if utf16Map:
+                        s = utf16Map[s]
+                        e = utf16Map[e]
                     self._metaData.append((s, e, res.group(0), "url"))
 
         self._text = text.replace("\u02bc", "'").replace("_", " ")
         self._offset = offset
+        self._utf16Map = utf16Map
 
-    def spellCheck(self, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
+    def spellCheck(self) -> list[tuple[int, int, str]]:
         """Run the spell checker and cache the result, and return the
         list of spell check errors.
         """
         spell = SHARED.spelling
-        if utf16Map:
+        if utf16Map := self._utf16Map:
             self._spellErrors = [
                 (utf16Map[r.start(0)], utf16Map[r.end(0)], w)
                 for r in RX_WORDS.finditer(self._text, self._offset)

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -60,7 +60,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         "_isInactive",
         "_isNovel",
         "_minRules",
-        "_spellCheck",
         "_tHandle",
         "_txtRules",
     )
@@ -73,7 +72,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._tHandle = None
         self._isNovel = False
         self._isInactive = False
-        self._spellCheck = False
 
         self._hStyles: dict[str, QTextCharFormat] = {}
         self._minRules: list[tuple[re.Pattern, dict[int, QTextCharFormat]]] = []
@@ -257,10 +255,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
     #  Setters
     ##
 
-    def setSpellCheck(self, state: bool) -> None:
-        """Enable/disable the real time spell checker."""
-        self._spellCheck = state
-
     def setHandle(self, tHandle: str) -> None:
         """Set the handle of the currently highlighted document."""
         self._tHandle = tHandle
@@ -300,6 +294,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         """
         self.setCurrentBlockState(BLOCK_NONE)
         if self._tHandle is None or not text:
+            self._clearBlockData()
             return
 
         blockLen = self.currentBlock().length()
@@ -335,7 +330,8 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                         self.setFormat(pos, length, self._hStyles["invalid"])
 
             # We never want to run the spell checker on keyword/values,
-            # so we force a return here
+            # so we clear the cached data and force a return here
+            self._clearBlockData()
             return
 
         elif text.startswith(("# ", "#! ", "## ", "##! ", "### ", "###! ", "#### ")):
@@ -386,6 +382,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 self.setFormat(0, length, self._hStyles["hidden"])
             elif style == nwComment.IGNORE:
                 self.setFormat(0, length, self._hStyles["strike"])
+                self._clearBlockData()
                 return  # No more processing for these
             elif mod:
                 self.setFormat(0, dot, self._hStyles["modifier"])
@@ -402,6 +399,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             check = text.rstrip().lower()
             if check in ("[newpage]", "[new page]", "[vspace]"):
                 self.setFormat(0, blockLen, self._hStyles["code"])
+                self._clearBlockData()
                 return
             elif check.startswith("[vspace:") and check.endswith("]"):
                 value = checkInt(check[8:-1], 0)
@@ -409,6 +407,7 @@ class GuiDocHighlighter(QSyntaxHighlighter):
                 self.setFormat(0, 8, self._hStyles["code"])
                 self.setFormat(8, blockLen - 10, self._hStyles[style])
                 self.setFormat(blockLen - 2, blockLen, self._hStyles["code"])
+                self._clearBlockData()
                 return
 
         else:  # Text Paragraph
@@ -455,15 +454,17 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             self.setCurrentBlockUserData(data)
 
         data.processText(text, offset, utf16Map)
-        if self._spellCheck:
-            # The result is cached and rendered by the editor
-            data.spellCheck()
 
         return
 
     ##
     #  Internal Functions
     ##
+
+    def _clearBlockData(self) -> None:
+        """Clear the cached user data of the current block."""
+        if isinstance(data := self.currentBlockUserData(), TextBlockData):
+            data.clear()
 
     def _addCharFormat(
         self,
@@ -532,6 +533,14 @@ class TextBlockData(QTextBlockUserData):
     def spellErrors(self) -> list[tuple[int, int, str]]:
         """Return spell error data from last check."""
         return self._spellErrors
+
+    def clear(self) -> None:
+        """Clear all cached data."""
+        self._text = ""
+        self._offset = 0
+        self._utf16Map = None
+        self._metaData = []
+        self._spellErrors = []
 
     def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
         """Extract meta data from the text. The map, when set, converts

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -27,22 +27,19 @@ import re
 from time import time
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QBrush, QColor, QSyntaxHighlighter, QTextBlockUserData, QTextCharFormat, QTextDocument
+from PyQt6.QtGui import QBrush, QColor, QSyntaxHighlighter, QTextCharFormat, QTextDocument
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import checkInt, utf16CharMap
 from novelwriter.constants import nwStyles, nwUnicode
 from novelwriter.enum import nwComment
+from novelwriter.gui.doctextblock import TextBlockData
 from novelwriter.text.formats import processComment
 from novelwriter.text.patterns import REGEX_PATTERNS, DialogParser
 from novelwriter.types import QtFontBold, QtTextUserProperty
 
 logger = logging.getLogger(__name__)
 
-RX_URL = REGEX_PATTERNS.url
-RX_WORDS = REGEX_PATTERNS.wordSplit
-RX_FMT_SC = REGEX_PATTERNS.shortcodePlain
-RX_FMT_SV = REGEX_PATTERNS.shortcodeValue
 
 BLOCK_NONE = 0
 BLOCK_TEXT = 1
@@ -504,110 +501,3 @@ class GuiDocHighlighter(QSyntaxHighlighter):
             charFormat.setFontPointSize(round(size * CONFIG.textFont.pointSize()))
 
         self._hStyles[name] = charFormat
-
-
-class TextBlockData(QTextBlockUserData):
-    """Custom QTextBlock Data.
-
-    Custom data stored in a single text block. The spell check state is
-    cached here and used when correcting misspelled text. All cached
-    positions are in UTF-16 units, matching Qt document positions.
-    """
-
-    __slots__ = ("_metaData", "_offset", "_revision", "_spellErrors", "_text", "_utf16Map")
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._text = ""
-        self._offset = 0
-        self._revision = 0
-        self._utf16Map: list[int] | None = None
-        self._metaData: list[tuple[int, int, str, str]] = []
-        self._spellErrors: list[tuple[int, int, str]] = []
-
-    @property
-    def metaData(self) -> list[tuple[int, int, str, str]]:
-        """Return meta data from last check."""
-        return self._metaData
-
-    @property
-    def spellErrors(self) -> list[tuple[int, int, str]]:
-        """Return spell error data from last check."""
-        return self._spellErrors
-
-    @property
-    def revision(self) -> int:
-        """Return the revision number of the cached text."""
-        return self._revision
-
-    def clear(self) -> None:
-        """Clear all cached data."""
-        self._text = ""
-        self._offset = 0
-        self._revision += 1
-        self._utf16Map = None
-        self._metaData = []
-        self._spellErrors = []
-
-    def spellData(self) -> tuple[str, int, list[int] | None]:
-        """Return a snapshot of the text for external spell checking."""
-        return self._text, self._offset, self._utf16Map
-
-    def setSpellErrors(self, errors: list[tuple[int, int, str]]) -> None:
-        """Store spell error data computed from a text snapshot."""
-        self._spellErrors = errors
-
-    def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
-        """Extract meta data from the text. The map, when set, converts
-        cached positions to UTF-16 units.
-        """
-        self._metaData = []
-        if "[" in text:
-            # Strip shortcodes
-            for regEx in [RX_FMT_SC, RX_FMT_SV]:
-                for res in regEx.finditer(text, offset):
-                    if (s := res.start(0)) >= 0 and (e := res.end(0)) >= 0:  # pragma: no branch
-                        pad = " " * (e - s)
-                        text = f"{text[:s]}{pad}{text[e:]}"
-
-        if "http" in text:
-            # Strip URLs
-            for res in RX_URL.finditer(text, offset):
-                if (s := res.start(0)) >= 0 and (e := res.end(0)) >= 0:  # pragma: no branch
-                    pad = " " * (e - s)
-                    text = f"{text[:s]}{pad}{text[e:]}"
-                    if utf16Map:
-                        s = utf16Map[s]
-                        e = utf16Map[e]
-                    self._metaData.append((s, e, res.group(0), "url"))
-
-        self._text = text.replace("\u02bc", "'").replace("_", " ")
-        self._offset = offset
-        self._revision += 1
-        self._utf16Map = utf16Map
-
-    def spellCheck(self) -> list[tuple[int, int, str]]:
-        """Run the spell checker and cache the result, and return the
-        list of spell check errors.
-        """
-        self._spellErrors = spellCheckText(self._text, self._offset, self._utf16Map)
-        return self._spellErrors
-
-
-def spellCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
-    """Spell check a piece of text and return the list of errors. This
-    function does not touch any Qt document classes, so it is safe to
-    call from a worker thread.
-    """
-    spell = SHARED.spelling
-    if utf16Map:
-        return [
-            (utf16Map[r.start(0)], utf16Map[r.end(0)], w)
-            for r in RX_WORDS.finditer(text, offset)
-            if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
-        ]
-    return [
-        (r.start(0), r.end(0), w)
-        for r in RX_WORDS.finditer(text, offset)
-        if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
-    ]

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -514,12 +514,13 @@ class TextBlockData(QTextBlockUserData):
     positions are in UTF-16 units, matching Qt document positions.
     """
 
-    __slots__ = ("_metaData", "_offset", "_spellErrors", "_text", "_utf16Map")
+    __slots__ = ("_metaData", "_offset", "_revision", "_spellErrors", "_text", "_utf16Map")
 
     def __init__(self) -> None:
         super().__init__()
         self._text = ""
         self._offset = 0
+        self._revision = 0
         self._utf16Map: list[int] | None = None
         self._metaData: list[tuple[int, int, str, str]] = []
         self._spellErrors: list[tuple[int, int, str]] = []
@@ -534,13 +535,27 @@ class TextBlockData(QTextBlockUserData):
         """Return spell error data from last check."""
         return self._spellErrors
 
+    @property
+    def revision(self) -> int:
+        """Return the revision number of the cached text."""
+        return self._revision
+
     def clear(self) -> None:
         """Clear all cached data."""
         self._text = ""
         self._offset = 0
+        self._revision += 1
         self._utf16Map = None
         self._metaData = []
         self._spellErrors = []
+
+    def spellData(self) -> tuple[str, int, list[int] | None]:
+        """Return a snapshot of the text for external spell checking."""
+        return self._text, self._offset, self._utf16Map
+
+    def setSpellErrors(self, errors: list[tuple[int, int, str]]) -> None:
+        """Store spell error data computed from a text snapshot."""
+        self._spellErrors = errors
 
     def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
         """Extract meta data from the text. The map, when set, converts
@@ -568,23 +583,31 @@ class TextBlockData(QTextBlockUserData):
 
         self._text = text.replace("\u02bc", "'").replace("_", " ")
         self._offset = offset
+        self._revision += 1
         self._utf16Map = utf16Map
 
     def spellCheck(self) -> list[tuple[int, int, str]]:
         """Run the spell checker and cache the result, and return the
         list of spell check errors.
         """
-        spell = SHARED.spelling
-        if utf16Map := self._utf16Map:
-            self._spellErrors = [
-                (utf16Map[r.start(0)], utf16Map[r.end(0)], w)
-                for r in RX_WORDS.finditer(self._text, self._offset)
-                if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
-            ]
-        else:
-            self._spellErrors = [
-                (r.start(0), r.end(0), w)
-                for r in RX_WORDS.finditer(self._text, self._offset)
-                if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
-            ]
+        self._spellErrors = spellCheckText(self._text, self._offset, self._utf16Map)
         return self._spellErrors
+
+
+def spellCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
+    """Spell check a piece of text and return the list of errors. This
+    function does not touch any Qt document classes, so it is safe to
+    call from a worker thread.
+    """
+    spell = SHARED.spelling
+    if utf16Map:
+        return [
+            (utf16Map[r.start(0)], utf16Map[r.end(0)], w)
+            for r in RX_WORDS.finditer(text, offset)
+            if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
+        ]
+    return [
+        (r.start(0), r.end(0), w)
+        for r in RX_WORDS.finditer(text, offset)
+        if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
+    ]

--- a/novelwriter/gui/dochighlight.py
+++ b/novelwriter/gui/dochighlight.py
@@ -61,7 +61,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         "_isNovel",
         "_minRules",
         "_spellCheck",
-        "_spellErr",
         "_tHandle",
         "_txtRules",
     )
@@ -75,7 +74,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._isNovel = False
         self._isInactive = False
         self._spellCheck = False
-        self._spellErr = QTextCharFormat()
 
         self._hStyles: dict[str, QTextCharFormat] = {}
         self._minRules: list[tuple[re.Pattern, dict[int, QTextCharFormat]]] = []
@@ -133,11 +131,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._addCharFormat("value", syntax.val, fmtCodes)
         self._addCharFormat("optional", syntax.opt)
         self._addCharFormat("invalid", None, "err")
-
-        # Cache Spell Error Format
-        self._spellErr = QTextCharFormat()
-        self._spellErr.setUnderlineColor(syntax.spell)
-        self._spellErr.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)
 
         self._txtRules.clear()
         self._cmnRules.clear()
@@ -463,11 +456,8 @@ class GuiDocHighlighter(QSyntaxHighlighter):
 
         data.processText(text, offset, utf16Map)
         if self._spellCheck:
-            for pos, end, _ in data.spellCheck():
-                for x in range(pos, end):
-                    cFmt = self.format(x)
-                    cFmt.merge(self._spellErr)
-                    self.setFormat(x, 1, cFmt)
+            # The result is cached and rendered by the editor
+            data.spellCheck()
 
         return
 

--- a/novelwriter/gui/doctextblock.py
+++ b/novelwriter/gui/doctextblock.py
@@ -1,0 +1,137 @@
+"""
+novelWriter – GUI Text Block Data
+=================================
+
+This file is a part of novelWriter
+Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""  # noqa
+
+from PyQt6.QtGui import QTextBlockUserData
+
+from novelwriter import SHARED
+from novelwriter.text.patterns import REGEX_PATTERNS
+
+RX_URL = REGEX_PATTERNS.url
+RX_WORDS = REGEX_PATTERNS.wordSplit
+RX_FMT_SC = REGEX_PATTERNS.shortcodePlain
+RX_FMT_SV = REGEX_PATTERNS.shortcodeValue
+
+
+class TextBlockData(QTextBlockUserData):
+    """Custom QTextBlock Data.
+
+    Custom data stored in a single text block. The spell check state is
+    cached here and used when correcting misspelled text. All cached
+    positions are in UTF-16 units, matching Qt document positions.
+    """
+
+    __slots__ = ("_metaData", "_offset", "_revision", "_spellErrors", "_text", "_utf16Map")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._text = ""
+        self._offset = 0
+        self._revision = 0
+        self._utf16Map: list[int] | None = None
+        self._metaData: list[tuple[int, int, str, str]] = []
+        self._spellErrors: list[tuple[int, int, str]] = []
+
+    @property
+    def metaData(self) -> list[tuple[int, int, str, str]]:
+        """Return meta data from last check."""
+        return self._metaData
+
+    @property
+    def spellErrors(self) -> list[tuple[int, int, str]]:
+        """Return spell error data from last check."""
+        return self._spellErrors
+
+    @property
+    def revision(self) -> int:
+        """Return the revision number of the cached text."""
+        return self._revision
+
+    def clear(self) -> None:
+        """Clear all cached data."""
+        self._text = ""
+        self._offset = 0
+        self._revision += 1
+        self._utf16Map = None
+        self._metaData = []
+        self._spellErrors = []
+
+    def spellData(self) -> tuple[str, int, list[int] | None]:
+        """Return a snapshot of the text for external spell checking."""
+        return self._text, self._offset, self._utf16Map
+
+    def setSpellErrors(self, errors: list[tuple[int, int, str]]) -> None:
+        """Store spell error data computed from a text snapshot."""
+        self._spellErrors = errors
+
+    def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
+        """Extract meta data from the text. The map, when set, converts
+        cached positions to UTF-16 units.
+        """
+        self._metaData = []
+        if "[" in text:
+            # Strip shortcodes
+            for regEx in [RX_FMT_SC, RX_FMT_SV]:
+                for res in regEx.finditer(text, offset):
+                    if (s := res.start(0)) >= 0 and (e := res.end(0)) >= 0:  # pragma: no branch
+                        pad = " " * (e - s)
+                        text = f"{text[:s]}{pad}{text[e:]}"
+
+        if "http" in text:
+            # Strip URLs
+            for res in RX_URL.finditer(text, offset):
+                if (s := res.start(0)) >= 0 and (e := res.end(0)) >= 0:  # pragma: no branch
+                    pad = " " * (e - s)
+                    text = f"{text[:s]}{pad}{text[e:]}"
+                    if utf16Map:
+                        s = utf16Map[s]
+                        e = utf16Map[e]
+                    self._metaData.append((s, e, res.group(0), "url"))
+
+        self._text = text.replace("\u02bc", "'").replace("_", " ")
+        self._offset = offset
+        self._revision += 1
+        self._utf16Map = utf16Map
+
+    def spellCheck(self) -> list[tuple[int, int, str]]:
+        """Run the spell checker and cache the result, and return the
+        list of spell check errors.
+        """
+        self._spellErrors = spellCheckText(self._text, self._offset, self._utf16Map)
+        return self._spellErrors
+
+
+def spellCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
+    """Spell check a piece of text and return the list of errors. This
+    function does not touch any Qt document classes, so it is safe to
+    call from a worker thread.
+    """
+    spell = SHARED.spelling
+    if utf16Map:
+        return [
+            (utf16Map[r.start(0)], utf16Map[r.end(0)], w)
+            for r in RX_WORDS.finditer(text, offset)
+            if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
+        ]
+    return [
+        (r.start(0), r.end(0), w)
+        for r in RX_WORDS.finditer(text, offset)
+        if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
+    ]

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -30,7 +30,8 @@ from PyQt6.QtGui import QTextBlock, QTextCursor, QTextDocument
 from PyQt6.QtWidgets import QApplication, QPlainTextDocumentLayout
 
 from novelwriter import SHARED
-from novelwriter.gui.dochighlight import GuiDocHighlighter, TextBlockData
+from novelwriter.gui.dochighlight import GuiDocHighlighter
+from novelwriter.gui.doctextblock import TextBlockData
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -111,9 +111,10 @@ class GuiTextDocument(QTextDocument):
                     return cData, cType
         return "", ""
 
-    def spellErrorAtPos(self, pos: int) -> tuple[str, int, list[str]]:
+    def spellErrorAtPos(self, pos: int) -> tuple[str, int, int, list[str]]:
         """Check if there is a misspelled word at a given position in
-        the document, and if so, return it.
+        the document, and if so, return it with its start and end
+        positions within the block.
         """
         cursor = QTextCursor(self)
         cursor.setPosition(pos)
@@ -122,8 +123,8 @@ class GuiTextDocument(QTextDocument):
         if block.isValid() and isinstance(data, TextBlockData) and (check := pos - block.position()) >= 0:
             for start, end, word in data.spellErrors:
                 if start <= check <= end:
-                    return word, start, SHARED.spelling.suggestWords(word)
-        return "", -1, []
+                    return word, start, end, SHARED.spelling.suggestWords(word)
+        return "", -1, -1, []
 
     def iterBlockByType(self, cType: int, maxCount: int = 1000) -> Iterable[QTextBlock]:
         """Iterate over all text blocks of a given type."""

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -26,7 +26,6 @@ import logging
 from time import time
 from typing import TYPE_CHECKING
 
-from PyQt6.QtCore import QObject, pyqtSlot
 from PyQt6.QtGui import QTextBlock, QTextCursor, QTextDocument
 from PyQt6.QtWidgets import QApplication, QPlainTextDocumentLayout
 
@@ -35,6 +34,8 @@ from novelwriter.gui.dochighlight import GuiDocHighlighter, TextBlockData
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from PyQt6.QtCore import QObject
 
 logger = logging.getLogger(__name__)
 
@@ -135,12 +136,3 @@ class GuiTextDocument(QTextDocument):
                 count += 1
                 yield block
         return
-
-    ##
-    #  Public Slots
-    ##
-
-    @pyqtSlot(bool)
-    def setSpellCheckState(self, state: bool) -> None:
-        """Set the spell check state of the syntax highlighter."""
-        self._syntax.setSpellCheck(state)

--- a/tests/test_dialogs/test_preferences.py
+++ b/tests/test_dialogs/test_preferences.py
@@ -30,6 +30,7 @@ from PyQt6.QtWidgets import QFileDialog
 from novelwriter import CONFIG, SHARED
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_TREECOL
 from novelwriter.constants import nwUnicode
+from novelwriter.core.spellcheck import NWSpellEnchant
 from novelwriter.dialogs.preferences import GuiPreferences
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 from novelwriter.extensions.modified import NFontDialog
@@ -42,7 +43,7 @@ KEY_DELAY = 1
 @pytest.mark.gui
 def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     """Test the preferences dialog loading."""
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "English [en]")])
+    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
     monkeypatch.setattr(GuiPreferences, "exec", lambda *a: None)
 
     # Load GUI with standard values
@@ -89,7 +90,7 @@ def testDlgPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
 @pytest.mark.gui
 def testDlgPreferences_Actions(qtbot, monkeypatch, nwGUI):
     """Test the preferences dialog actions."""
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: [("en", "English [en]")])
+    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
     prefs = GuiPreferences(nwGUI)
     with qtbot.waitExposed(prefs):
         prefs.show()
@@ -147,7 +148,7 @@ def testDlgPreferences_Actions(qtbot, monkeypatch, nwGUI):
 def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     """Test the preferences dialog settings."""
     spelling = [("en", "English [en]"), ("de", "Deutch [de]")]
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda: spelling)
+    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: spelling)
 
     (fncPath / "nw_en_US.qm").touch()
     (fncPath / "project_en_US.json").touch()

--- a/tests/test_dialogs/test_projectsettings.py
+++ b/tests/test_dialogs/test_projectsettings.py
@@ -27,6 +27,7 @@ from PyQt6.QtGui import QAction, QColor
 from PyQt6.QtWidgets import QColorDialog, QFileDialog, QToolButton
 
 from novelwriter import CONFIG, SHARED
+from novelwriter.core.spellcheck import NWSpellEnchant
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
 from novelwriter.enum import nwItemType, nwStatusShape
@@ -94,7 +95,7 @@ def testDlgProjSettings_Dialog(qtbot, monkeypatch, nwGUI):
 def testDlgProjSettings_SettingsPage(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
     """Test the settings page of the dialog."""
     languages = [("en", "English"), ("de", "German")]
-    monkeypatch.setattr(SHARED._spelling, "listDictionaries", lambda *a: languages)
+    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: languages)
 
     (fncPath / "nw_en.qm").touch()
     (fncPath / "nw_de.qm").touch()

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -610,8 +610,10 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     buildTestProject(nwGUI, projPath)
 
     # The test must not depend on which dictionaries are available on
-    # the host system, so all words are accepted from the start
+    # the host system, so all words are accepted from the start, and
+    # the spell check worker must run synchronously
     monkeypatch.setattr(SHARED.spelling, "checkWord", lambda *a: True)
+    monkeypatch.setattr(SHARED, "runInThreadPool", lambda r: r.run())
 
     assert nwGUI.openDocument(C.hSceneDoc) is True
     docEditor = nwGUI.docEditor
@@ -761,9 +763,10 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     assert docEditor._dirtySpell != {}
     assert docEditor._timerSpellCheck.isActive()
 
-    # Running the check consumes the dirty blocks
-    docEditor._runSpellCheck()
+    # Running the check dispatches the dirty blocks to the worker
+    docEditor._dispatchSpellCheck()
     assert docEditor._dirtySpell == {}
+    assert docEditor._spellJob is None
 
     # An error under the caret is not underlined
     data = docEditor.textCursor().block().userData()
@@ -785,27 +788,30 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.gui.doceditor.SPELL_PASS_CHUNK", 2)
 
-        # The pass starts with the visible blocks checked
+        # A full pass runs chunked worker jobs until the document is
+        # done, which with a synchronous worker completes immediately
         docEditor._beginSpellPass()
-        assert docEditor._spellPassNo == 0
-        assert docEditor._timerSpellPass.isActive()
+        assert docEditor._spellPassNo == -1
+        assert docEditor._spellJob is None
 
-        # The first chunk should leave the pass incomplete
-        docEditor._runSpellPass()
-        assert docEditor._spellPassNo == 2
-        assert docEditor._timerSpellPass.isActive()
-
-        # Running the remaining chunks should end the pass
-        while docEditor._spellPassNo >= 0:
-            docEditor._runSpellPass()
-        assert not docEditor._timerSpellPass.isActive()
-
-        # A full spell check requests a notification when it ends
+        # A full spell check notifies when the pass completes
         docEditor.spellCheckDocument()
-        assert docEditor._spellPassNotify is True
-        while docEditor._spellPassNo >= 0:
-            docEditor._runSpellPass()
         assert docEditor._spellPassNotify is False
+
+    # Results from a cancelled job are dropped
+    docEditor._spellCheckResults(docEditor._spellJobId + 1, [])
+    assert docEditor._spellJob is None
+
+    # Results for blocks modified while checking are discarded
+    block = docEditor.textCursor().block()
+    data = block.userData()
+    assert isinstance(data, TextBlockData)
+    data._spellErrors = []
+    docEditor._spellJobId += 1
+    docEditor._spellJob = (docEditor._spellJobId, [(block, data, data.revision - 1)])
+    docEditor._spellCheckResults(docEditor._spellJobId, [(0, [(0, 5, "wrong")])])
+    assert data.spellErrors == []
+    assert docEditor._spellJob is None
 
     # qtbot.stop()
 

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -651,17 +651,17 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     data._spellErrors = [(0, 5, "Lorem")]
 
     # No known position
-    assert docEditor._qDocument.spellErrorAtPos(-1) == ("", -1, [])
+    assert docEditor._qDocument.spellErrorAtPos(-1) == ("", -1, -1, [])
 
     # Multiple entries: the first doesn't match, the second does
     blockPos = cursor.block().position()
     data._spellErrors = [(0, 5, "Lorem"), (6, 11, "ipsum")]
     with monkeypatch.context() as mp:
         mp.setattr(SHARED.spelling, "suggestWords", lambda *a: [])
-        assert docEditor._qDocument.spellErrorAtPos(blockPos + 8) == ("ipsum", 6, [])
+        assert docEditor._qDocument.spellErrorAtPos(blockPos + 8) == ("ipsum", 6, 11, [])
 
     # No entry matches the given position
-    assert docEditor._qDocument.spellErrorAtPos(blockPos + 20) == ("", -1, [])
+    assert docEditor._qDocument.spellErrorAtPos(blockPos + 20) == ("", -1, -1, [])
 
     # Meta data lookup follows the same pattern
     data._metaData = [(0, 5, "Lorem", "url"), (6, 11, "ipsum", "url")]

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -49,10 +49,11 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import decodeMimeHandles
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.core.item import NWItem
+from novelwriter.core.spellcheck import NWSpellEnchant
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwComment, nwDocAction, nwDocInsert, nwItemClass, nwItemLayout, nwState, nwVimMode
 from novelwriter.gui.doceditor import CommandCompleter, GuiDocEditor, TextAutoReplace, _TagAction
-from novelwriter.gui.dochighlight import TextBlockData
+from novelwriter.gui.doctextblock import TextBlockData
 from novelwriter.shared import _GuiAlert
 from novelwriter.text.counting import standardCounter
 from novelwriter.types import (
@@ -612,7 +613,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     # The test must not depend on which dictionaries are available on
     # the host system, so all words are accepted from the start, and
     # the spell check worker must run synchronously
-    monkeypatch.setattr(SHARED.spelling, "checkWord", lambda *a: True)
+    monkeypatch.setattr(NWSpellEnchant, "checkWord", lambda *a: True)
     monkeypatch.setattr(SHARED, "runInThreadPool", lambda r: r.run())
 
     assert nwGUI.openDocument(C.hSceneDoc) is True
@@ -665,7 +666,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     blockPos = cursor.block().position()
     data._spellErrors = [(0, 5, "Lorem"), (6, 11, "ipsum")]
     with monkeypatch.context() as mp:
-        mp.setattr(SHARED.spelling, "suggestWords", lambda *a: [])
+        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
         assert docEditor._qDocument.spellErrorAtPos(blockPos + 8) == ("ipsum", 6, 11, [])
 
     # No entry matches the given position
@@ -697,7 +698,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
 
     # With Suggestion
     with monkeypatch.context() as mp:
-        mp.setattr(SHARED.spelling, "suggestWords", lambda *a: [LORAX])
+        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [LORAX])
         suggestion = f"{nwUnicode.U_ENDASH} {LORAX}"
 
         ctxMenu = getMenuForPos(docEditor, 16)
@@ -716,7 +717,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
 
     # Without Suggestion
     with monkeypatch.context() as mp:
-        mp.setattr(SHARED.spelling, "suggestWords", lambda *a: [])
+        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
 
         ctxMenu = getMenuForPos(docEditor, 16)
         assert ctxMenu is not None
@@ -728,7 +729,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
 
     # Add to Dictionary
     with monkeypatch.context() as mp:
-        mp.setattr(SHARED.spelling, "suggestWords", lambda *a: [])
+        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
 
         ctxMenu = getMenuForPos(docEditor, 16)
         assert ctxMenu is not None
@@ -746,7 +747,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
 
     # No spelling error at the clicked position: no spelling actions
     with monkeypatch.context() as mp:
-        mp.setattr(SHARED.spelling, "suggestWords", lambda *a: [])
+        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
 
         ctxMenu = getMenuForPos(docEditor, blockPos + 20)
         assert ctxMenu is not None

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -813,6 +813,14 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     assert data.spellErrors == []
     assert docEditor._spellJob is None
 
+    # No new dispatch is made while a job is still in flight
+    docEditor._dirtySpell[block.blockNumber()] = block
+    docEditor._spellJob = (docEditor._spellJobId, [])
+    docEditor._dispatchSpellCheck()
+    assert docEditor._dirtySpell != {}
+    docEditor._spellJob = None
+    docEditor._dirtySpell.clear()
+
     # qtbot.stop()
 
 

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -608,6 +608,11 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     monkeypatch.setattr(QMenu, "setParent", lambda *a: None)
 
     buildTestProject(nwGUI, projPath)
+
+    # The test must not depend on which dictionaries are available on
+    # the host system, so all words are accepted from the start
+    monkeypatch.setattr(SHARED.spelling, "checkWord", lambda *a: True)
+
     assert nwGUI.openDocument(C.hSceneDoc) is True
     docEditor = nwGUI.docEditor
 

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -38,6 +38,7 @@ from PyQt6.QtGui import (
     QInputMethodEvent,
     QMouseEvent,
     QTextBlock,
+    QTextCharFormat,
     QTextCursor,
     QTextDocument,
     QTextOption,
@@ -669,6 +670,23 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     assert docEditor._qDocument.metaDataAtPos(blockPos + 20) == ("", "")
 
     data._spellErrors = [(0, 5, "Lorem")]
+
+    # The spell error should be rendered as an extra selection
+    docEditor._updateSpellSelections()
+    spellSel = [
+        s
+        for s in docEditor.extraSelections()
+        if s.format.underlineStyle() == QTextCharFormat.UnderlineStyle.SpellCheckUnderline
+    ]
+    assert len(spellSel) == 1
+    assert spellSel[0].cursor.selectionStart() == blockPos
+    assert spellSel[0].cursor.selectionEnd() == blockPos + 5
+
+    # With spell check disabled, the selections should be cleared
+    SHARED.project.data.setSpellCheck(False)
+    docEditor._updateSpellSelections()
+    assert docEditor._spellSelections == []
+    SHARED.project.data.setSpellCheck(True)
 
     # With Suggestion
     with monkeypatch.context() as mp:

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -775,6 +775,33 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     assert docEditor._suppressed is False
     assert len(docEditor._spellSelections) == 1
 
+    # Background Spell Pass
+    # =====================
+    with monkeypatch.context() as mp:
+        mp.setattr("novelwriter.gui.doceditor.SPELL_PASS_CHUNK", 2)
+
+        # The pass starts with the visible blocks checked
+        docEditor._beginSpellPass()
+        assert docEditor._spellPassNo == 0
+        assert docEditor._timerSpellPass.isActive()
+
+        # The first chunk should leave the pass incomplete
+        docEditor._runSpellPass()
+        assert docEditor._spellPassNo == 2
+        assert docEditor._timerSpellPass.isActive()
+
+        # Running the remaining chunks should end the pass
+        while docEditor._spellPassNo >= 0:
+            docEditor._runSpellPass()
+        assert not docEditor._timerSpellPass.isActive()
+
+        # A full spell check requests a notification when it ends
+        docEditor.spellCheckDocument()
+        assert docEditor._spellPassNotify is True
+        while docEditor._spellPassNo >= 0:
+            docEditor._runSpellPass()
+        assert docEditor._spellPassNotify is False
+
     # qtbot.stop()
 
 

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -749,6 +749,32 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
         ctxMenu.setObjectName("")
         ctxMenu.deleteLater()
 
+    # Editing a block flags it for the debounced spell check
+    docEditor._dirtySpell.clear()
+    docEditor.setCursorPosition(blockPos + 5)
+    docEditor.textCursor().insertText("x")
+    assert docEditor._dirtySpell != {}
+    assert docEditor._timerSpellCheck.isActive()
+
+    # Running the check consumes the dirty blocks
+    docEditor._runSpellCheck()
+    assert docEditor._dirtySpell == {}
+
+    # An error under the caret is not underlined
+    data = docEditor.textCursor().block().userData()
+    assert isinstance(data, TextBlockData)
+    data._spellErrors = [(0, 5, "Lorem")]
+    docEditor.setCursorPosition(blockPos + 3)
+    docEditor._updateSpellSelections()
+    assert docEditor._suppressed is True
+    assert docEditor._spellSelections == []
+
+    # Moving the caret out of the word restores the underline
+    docEditor.setCursorPosition(blockPos + 10)
+    docEditor._updateSpellSelections()
+    assert docEditor._suppressed is False
+    assert len(docEditor._spellSelections) == 1
+
     # qtbot.stop()
 
 

--- a/tests/test_gui/test_dochighlighter.py
+++ b/tests/test_gui/test_dochighlighter.py
@@ -27,8 +27,10 @@ from PyQt6.QtGui import QTextCharFormat, QTextCursor, QTextDocument
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.core.item import NWItem
+from novelwriter.core.spellcheck import NWSpellEnchant
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwTheme
-from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, GuiDocHighlighter, TextBlockData
+from novelwriter.gui.dochighlight import BLOCK_META, BLOCK_TITLE, GuiDocHighlighter
+from novelwriter.gui.doctextblock import TextBlockData
 from novelwriter.types import QtKeepAnchor
 
 R_HANDLE = "3456789abcdef"
@@ -515,7 +517,7 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     # Settings
     syntax._tHandle = T_HANDLE
     syntax._isNovel = True
-    monkeypatch.setattr(SHARED.spelling, "checkWord", lambda *a: False)
+    monkeypatch.setattr(NWSpellEnchant, "checkWord", lambda *a: False)
 
     colHidden = theme.syntaxTheme.hidden.getRgb()
     colEmph = theme.syntaxTheme.emph.getRgb()

--- a/tests/test_gui/test_dochighlighter.py
+++ b/tests/test_gui/test_dochighlighter.py
@@ -526,7 +526,6 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     colHidden = theme.syntaxTheme.hidden.getRgb()
     colEmph = theme.syntaxTheme.emph.getRgb()
     colLink = theme.syntaxTheme.link.getRgb()
-    colSpell = theme.syntaxTheme.spell.getRgb()
     colCode = theme.syntaxTheme.code.getRgb()
     colDialogue = theme.syntaxTheme.dialN.getRgb()
     colAltDialogue = theme.syntaxTheme.dialA.getRgb()
@@ -538,45 +537,32 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
 
     pieces, formats = getFragments(syntax)
     assert pieces == [
-        (0, 0, 4, "Text"),
         (0, 5, 2, "**"),
         (0, 7, 4, "bold"),
         (0, 11, 2, "**"),
-        (0, 14, 4, "text"),
         (0, 19, 1, "_"),
         (0, 20, 6, "italic"),
         (0, 26, 1, "_"),
-        (0, 28, 4, "text"),
         (0, 33, 2, "~~"),
         (0, 35, 6, "strike"),
         (0, 41, 2, "~~"),
-        (0, 44, 4, "text"),
         (0, 49, 3, "[b]"),
-        (0, 52, 4, "bold"),
         (0, 56, 4, "[/b]"),
         (0, 62, 18, "http://example.com"),
     ]
-    assert formats[0].underlineColor().getRgb() == colSpell  # Text
-    assert formats[1].foreground().color().getRgb() == colHidden  # **
-    assert formats[2].foreground().color().getRgb() == colEmph  # bold
-    assert formats[2].underlineColor().getRgb() == colSpell
-    assert formats[3].foreground().color().getRgb() == colHidden  # **
-    assert formats[4].underlineColor().getRgb() == colSpell  # text
+    assert formats[0].foreground().color().getRgb() == colHidden  # **
+    assert formats[1].foreground().color().getRgb() == colEmph  # bold
+    assert formats[2].foreground().color().getRgb() == colHidden  # **
+    assert formats[3].foreground().color().getRgb() == colHidden  # _
+    assert formats[4].foreground().color().getRgb() == colEmph  # italic
     assert formats[5].foreground().color().getRgb() == colHidden  # _
-    assert formats[6].foreground().color().getRgb() == colEmph  # italic
-    assert formats[6].underlineColor().getRgb() == colSpell
-    assert formats[7].foreground().color().getRgb() == colHidden  # _
-    assert formats[8].underlineColor().getRgb() == colSpell  # text
-    assert formats[9].foreground().color().getRgb() == colHidden  # ~~
-    assert formats[10].foreground().color().getRgb() == colHidden  # strike
-    assert formats[10].fontStrikeOut() is True
-    assert formats[10].underlineColor().getRgb() == colSpell
-    assert formats[11].foreground().color().getRgb() == colHidden  # ~~
-    assert formats[12].underlineColor().getRgb() == colSpell  # text
-    assert formats[13].foreground().color().getRgb() == colCode  # [b]
-    assert formats[14].underlineColor().getRgb() == colSpell  # bold
-    assert formats[15].foreground().color().getRgb() == colCode  # [/b]
-    assert formats[16].foreground().color().getRgb() == colLink  # http://example.com
+    assert formats[6].foreground().color().getRgb() == colHidden  # ~~
+    assert formats[7].foreground().color().getRgb() == colHidden  # strike
+    assert formats[7].fontStrikeOut() is True
+    assert formats[8].foreground().color().getRgb() == colHidden  # ~~
+    assert formats[9].foreground().color().getRgb() == colCode  # [b]
+    assert formats[10].foreground().color().getRgb() == colCode  # [/b]
+    assert formats[11].foreground().color().getRgb() == colLink  # http://example.com
 
     # Spell Check
     data = doc.findBlockByNumber(0).userData()
@@ -600,27 +586,13 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
 
     pieces, formats = getFragments(syntax)
     assert pieces == [
-        (0, 0, 1, "\u201c"),
-        (0, 1, 8, "Dialogue"),
-        (0, 9, 2, ",\u201d"),
-        (0, 12, 3, "and"),
-        (0, 16, 4, "then"),
-        (0, 21, 2, "::"),
-        (0, 23, 8, "dialogue"),
-        (0, 31, 2, "::"),
+        (0, 0, 11, "\u201cDialogue,\u201d"),
+        (0, 21, 12, "::dialogue::"),
         (0, 35, 18, "http://example.com"),
     ]
-    assert formats[0].foreground().color().getRgb() == colDialogue  # Quote
-    assert formats[1].foreground().color().getRgb() == colDialogue  # Dialogue
-    assert formats[1].underlineColor().getRgb() == colSpell
-    assert formats[2].foreground().color().getRgb() == colDialogue  # Quote
-    assert formats[3].underlineColor().getRgb() == colSpell  # and
-    assert formats[4].underlineColor().getRgb() == colSpell  # then
-    assert formats[5].foreground().color().getRgb() == colAltDialogue  # ::
-    assert formats[6].foreground().color().getRgb() == colAltDialogue  # dialogue
-    assert formats[6].underlineColor().getRgb() == colSpell
-    assert formats[7].foreground().color().getRgb() == colAltDialogue  # ::
-    assert formats[8].foreground().color().getRgb() == colLink  # http://example.com
+    assert formats[0].foreground().color().getRgb() == colDialogue  # Dialogue
+    assert formats[1].foreground().color().getRgb() == colAltDialogue  # Alt dialogue
+    assert formats[2].foreground().color().getRgb() == colLink  # http://example.com
 
     # Spell Check
     data = doc.findBlockByNumber(0).userData()
@@ -640,27 +612,13 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
 
     pieces, formats = getFragments(syntax)
     assert pieces == [
-        (0, 0, 4, "\u201c😁 "),
-        (0, 4, 8, "Grinning"),
-        (0, 12, 5, " 😁,\u201d"),
-        (0, 18, 3, "and"),
-        (0, 22, 4, "then"),
-        (0, 27, 5, "::🙊 "),
-        (0, 32, 5, "shush"),
-        (0, 37, 5, " 🙊::"),
+        (0, 0, 17, "\u201c😁 Grinning 😁,\u201d"),
+        (0, 27, 15, "::🙊 shush 🙊::"),
         (0, 44, 18, "http://example.com"),
     ]
-    assert formats[0].foreground().color().getRgb() == colDialogue  # Quote😁
-    assert formats[1].foreground().color().getRgb() == colDialogue  # Grinning
-    assert formats[1].underlineColor().getRgb() == colSpell
-    assert formats[2].foreground().color().getRgb() == colDialogue  # 😁Quote
-    assert formats[3].underlineColor().getRgb() == colSpell  # and
-    assert formats[4].underlineColor().getRgb() == colSpell  # then
-    assert formats[5].foreground().color().getRgb() == colAltDialogue  # ::🙊
-    assert formats[6].foreground().color().getRgb() == colAltDialogue  # shush
-    assert formats[6].underlineColor().getRgb() == colSpell
-    assert formats[7].foreground().color().getRgb() == colAltDialogue  # 🙊::
-    assert formats[8].foreground().color().getRgb() == colLink  # http://example.com
+    assert formats[0].foreground().color().getRgb() == colDialogue  # Dialogue
+    assert formats[1].foreground().color().getRgb() == colAltDialogue  # Alt dialogue
+    assert formats[2].foreground().color().getRgb() == colLink  # http://example.com
 
     # Spell Check
     data = doc.findBlockByNumber(0).userData()

--- a/tests/test_gui/test_dochighlighter.py
+++ b/tests/test_gui/test_dochighlighter.py
@@ -102,11 +102,6 @@ def maxOrd(text: str) -> int:
 @pytest.mark.gui
 def testGuiDocHighlighter_Basic(syntax):
     """Test the basic functionality of the syntax highlighter."""
-    # Alternate Spell Check
-    assert syntax._spellCheck is False
-    syntax.setSpellCheck(True)
-    assert syntax._spellCheck is True
-
     # Check Handle
     assert syntax._tHandle is None
     syntax.setHandle(T_HANDLE)
@@ -520,7 +515,6 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     # Settings
     syntax._tHandle = T_HANDLE
     syntax._isNovel = True
-    syntax.setSpellCheck(True)
     monkeypatch.setattr(SHARED.spelling, "checkWord", lambda *a: False)
 
     colHidden = theme.syntaxTheme.hidden.getRgb()
@@ -568,7 +562,7 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     data = doc.findBlockByNumber(0).userData()
     assert isinstance(data, TextBlockData)
     assert data.metaData == [(62, 80, "http://example.com", "url")]
-    assert data.spellErrors == [
+    assert data.spellCheck() == [
         (0, 4, "Text"),
         (7, 11, "bold"),
         (14, 18, "text"),
@@ -598,7 +592,7 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     data = doc.findBlockByNumber(0).userData()
     assert isinstance(data, TextBlockData)
     assert data.metaData == [(35, 53, "http://example.com", "url")]
-    assert data.spellErrors == [
+    assert data.spellCheck() == [
         (1, 9, "Dialogue"),
         (12, 15, "and"),
         (16, 20, "then"),
@@ -624,7 +618,7 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     data = doc.findBlockByNumber(0).userData()
     assert isinstance(data, TextBlockData)
     assert data.metaData == [(44, 62, "http://example.com", "url")]
-    assert data.spellErrors == [
+    assert data.spellCheck() == [
         (4, 12, "Grinning"),
         (18, 21, "and"),
         (22, 26, "then"),

--- a/tests/test_gui/test_dochighlighter.py
+++ b/tests/test_gui/test_dochighlighter.py
@@ -665,7 +665,7 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     # Spell Check
     data = doc.findBlockByNumber(0).userData()
     assert isinstance(data, TextBlockData)
-    assert data.metaData == [(40, 58, "http://example.com", "url")]
+    assert data.metaData == [(44, 62, "http://example.com", "url")]
     assert data.spellErrors == [
         (4, 12, "Grinning"),
         (18, 21, "and"),


### PR DESCRIPTION
**Summary:**

This PR moves the spell checking out of the syntax highlighter and implements it as a chunked and timed spell check run in the editor itself. It tracks the spell checked blocks via dirty-flagged TextBlockData objects. This is what the block data was designed for in the first place.Instead of using the syntax highlighter to underline misspelled words, this implementation uses the ExtraSelection feature of QTextEdit, the same used for current line highlighting.

This is an important change because it unblocks a bunch of possibilities. It is now possible to run the spell check off the GUI thread, which means we can add more validation tooling later on without blocking and slowing down the editor itself so that typing speed is affected. It also means we may be able to switch back to QTextEdit being the base of the editor, which means we may be able to implement line height.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
