### PR TITLE
Switch editor back to QTextEdit

### DIFF
--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -30,9 +30,11 @@ from typing import NamedTuple
 
 from PyQt6 import sip
 from PyQt6.QtCore import (
+    QAbstractAnimation,
     QMimeData,
     QObject,
     QPoint,
+    QPropertyAnimation,
     QRect,
     QRegularExpression,
     QRunnable,
@@ -539,7 +541,6 @@ class GuiDocEditor(QTextEdit):
         self._qDocument.setDefaultTextOption(options)
 
         # Scrolling
-        # self.setCenterOnScroll(CONFIG.scrollPastEnd)
         if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
@@ -746,6 +747,14 @@ class GuiDocEditor(QTextEdit):
         uM = max(self._vpMargin, tH, rH)
         lM = max(self._vpMargin, fH)
         self.setViewportMargins(tM, uM, tM, lM)
+
+        # Scroll Past End
+        if rootFrame := self._qDocument.rootFrame():  # pragma: no branch
+            frameFormat = rootFrame.frameFormat()
+            bottomMargin = max(wH - 2 * tB - uM - lM - sH, 0) if CONFIG.scrollPastEnd else 0
+            if frameFormat.bottomMargin() != bottomMargin:
+                frameFormat.setBottomMargin(bottomMargin)
+                rootFrame.setFrameFormat(frameFormat)
 
     ##
     #  Getters
@@ -1152,7 +1161,12 @@ class GuiDocEditor(QTextEdit):
             if nPos != cPos and okMod and okKey and (viewport := self.viewport()):
                 mPos = CONFIG.autoScrollPos * 0.01 * viewport.height()
                 if cPos > mPos and (vBar := self.verticalScrollBar()):
-                    vBar.setValue(vBar.value() + (1 if nPos > cPos else -1))
+                    cMov = nPos - cPos
+                    anim = QPropertyAnimation(vBar, b"value", self)
+                    anim.setDuration(120)
+                    anim.setStartValue(vBar.value())
+                    anim.setEndValue(vBar.value() + cMov)
+                    anim.start(QAbstractAnimation.DeletionPolicy.DeleteWhenStopped)
         else:
             super().keyPressEvent(event)
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -323,6 +323,7 @@ class GuiDocEditor(QTextEdit):
         self.setAutoFillBackground(True)
         self.setFrameStyle(QFrame.Shape.NoFrame)
         self.setAcceptDrops(True)
+        self.setAcceptRichText(False)
 
         # Custom Shortcuts
         self._keyContext = QShortcut(self)
@@ -692,22 +693,19 @@ class GuiDocEditor(QTextEdit):
         height = viewport.height() if viewport else 0
         return self.cursorRect().top() > 0 and self.cursorRect().bottom() < height
 
-    def ensureCursorVisibleNoCentre(self) -> None:
-        """Ensure cursor is visible, but don't force it to centre."""
+    def ensureCursorVisible(self, *, centre: bool) -> None:
+        """Ensure cursor is visible, and optionally centre it."""
         if (viewport := self.viewport()) and (vBar := self.verticalScrollBar()):  # pragma: no branch
             cT = self.cursorRect().top()
             cB = self.cursorRect().bottom()
             vH = viewport.height()
-            if cT < 0:
-                count = 0
-                while self.cursorRect().top() < 0 and count < 100000:
-                    vBar.setValue(vBar.value() - 1)
-                    count += 1
+            if centre:
+                cY = (cT + cB) // 2
+                vBar.setValue(vBar.value() + cY - vH // 2)
+            elif cT < 0:
+                vBar.setValue(vBar.value() + cT - 1)
             elif cB > vH:
-                count = 0
-                while self.cursorRect().bottom() > vH and count < 100000:
-                    vBar.setValue(vBar.value() + 1)
-                    count += 1
+                vBar.setValue(vBar.value() + (cB - vH) + 1)
             QApplication.processEvents()
 
     def updateDocMargins(self) -> None:
@@ -810,7 +808,7 @@ class GuiDocEditor(QTextEdit):
             cursor = self.textCursor()
             cursor.setPosition(minmax(position, 0, chars - 1))
             self.setTextCursor(cursor)
-            # self.centerCursor()
+            self.ensureCursorVisible(centre=True)
 
     def saveCursorPosition(self) -> None:
         """Save the cursor position to the current project item."""
@@ -1221,7 +1219,7 @@ class GuiDocEditor(QTextEdit):
         super().inputMethodEvent(event)
         if event.commitString():
             # See issues #2267 and #2517
-            self.ensureCursorVisible()
+            self.ensureCursorVisible(centre=False)
             self._completerToCursor()
 
     def inputMethodQuery(self, query: Qt.InputMethodQuery) -> QRect | QVariant:
@@ -2467,8 +2465,8 @@ class GuiDocEditor(QTextEdit):
             self._vim.resetCommand()
 
         elif command == "zz":
-            # self.centerCursor()
             self.setTextCursor(cursor)
+            self.ensureCursorVisible(centre=True)
             self._vim.resetCommand()
 
         # Single-step navigation

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -562,8 +562,8 @@ class GuiDocEditor(QTextEdit):
         # font changed, otherwise we just clear the editor entirely,
         # which makes it read only.
         if self._docHandle:
-            print("Ping!")
             self._qDocument.syntaxHighlighter.rehighlight()
+            self._qDocument.markContentsDirty(0, self._qDocument.characterCount())
             self._beginSpellPass()
             self.docHeader.setHandle(self._docHandle)
         else:

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -71,7 +71,6 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMenu,
-    QPlainTextEdit,
     QTextEdit,
     QToolBar,
     QVBoxLayout,
@@ -159,7 +158,7 @@ class _TagAction(IntFlag):
     CREATE = 0b10
 
 
-class GuiDocEditor(QPlainTextEdit):
+class GuiDocEditor(QTextEdit):
     """Gui Widget: Main Document Editor."""
 
     __slots__ = (
@@ -539,7 +538,7 @@ class GuiDocEditor(QPlainTextEdit):
         self._qDocument.setDefaultTextOption(options)
 
         # Scrolling
-        self.setCenterOnScroll(CONFIG.scrollPastEnd)
+        # self.setCenterOnScroll(CONFIG.scrollPastEnd)
         if CONFIG.hideVScroll:
             self.setVerticalScrollBarPolicy(QtScrollAlwaysOff)
         else:
@@ -561,6 +560,7 @@ class GuiDocEditor(QPlainTextEdit):
         # font changed, otherwise we just clear the editor entirely,
         # which makes it read only.
         if self._docHandle:
+            print("Ping!")
             self._qDocument.syntaxHighlighter.rehighlight()
             self._beginSpellPass()
             self.docHeader.setHandle(self._docHandle)
@@ -810,7 +810,7 @@ class GuiDocEditor(QPlainTextEdit):
             cursor = self.textCursor()
             cursor.setPosition(minmax(position, 0, chars - 1))
             self.setTextCursor(cursor)
-            self.centerCursor()
+            # self.centerCursor()
 
     def saveCursorPosition(self) -> None:
         """Save the cursor position to the current project item."""
@@ -1364,7 +1364,7 @@ class GuiDocEditor(QPlainTextEdit):
         if SHARED.project.data.spellCheck and (viewport := self.viewport()):
             cPos = self.textCursor().position()
             last = self.cursorForPosition(viewport.rect().bottomLeft()).blockNumber()
-            block = self.firstVisibleBlock()
+            block = self.cursorForPosition(viewport.rect().topLeft()).block()
             while block.isValid() and block.blockNumber() <= last:
                 if isinstance(data := block.userData(), TextBlockData):
                     position = block.position()
@@ -2467,7 +2467,7 @@ class GuiDocEditor(QPlainTextEdit):
             self._vim.resetCommand()
 
         elif command == "zz":
-            self.centerCursor()
+            # self.centerCursor()
             self.setTextCursor(cursor)
             self._vim.resetCommand()
 
@@ -2604,7 +2604,7 @@ class GuiDocEditor(QPlainTextEdit):
                 # Check the visible blocks first so that their result
                 # is available immediately
                 last = self.cursorForPosition(viewport.rect().bottomLeft()).blockNumber()
-                block = self.firstVisibleBlock()
+                block = self.cursorForPosition(viewport.rect().topLeft()).block()
                 while block.isValid() and block.blockNumber() <= last:
                     if isinstance(data := block.userData(), TextBlockData):
                         data.spellCheck()

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -53,7 +53,6 @@ class GuiTextDocument(QTextDocument):
 
         self._handle = None
         self._syntax = GuiDocHighlighter(self)
-        # self.setDocumentLayout(QPlainTextDocumentLayout(self))
 
         logger.debug("Ready: GuiTextDocument")
 

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -27,7 +27,7 @@ from time import time
 from typing import TYPE_CHECKING
 
 from PyQt6.QtGui import QTextBlock, QTextCursor, QTextDocument
-from PyQt6.QtWidgets import QApplication, QPlainTextDocumentLayout
+from PyQt6.QtWidgets import QApplication
 
 from novelwriter import SHARED
 from novelwriter.gui.dochighlight import GuiDocHighlighter
@@ -53,7 +53,7 @@ class GuiTextDocument(QTextDocument):
 
         self._handle = None
         self._syntax = GuiDocHighlighter(self)
-        self.setDocumentLayout(QPlainTextDocumentLayout(self))
+        # self.setDocumentLayout(QPlainTextDocumentLayout(self))
 
         logger.debug("Ready: GuiTextDocument")
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -627,7 +627,7 @@ class GuiMain(QMainWindow):
                 # Since editor width changes, we need to make sure we
                 # restore cursor visibility in the editor. See #1302
                 if cursorVisible:
-                    self.docEditor.ensureCursorVisibleNoCentre()
+                    self.docEditor.ensureCursorVisible(centre=False)
 
             if sTitle:
                 self.docViewer.navigateTo(f"#{tHandle}:{sTitle}")
@@ -871,7 +871,7 @@ class GuiMain(QMainWindow):
         # Since editor width changes, we need to make sure we restore
         # cursor visibility in the editor. See #1302
         if cursorVisible:
-            self.docEditor.ensureCursorVisibleNoCentre()
+            self.docEditor.ensureCursorVisible(centre=False)
 
         return not self.splitView.isVisible()
 
@@ -992,7 +992,7 @@ class GuiMain(QMainWindow):
             self.splitView.setVisible(True)
 
         if cursorVisible:
-            self.docEditor.ensureCursorVisibleNoCentre()
+            self.docEditor.ensureCursorVisible(centre=False)
 
     @pyqtSlot(nwFocus)
     def _switchFocus(self, paneNo: nwFocus) -> None:

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -43,7 +43,7 @@ from PyQt6.QtGui import (
     QTextDocument,
     QTextOption,
 )
-from PyQt6.QtWidgets import QApplication, QMenu, QPlainTextEdit
+from PyQt6.QtWidgets import QApplication, QMenu, QTextEdit
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import decodeMimeHandles
@@ -313,7 +313,7 @@ def testGuiEditor_DragAndDrop(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     docEvent = QDragEnterEvent(middle, action, docMime, mouse, QtModNone)
     noneEvent = QDragEnterEvent(middle, action, noneMime, mouse, QtModNone)
     with monkeypatch.context() as mp:
-        mp.setattr(QPlainTextEdit, "dragEnterEvent", mockEnter)
+        mp.setattr(QTextEdit, "dragEnterEvent", mockEnter)
 
         # Document Enter
         docEditor.dragEnterEvent(docEvent)
@@ -329,7 +329,7 @@ def testGuiEditor_DragAndDrop(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     docEvent = QDragMoveEvent(middle, action, docMime, mouse, QtModNone)
     noneEvent = QDragMoveEvent(middle, action, noneMime, mouse, QtModNone)
     with monkeypatch.context() as mp:
-        mp.setattr(QPlainTextEdit, "dragMoveEvent", mockMove)
+        mp.setattr(QTextEdit, "dragMoveEvent", mockMove)
 
         # Document Move
         docEditor.dragMoveEvent(docEvent)
@@ -346,7 +346,7 @@ def testGuiEditor_DragAndDrop(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     docEvent = QDropEvent(middle, action, docMime, mouse, QtModNone)
     noneEvent = QDropEvent(middle, action, noneMime, mouse, QtModNone)
     with monkeypatch.context() as mp:
-        mp.setattr(QPlainTextEdit, "dropEvent", mockDrop)
+        mp.setattr(QTextEdit, "dropEvent", mockDrop)
 
         # Document Drop
         docEditor.dropEvent(docEvent)
@@ -2588,7 +2588,6 @@ def testGuiEditor_CursorVisibility(qtbot, monkeypatch, nwGUI, projPath, mockRnd)
 
     docEditor.setPlainText("### Scene\n\n" + "".join(["Text\n\n"] * 100))
     assert docEditor.cursorIsVisible() is True
-    docEditor.setCenterOnScroll(False)
 
     # Scroll Down
     cursor = docEditor.textCursor()
@@ -2596,7 +2595,7 @@ def testGuiEditor_CursorVisibility(qtbot, monkeypatch, nwGUI, projPath, mockRnd)
     docEditor.setTextCursor(cursor)
     docEditor.verticalScrollBar().setValue(0)
     assert docEditor.verticalScrollBar().value() == 0
-    docEditor.ensureCursorVisibleNoCentre()
+    docEditor.ensureCursorVisible(centre=False)
     assert docEditor.verticalScrollBar().value() > 0
     assert docEditor.cursorIsVisible() is True
 
@@ -2606,9 +2605,33 @@ def testGuiEditor_CursorVisibility(qtbot, monkeypatch, nwGUI, projPath, mockRnd)
     docEditor.setTextCursor(cursor)
     docEditor.verticalScrollBar().setValue(200)
     assert docEditor.verticalScrollBar().value() > 100
-    docEditor.ensureCursorVisibleNoCentre()
-    assert docEditor.verticalScrollBar().value() == 0
+    docEditor.ensureCursorVisible(centre=False)
+    assert docEditor.verticalScrollBar().value() < 100
     assert docEditor.cursorIsVisible() is True
+
+    # Centre Cursor
+    viewport = docEditor.viewport()
+    cursor = docEditor.textCursor()
+    cursor.setPosition(300)
+    docEditor.setTextCursor(cursor)
+    docEditor.verticalScrollBar().setValue(0)
+    docEditor.ensureCursorVisible(centre=True)
+    cRect = docEditor.cursorRect()
+    cCentre = (cRect.top() + cRect.bottom()) // 2
+    assert abs(cCentre - viewport.height() // 2) <= 1
+    assert docEditor.cursorIsVisible() is True
+
+    # Centre Cursor, Already Visible
+    # Even if the cursor is already visible but off-centre, centre=True
+    # should still move it, rather than no-op like centre=False does
+    vBarAfterCentre = docEditor.verticalScrollBar().value()
+    docEditor.verticalScrollBar().setValue(vBarAfterCentre - 5)
+    assert docEditor.cursorIsVisible() is True
+    docEditor.ensureCursorVisible(centre=True)
+    assert docEditor.verticalScrollBar().value() == vBarAfterCentre
+    cRect = docEditor.cursorRect()
+    cCentre = (cRect.top() + cRect.bottom()) // 2
+    assert abs(cCentre - viewport.height() // 2) <= 1
 
     # qtbot.stop()
 

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -2580,6 +2580,61 @@ def testGuiEditor_UpdateDocMargins(qtbot, nwGUI, projPath, mockRnd):
 
 
 @pytest.mark.gui
+def testGuiEditor_ScrollPastEnd(qtbot, nwGUI, projPath, mockRnd):
+    """Test the scroll-past-end feature, which fakes QPlainTextEdit's
+    centerOnScroll via a bottom margin on the document's root frame.
+    """
+    buildTestProject(nwGUI, projPath)
+    nwGUI.openDocument(C.hSceneDoc)
+    docEditor = nwGUI.docEditor
+    docEditor.resize(400, 300)
+
+    rootFrame = docEditor.document().rootFrame()
+
+    CONFIG.scrollPastEnd = True
+    docEditor.updateDocMargins()
+    assert rootFrame.frameFormat().bottomMargin() > 0
+    maxWithScrollPastEnd = docEditor.verticalScrollBar().maximum()
+
+    CONFIG.scrollPastEnd = False
+    docEditor.updateDocMargins()
+    assert rootFrame.frameFormat().bottomMargin() == 0
+    assert docEditor.verticalScrollBar().maximum() < maxWithScrollPastEnd
+
+
+@pytest.mark.gui
+def testGuiEditor_TypewriterScrolling(qtbot, nwGUI, projPath, mockRnd):
+    """Test the typewriter scrolling (auto-scroll) feature, which
+    animates the scrollbar by the actual pixel movement of the cursor.
+    """
+    buildTestProject(nwGUI, projPath)
+    nwGUI.openDocument(C.hSceneDoc)
+    docEditor = nwGUI.docEditor
+    docEditor.resize(400, 300)
+
+    docEditor.setPlainText("Text\n\n" * 100)
+    cursor = docEditor.textCursor()
+    cursor.setPosition(0)
+    docEditor.setTextCursor(cursor)
+    docEditor.verticalScrollBar().setValue(0)
+
+    CONFIG.autoScroll = True
+    CONFIG.autoScrollPos = 30
+
+    vBar = docEditor.verticalScrollBar()
+    assert vBar.value() == 0
+
+    # Move the cursor down past the auto-scroll threshold by inserting
+    # newlines, which advances the cursor without hitting the MOVE_KEYS
+    # exclusion used for arrow-key navigation
+    for _ in range(30):
+        qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+
+    qtbot.wait(200)  # Let the scroll animation finish
+    assert vBar.value() > 0
+
+
+@pytest.mark.gui
 def testGuiEditor_CursorVisibility(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test the custom ensure cursor visible feature."""
     buildTestProject(nwGUI, projPath)


### PR DESCRIPTION
**Summary:**

This reverts the key change of #1521 to change the base class of the document editor. It leaves out the large document size logic though, as that seems to no longer be relevant. Either due to the Qt6 move, or #2812 simply makes it irrelevant. The latter is certainly partially true, but the big doc limit was also used in the logic that restored cursor position. This needs a bit of beta testing to confirm in any case.

**Related Issue(s):**

Closes #2815

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
