### PR TITLE
Add line height setting for editor and viewer

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -161,6 +161,7 @@ class Config:
         "kernelVer",
         "lastNotes",
         "lightTheme",
+        "lineHeight",
         "lineHighlight",
         "mainPanePos",
         "mainWinSize",
@@ -322,6 +323,7 @@ class Config:
         self.textWidth = 700  # Editor text width
         self.textMargin = 40  # Editor/viewer text margin
         self.tabWidth = 40  # Editor tabulator width
+        self.lineHeight = 1.0  # Editor line height
         self.cursorWidth = 1  # Editor cursor width
         self.lineHighlight = False  # Highlight current line in editor
 

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -809,6 +809,7 @@ class Config:
         self.textWidth = conf.rdInt(sec, "width", self.textWidth)
         self.textMargin = conf.rdInt(sec, "margin", self.textMargin)
         self.tabWidth = conf.rdInt(sec, "tabwidth", self.tabWidth)
+        self.lineHeight = conf.rdFlt(sec, "lineheight", self.lineHeight)
         self.cursorWidth = conf.rdInt(sec, "cursorwidth", self.cursorWidth)
         self.lineHighlight = conf.rdBool(sec, "linehighlight", self.lineHighlight)
         self.focusWidth = conf.rdInt(sec, "focuswidth", self.focusWidth)
@@ -943,6 +944,7 @@ class Config:
             "width": str(self.textWidth),
             "margin": str(self.textMargin),
             "tabwidth": str(self.tabWidth),
+            "lineheight": str(self.lineHeight),
             "cursorwidth": str(self.cursorWidth),
             "lineHighlight": str(self.lineHighlight),
             "focuswidth": str(self.focusWidth),

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -545,6 +545,17 @@ class GuiPreferences(NDialog):
             unit=self.tr("px"),
         )
 
+        # Line Height
+        self.lineHeight = NDoubleSpinBox(self, minVal=0.5, maxVal=3.0, step=0.05, prec=2)
+        self.lineHeight.setValue(CONFIG.lineHeight)
+        self.lineHeight.setFixedNumbersWidth(4)
+        self.mainForm.addRow(
+            self.tr("Line height"),
+            self.lineHeight,
+            self.tr("The relative line height in the editor and viewer."),
+            unit=self.tr("em"),
+        )
+
         # Text Editing
         # ============
 
@@ -1175,6 +1186,7 @@ class GuiPreferences(NDialog):
         CONFIG.doJustify = self.doJustify.isChecked()
         CONFIG.textMargin = self.textMargin.value()
         CONFIG.tabWidth = self.tabWidth.value()
+        CONFIG.lineHeight = self.lineHeight.value()
 
         # Text Editing
         scaleHeadings = self.scaleHeadings.isChecked()

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import logging
 
+from typing import NamedTuple
+
 from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QAction, QCloseEvent, QKeyEvent, QKeySequence
 from PyQt6.QtWidgets import (
@@ -52,10 +54,21 @@ from novelwriter.types import QtAlignCenter, QtRoleAccept, QtRoleReject
 logger = logging.getLogger(__name__)
 
 
+class GuiNeedsUpdate(NamedTuple):
+    """The update flags after settings have been processed."""
+
+    restart: bool
+    tree: bool
+    theme: bool
+    syntax: bool
+    editor: bool
+    viewer: bool
+
+
 class GuiPreferences(NDialog):
     """GUI: Preferences Dialog."""
 
-    newPreferencesReady = pyqtSignal(bool, bool, bool, bool)
+    newPreferencesReady = pyqtSignal(GuiNeedsUpdate)
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
@@ -1119,12 +1132,16 @@ class GuiPreferences(NDialog):
         needsRestart = False
         updateSyntax = False
         refreshTree = False
+        initEditor = False
+        initViewer = False
 
         # Appearance
         guiLocale = self.guiLocale.currentData()
         lightTheme = self.lightTheme.currentData()
         darkTheme = self.darkTheme.currentData()
         iconTheme = self.iconTheme.currentData()
+        hideVScroll = self.hideVScroll.isChecked()
+        hideHScroll = self.hideHScroll.isChecked()
         useCharCount = self.useCharCount.isChecked()
 
         updateTheme |= CONFIG.lightTheme != lightTheme
@@ -1135,21 +1152,30 @@ class GuiPreferences(NDialog):
         refreshTree |= CONFIG.useCharCount != useCharCount
         updateSyntax |= CONFIG.lightTheme != lightTheme
         updateSyntax |= CONFIG.darkTheme != darkTheme
+        initEditor |= CONFIG.hideVScroll != hideVScroll
+        initEditor |= CONFIG.hideHScroll != hideHScroll
+        initViewer |= CONFIG.hideVScroll != hideVScroll
+        initViewer |= CONFIG.hideHScroll != hideHScroll
 
         CONFIG.guiLocale = guiLocale
         CONFIG.lightTheme = lightTheme
         CONFIG.darkTheme = darkTheme
         CONFIG.iconTheme = iconTheme
-        CONFIG.hideVScroll = self.hideVScroll.isChecked()
-        CONFIG.hideHScroll = self.hideHScroll.isChecked()
+        CONFIG.hideVScroll = hideVScroll
+        CONFIG.hideHScroll = hideHScroll
         CONFIG.nativeFont = self.nativeFont.isChecked()
         CONFIG.setGuiFont(self._guiFont)
         CONFIG.setPrimaryCount(useCharCount)
 
         # Document Style
+        textFont = self._textFont
+
+        initEditor |= CONFIG.textFont != textFont
+        initViewer |= CONFIG.textFont != textFont
+
         CONFIG.showFullPath = self.showFullPath.isChecked()
         CONFIG.incNotesWCount = self.incNotesWCount.isChecked()
-        CONFIG.setTextFont(self._textFont)
+        CONFIG.setTextFont(textFont)
 
         # Project View
         iconColTree = self.iconColTree.currentData()
@@ -1180,31 +1206,48 @@ class GuiPreferences(NDialog):
         CONFIG.userIdleTime = round(self.userIdleTime.value() * 60)
 
         # Text Flow
+        doJustify = self.doJustify.isChecked()
+        tabWidth = self.tabWidth.value()
+        lineHeight = self.lineHeight.value()
+
+        initEditor |= CONFIG.doJustify != doJustify
+        initEditor |= CONFIG.tabWidth != tabWidth
+        initEditor |= CONFIG.lineHeight != lineHeight
+        initViewer |= CONFIG.doJustify != doJustify
+        initViewer |= CONFIG.tabWidth != tabWidth
+        initViewer |= CONFIG.lineHeight != lineHeight
+
         CONFIG.textWidth = self.textWidth.value()
         CONFIG.focusWidth = self.focusWidth.value()
         CONFIG.hideFocusFooter = self.hideFocusFooter.isChecked()
-        CONFIG.doJustify = self.doJustify.isChecked()
+        CONFIG.doJustify = doJustify
         CONFIG.textMargin = self.textMargin.value()
-        CONFIG.tabWidth = self.tabWidth.value()
-        CONFIG.lineHeight = self.lineHeight.value()
+        CONFIG.tabWidth = tabWidth
+        CONFIG.lineHeight = lineHeight
 
         # Text Editing
+        cursorWidth = self.cursorWidth.value()
         scaleHeadings = self.scaleHeadings.isChecked()
         singleStarBold = self.singleStarBold.isChecked()
         lineHighlight = self.lineHighlight.isChecked()
+        showTabsNSpaces = self.showTabsNSpaces.isChecked()
+        showLineEndings = self.showLineEndings.isChecked()
 
         updateSyntax |= CONFIG.scaleHeadings != scaleHeadings
         updateSyntax |= CONFIG.singleStarBold != singleStarBold
         updateSyntax |= CONFIG.lineHighlight != lineHighlight
+        initEditor |= CONFIG.cursorWidth != cursorWidth
+        initEditor |= CONFIG.showTabsNSpaces != showTabsNSpaces
+        initEditor |= CONFIG.showLineEndings != showLineEndings
 
         CONFIG.spellLanguage = self.spellLanguage.currentData()
         CONFIG.autoSelect = self.autoSelect.isChecked()
-        CONFIG.cursorWidth = self.cursorWidth.value()
+        CONFIG.cursorWidth = cursorWidth
         CONFIG.scaleHeadings = scaleHeadings
         CONFIG.singleStarBold = singleStarBold
         CONFIG.lineHighlight = lineHighlight
-        CONFIG.showTabsNSpaces = self.showTabsNSpaces.isChecked()
-        CONFIG.showLineEndings = self.showLineEndings.isChecked()
+        CONFIG.showTabsNSpaces = showTabsNSpaces
+        CONFIG.showLineEndings = showLineEndings
 
         # Editor Scrolling
         CONFIG.autoScroll = self.autoScroll.isChecked()
@@ -1273,6 +1316,15 @@ class GuiPreferences(NDialog):
 
         # Finalise
         CONFIG.saveConfig()
-        self.newPreferencesReady.emit(needsRestart, refreshTree, updateTheme, updateSyntax)
+        self.newPreferencesReady.emit(
+            GuiNeedsUpdate(
+                restart=needsRestart,
+                tree=refreshTree,
+                theme=updateTheme,
+                syntax=updateSyntax,
+                editor=initEditor,
+                viewer=initViewer,
+            )
+        )
 
         self.close()

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -184,7 +184,7 @@ def exceptionHandler(exType: type, exValue: BaseException, exTrace: TracebackTyp
     try:
         nwGUI = None
         for qWin in QApplication.topLevelWidgets():
-            if qWin.objectName() == "GuiMain":
+            if qWin.objectName() == "GuiMain":  # pragma: no branch (this branch is flaky)
                 nwGUI = qWin
                 break
 

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -562,6 +562,7 @@ class GuiDocEditor(QTextEdit):
         # font changed, otherwise we just clear the editor entirely,
         # which makes it read only.
         if self._docHandle:
+            self._qDocument.setLineHeight(CONFIG.lineHeight)
             self._qDocument.syntaxHighlighter.rehighlight()
             self._qDocument.markContentsDirty(0, self._qDocument.characterCount())
             self._beginSpellPass()
@@ -645,6 +646,7 @@ class GuiDocEditor(QTextEdit):
         """
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         self.setPlainText(text)
+        self._qDocument.setLineHeight(CONFIG.lineHeight)
         self.updateDocMargins()
         self.setDocumentChanged(True)
         QApplication.restoreOverrideCursor()

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1154,7 +1154,7 @@ class GuiDocEditor(QTextEdit):
 
         if CONFIG.autoScroll:
             cPos = self.cursorRect().topLeft().y()
-            super().keyPressEvent(event)
+            self._dispatchKeyPress(event)
             nPos = self.cursorRect().topLeft().y()
             kMod = event.modifiers()
             okMod = kMod in (QtModNone, QtModShift)
@@ -1170,9 +1170,35 @@ class GuiDocEditor(QTextEdit):
                     anim.setEndValue(vBar.value() + cMov)
                     anim.start(QAbstractAnimation.DeletionPolicy.DeleteWhenStopped)
         else:
-            super().keyPressEvent(event)
+            self._dispatchKeyPress(event)
 
         return
+
+    def _dispatchKeyPress(self, event: QKeyEvent) -> None:
+        """Send a key event on to the base class for regular handling,
+        except for a plain Return/Enter press, which is handled
+        directly instead.
+
+        Qt's own Return handling (QWidgetTextControlPrivate::
+        insertParagraphSeparator) resets the current block's format to
+        a bare default and swallows the keypress whenever the cursor
+        is on an empty block whose format isn't already default. That
+        heuristic exists so rich-text users can hit Enter twice to
+        escape a list/heading/quote, but every block here always
+        carries a non-default line height, so it fires on every
+        ordinary blank-line paragraph break and silently eats every
+        second Return. novelWriter never uses Qt's native list/heading
+        block formatting, so the heuristic serves no purpose here, and
+        can be bypassed entirely by inserting the new block directly.
+        """
+        if event.key() in self.ENTER_KEYS and event.modifiers() == QtModNone:
+            cursor = self.textCursor()
+            cursor.insertBlock()
+            self.setTextCursor(cursor)
+            self.ensureCursorVisible(centre=False)
+            event.accept()
+        else:
+            super().keyPressEvent(event)
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
         """Overload drag enter event to handle dragged items."""

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -1174,32 +1174,6 @@ class GuiDocEditor(QTextEdit):
 
         return
 
-    def _dispatchKeyPress(self, event: QKeyEvent) -> None:
-        """Send a key event on to the base class for regular handling,
-        except for a plain Return/Enter press, which is handled
-        directly instead.
-
-        Qt's own Return handling (QWidgetTextControlPrivate::
-        insertParagraphSeparator) resets the current block's format to
-        a bare default and swallows the keypress whenever the cursor
-        is on an empty block whose format isn't already default. That
-        heuristic exists so rich-text users can hit Enter twice to
-        escape a list/heading/quote, but every block here always
-        carries a non-default line height, so it fires on every
-        ordinary blank-line paragraph break and silently eats every
-        second Return. novelWriter never uses Qt's native list/heading
-        block formatting, so the heuristic serves no purpose here, and
-        can be bypassed entirely by inserting the new block directly.
-        """
-        if event.key() in self.ENTER_KEYS and event.modifiers() == QtModNone:
-            cursor = self.textCursor()
-            cursor.insertBlock()
-            self.setTextCursor(cursor)
-            self.ensureCursorVisible(centre=False)
-            event.accept()
-        else:
-            super().keyPressEvent(event)
-
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
         """Overload drag enter event to handle dragged items."""
         if (data := event.mimeData()) and data.hasFormat(nwConst.MIME_HANDLE):
@@ -2619,6 +2593,32 @@ class GuiDocEditor(QTextEdit):
     ##
     #  Internal Functions
     ##
+
+    def _dispatchKeyPress(self, event: QKeyEvent) -> None:
+        """Send a key event on to the base class for regular handling,
+        except for a plain Return/Enter press, which is handled
+        directly instead.
+
+        Qt's own Return handling (QWidgetTextControlPrivate::
+        insertParagraphSeparator) resets the current block's format to
+        a bare default and swallows the keypress whenever the cursor
+        is on an empty block whose format isn't already default. That
+        heuristic exists so rich-text users can hit Enter twice to
+        escape a list/heading/quote, but every block here always
+        carries a non-default line height, so it fires on every
+        ordinary blank-line paragraph break and silently eats every
+        second Return. novelWriter never uses Qt's native list/heading
+        block formatting, so the heuristic serves no purpose here, and
+        can be bypassed entirely by inserting the new block directly.
+        """
+        if event.key() in self.ENTER_KEYS and event.modifiers() == QtModNone:
+            cursor = self.textCursor()
+            cursor.insertBlock()
+            self.setTextCursor(cursor)
+            self.ensureCursorVisible(centre=False)
+            event.accept()
+        else:
+            super().keyPressEvent(event)
 
     def _applyExtraSelections(self) -> None:
         """Set the editor's extra selections from the line highlight

--- a/novelwriter/gui/doceditor.py
+++ b/novelwriter/gui/doceditor.py
@@ -116,6 +116,16 @@ from novelwriter.types import (
     QtImCurrentSelection,
     QtImCursorRectangle,
     QtKeepAnchor,
+    QtKeyDown,
+    QtKeyEnter,
+    QtKeyEscape,
+    QtKeyLeft,
+    QtKeyPageDown,
+    QtKeyPageUp,
+    QtKeyReturn,
+    QtKeyRight,
+    QtKeyTab,
+    QtKeyUp,
     QtModCtrl,
     QtModNone,
     QtModShift,
@@ -214,15 +224,8 @@ class GuiDocEditor(QTextEdit):
         "_wCounterSel",
     )
 
-    MOVE_KEYS = (
-        Qt.Key.Key_Left,
-        Qt.Key.Key_Right,
-        Qt.Key.Key_Up,
-        Qt.Key.Key_Down,
-        Qt.Key.Key_PageUp,
-        Qt.Key.Key_PageDown,
-    )
-    ENTER_KEYS = (Qt.Key.Key_Return, Qt.Key.Key_Enter)
+    MOVE_KEYS = (QtKeyLeft, QtKeyRight, QtKeyUp, QtKeyDown, QtKeyPageUp, QtKeyPageDown)
+    ENTER_KEYS = (QtKeyReturn, QtKeyEnter)
 
     # Custom Signals
     closeEditorRequest = pyqtSignal()
@@ -2958,27 +2961,27 @@ class CommandCompleter(QMenu):
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Capture keypresses and forward most of them to the editor."""
-        match event.key():
-            case Qt.Key.Key_Up | Qt.Key.Key_Down:
-                # Let the menu handle navigation
-                super().keyPressEvent(event)
-            case Qt.Key.Key_Right | Qt.Key.Key_Return | Qt.Key.Key_Enter | Qt.Key.Key_Tab:
-                # Activate the selection if there is one, otherwise close the completer
-                if action := self.activeAction():
-                    action.trigger()
-                else:
-                    self.clear()
-                    self.close()
-            case Qt.Key.Key_Left | Qt.Key.Key_Escape:
-                # Cancel the completer
+        key = event.key()
+        if key in (QtKeyUp, QtKeyDown):
+            # Let the menu handle navigation
+            super().keyPressEvent(event)
+        elif key in (QtKeyRight, QtKeyReturn, QtKeyEnter, QtKeyTab):
+            # Activate the selection if there is one, otherwise close the completer
+            if action := self.activeAction():
+                action.trigger()
+            else:
                 self.clear()
                 self.close()
-            case _:
-                # Any other keys, send back to the editor
-                # Also close to release the event lock before forwarding key press (#2510)
-                self.clear()
-                self.close()
-                self._parent.keyPressEvent(event)
+        elif key in (QtKeyLeft, QtKeyEscape):
+            # Cancel the completer
+            self.clear()
+            self.close()
+        else:
+            # Any other keys, send back to the editor
+            # Also close to release the event lock before forwarding key press (#2510)
+            self.clear()
+            self.close()
+            self._parent.keyPressEvent(event)
 
     ##
     #  Internal Slots

--- a/novelwriter/gui/docviewer.py
+++ b/novelwriter/gui/docviewer.py
@@ -227,6 +227,7 @@ class GuiDocViewer(QTextBrowser):
         qDoc.setJustify(CONFIG.doJustify, False)
         qDoc.setDialogHighlight(True)
         qDoc.setTextFont(CONFIG.textFont)
+        qDoc.setLineHeight(CONFIG.lineHeight)
         qDoc.setTheme(self._docTheme)
         qDoc.initDocument()
         qDoc.setKeywords(True)

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -101,27 +101,11 @@ class GuiTextDocument(QTextDocument):
         logger.debug("Highlighted document in %.3f ms", 1000 * (tEnd - tMid))
 
     def setLineHeight(self, height: float) -> None:
-        """Apply a line height to all blocks in the document.
-
-        The last block is deliberately excluded. Merging a block
-        format onto the block a live QTextCursor currently occupies
-        corrupts the following Return keypress (it silently fails to
-        split the block) for reasons that trace into Qt/PyQt6
-        internals rather than anything in this codebase. The excluded
-        block keeps its old height until the document is reloaded, or
-        until more text is added after it and this is called again.
-        """
-        end = self.lastBlock().position() - 1
-        if end <= 0:
-            # Single-block document: there is nothing to select before
-            # the last (and only) block, so it can't be touched safely
-            return
-
+        """Apply a line height to all blocks in the document."""
         blockFormat = QTextBlockFormat()
         blockFormat.setLineHeight(int(height * 100), QtPropLineHeight)
         cursor = QTextCursor(self)
-        cursor.setPosition(0)
-        cursor.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
+        cursor.select(QTextCursor.SelectionType.Document)
         cursor.mergeBlockFormat(blockFormat)
 
     def metaDataAtPos(self, pos: int) -> tuple[str, str]:

--- a/novelwriter/gui/editordocument.py
+++ b/novelwriter/gui/editordocument.py
@@ -26,12 +26,13 @@ import logging
 from time import time
 from typing import TYPE_CHECKING
 
-from PyQt6.QtGui import QTextBlock, QTextCursor, QTextDocument
+from PyQt6.QtGui import QTextBlock, QTextBlockFormat, QTextCursor, QTextDocument
 from PyQt6.QtWidgets import QApplication
 
-from novelwriter import SHARED
+from novelwriter import CONFIG, SHARED
 from novelwriter.gui.dochighlight import GuiDocHighlighter
 from novelwriter.gui.doctextblock import TextBlockData
+from novelwriter.types import QtPropLineHeight
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -84,6 +85,7 @@ class GuiTextDocument(QTextDocument):
         tStart = time()
 
         self.setPlainText(text)
+        self.setLineHeight(CONFIG.lineHeight)
         count = self.lineCount()
 
         tMid = time()
@@ -97,6 +99,30 @@ class GuiTextDocument(QTextDocument):
 
         logger.debug("Loaded %d text blocks in %.3f ms", count, 1000 * (tMid - tStart))
         logger.debug("Highlighted document in %.3f ms", 1000 * (tEnd - tMid))
+
+    def setLineHeight(self, height: float) -> None:
+        """Apply a line height to all blocks in the document.
+
+        The last block is deliberately excluded. Merging a block
+        format onto the block a live QTextCursor currently occupies
+        corrupts the following Return keypress (it silently fails to
+        split the block) for reasons that trace into Qt/PyQt6
+        internals rather than anything in this codebase. The excluded
+        block keeps its old height until the document is reloaded, or
+        until more text is added after it and this is called again.
+        """
+        end = self.lastBlock().position() - 1
+        if end <= 0:
+            # Single-block document: there is nothing to select before
+            # the last (and only) block, so it can't be touched safely
+            return
+
+        blockFormat = QTextBlockFormat()
+        blockFormat.setLineHeight(int(height * 100), QtPropLineHeight)
+        cursor = QTextCursor(self)
+        cursor.setPosition(0)
+        cursor.setPosition(end, QTextCursor.MoveMode.KeepAnchor)
+        cursor.mergeBlockFormat(blockFormat)
 
     def metaDataAtPos(self, pos: int) -> tuple[str, str]:
         """Check if there is meta data available at a given position in

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -52,6 +52,8 @@ from novelwriter.types import (
     QtHeaderStretch,
     QtHeaderToContents,
     QtHexArgb,
+    QtKeyDown,
+    QtKeyUp,
     QtModShift,
     QtUserRole,
 )
@@ -231,15 +233,11 @@ class GuiProjectSearch(QWidget):
         """Process key press events. This handles up and down arrow key
         presses to jump between search text box and result tree.
         """
-        if (
-            event.key() == Qt.Key.Key_Down
-            and self.searchText.hasFocus()
-            and (first := self.searchResult.topLevelItem(0))
-        ):
+        if event.key() == QtKeyDown and self.searchText.hasFocus() and (first := self.searchResult.topLevelItem(0)):
             first.setSelected(True)
             self.searchResult.setFocus()
         elif (
-            event.key() == Qt.Key.Key_Up
+            event.key() == QtKeyUp
             and self.searchResult.hasFocus()
             and (first := self.searchResult.topLevelItem(0))
             and first.isSelected()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -46,7 +46,7 @@ from novelwriter import CONFIG, SHARED, __hexversion__, __version__
 from novelwriter.common import formatFileFilter, formatVersion, hexToInt, minmax, safeIsFile
 from novelwriter.constants import nwConst
 from novelwriter.dialogs.about import GuiAbout
-from novelwriter.dialogs.preferences import GuiPreferences
+from novelwriter.dialogs.preferences import GuiNeedsUpdate, GuiPreferences
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
 from novelwriter.dialogs.wordlist import GuiWordList
 from novelwriter.enum import nwDocAction, nwDocInsert, nwDocMode, nwFocus, nwItemType, nwView, nwVimMode
@@ -1040,23 +1040,25 @@ class GuiMain(QMainWindow):
             self._changeView(nwView.OUTLINE, exitFocus=True)
             self.outlineView.setTreeFocus()
 
-    @pyqtSlot(bool, bool, bool, bool)
-    def _processConfigChanges(self, restart: bool, tree: bool, theme: bool, syntax: bool) -> None:
+    @pyqtSlot(GuiNeedsUpdate)
+    def _processConfigChanges(self, updateFlags: GuiNeedsUpdate) -> None:
         """Refresh GUI based on flags from the Preferences dialog."""
         logger.debug("Applying new preferences")
         self.initMain()
         self.saveDocument()
 
-        if tree and not theme:
+        if updateFlags.tree and not updateFlags.theme:
             # These are also updated by a theme refresh
             SHARED.project.tree.refreshAllItems()
             self.novelView.refreshCurrentTree()
 
-        if theme:
-            self.refreshThemeColors(syntax=syntax, force=True)
+        if updateFlags.theme:
+            self.refreshThemeColors(syntax=updateFlags.syntax, force=True)
+        if updateFlags.editor or updateFlags.theme:
+            self.docEditor.initEditor()
+        if updateFlags.viewer or updateFlags.theme:
+            self.docViewer.initViewer()
 
-        self.docEditor.initEditor()
-        self.docViewer.initViewer()
         self.projView.initSettings()
         self.novelView.initSettings()
         self.outlineView.initSettings()
@@ -1066,7 +1068,7 @@ class GuiMain(QMainWindow):
         self._lastTotalCount = 0
         self._updateStatusWordCount()
 
-        if restart:
+        if updateFlags.restart:
             SHARED.info(self.tr("Some changes will not be applied until novelWriter has been restarted."))
 
     @pyqtSlot()

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -60,6 +60,10 @@ from novelwriter.types import (
     QtAlignRightTop,
     QtDisplayRole,
     QtHexArgb,
+    QtKeyDown,
+    QtKeyEnter,
+    QtKeyReturn,
+    QtKeyUp,
     QtScrollAsNeeded,
     QtSelected,
 )
@@ -286,7 +290,7 @@ class _OpenProjectPage(QWidget):
         self._trPath = self.tr("Path")
 
         self.keyEnter = QShortcut(self.listWidget)
-        self.keyEnter.setKeys([Qt.Key.Key_Enter, Qt.Key.Key_Return])
+        self.keyEnter.setKeys([QtKeyEnter, QtKeyReturn])
         self.keyEnter.setContext(Qt.ShortcutContext.WidgetShortcut)
         self.keyEnter.activated.connect(self.openSelectedItem)
 
@@ -318,7 +322,7 @@ class _OpenProjectPage(QWidget):
 
     def keyPressEvent(self, event: QKeyEvent | None) -> None:
         """Capture key press events."""
-        if event and event.key() in (Qt.Key.Key_Up, Qt.Key.Key_Down):
+        if event and event.key() in (QtKeyUp, QtKeyDown):
             self.listWidget.setFocus()
             self.listWidget.keyPressEvent(event)
         else:

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -165,6 +165,20 @@ QtFontNormal = QFont.Weight.Normal
 QtFontSemiBold = QFont.Weight.DemiBold
 QtFontBold = QFont.Weight.Bold
 
+# Keys
+
+QtKeyReturn = Qt.Key.Key_Return
+QtKeyEnter = Qt.Key.Key_Enter
+QtKeyLeft = Qt.Key.Key_Left
+QtKeyRight = Qt.Key.Key_Right
+QtKeyUp = Qt.Key.Key_Up
+QtKeyDown = Qt.Key.Key_Down
+QtKeyPageUp = Qt.Key.Key_PageUp
+QtKeyPageDown = Qt.Key.Key_PageDown
+QtKeyTab = Qt.Key.Key_Tab
+QtKeyEscape = Qt.Key.Key_Escape
+QtKeyBackspace = Qt.Key.Key_Backspace
+
 # Maps
 
 FONT_WEIGHTS: dict[int, int] = {

--- a/tests/reference/baseConfig_novelwriter.conf
+++ b/tests/reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2026-04-11 16:07:17
+timestamp = 2026-07-06 15:09:36
 
 [Main]
 font = 
@@ -42,6 +42,7 @@ textfont =
 width = 700
 margin = 40
 tabwidth = 40
+lineheight = 1.0
 cursorwidth = 1
 linehighlight = False
 focuswidth = 800

--- a/tests/test_dialogs/test_preferences.py
+++ b/tests/test_dialogs/test_preferences.py
@@ -31,11 +31,11 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_TREECOL
 from novelwriter.constants import nwUnicode
 from novelwriter.core.spellcheck import NWSpellEnchant
-from novelwriter.dialogs.preferences import GuiPreferences
+from novelwriter.dialogs.preferences import GuiNeedsUpdate, GuiPreferences
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 from novelwriter.extensions.modified import NFontDialog
 from novelwriter.gui.theme import ThemeEntry
-from novelwriter.types import QtModNone
+from novelwriter.types import QtKeyEscape, QtModNone
 
 KEY_DELAY = 1
 
@@ -122,7 +122,8 @@ def testDlgPreferences_Actions(qtbot, monkeypatch, nwGUI):
     prefs.show()
     with qtbot.waitSignal(prefs.newPreferencesReady) as signal:
         prefs.btnSave.click()
-        assert len(signal.args) == 4
+        assert len(signal.args) == 1
+        assert isinstance(signal.args[0], GuiNeedsUpdate)
 
     # Check Close Button
     prefs.show()
@@ -131,7 +132,7 @@ def testDlgPreferences_Actions(qtbot, monkeypatch, nwGUI):
 
     # Close Using Escape Key
     prefs.show()
-    event = QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Escape, QtModNone)
+    event = QKeyEvent(QEvent.Type.KeyPress, QtKeyEscape, QtModNone)
     prefs.keyPressEvent(event)
     assert prefs.isHidden() is True
 
@@ -387,7 +388,9 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
         mp.setattr(QFontDatabase, "families", lambda *a: ["TestFont"])
         with qtbot.waitSignal(prefs.newPreferencesReady) as signal:
             prefs.btnSave.click()
-            assert signal.args == [True, True, True, True]
+            assert signal.args == [
+                GuiNeedsUpdate(restart=True, tree=True, theme=True, syntax=True, editor=True, viewer=True)
+            ]
 
     # Check Settings
     # ==============

--- a/tests/test_dialogs/test_preferences.py
+++ b/tests/test_dialogs/test_preferences.py
@@ -257,6 +257,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     prefs.doJustify.setChecked(True)
     prefs.textMargin.stepUp()
     prefs.tabWidth.stepUp()
+    prefs.lineHeight.stepUp()
 
     assert CONFIG.textWidth == 700
     assert CONFIG.focusWidth == 800
@@ -264,6 +265,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.doJustify is False
     assert CONFIG.textMargin == 40
     assert CONFIG.tabWidth == 40
+    assert CONFIG.lineHeight == 1.0
 
     # Text Editing
     prefs.spellLanguage.setCurrentIndex(prefs.spellLanguage.findData("de"))
@@ -431,6 +433,7 @@ def testDlgPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     assert CONFIG.doJustify is True
     assert CONFIG.textMargin == 41
     assert CONFIG.tabWidth == 41
+    assert CONFIG.lineHeight == 1.05
 
     # Text Editing
     assert CONFIG.spellLanguage == "de"

--- a/tests/test_ext/test_modified.py
+++ b/tests/test_ext/test_modified.py
@@ -42,7 +42,7 @@ from novelwriter.extensions.modified import (
     NToolDialog,
     NTreeView,
 )
-from novelwriter.types import QtModNone, QtMouseLeft, QtMouseMiddle, QtRejected
+from novelwriter.types import QtKeyEscape, QtModNone, QtMouseLeft, QtMouseMiddle, QtRejected
 
 from tests.tools import SimpleDialog
 
@@ -77,7 +77,7 @@ def testExtModified_NDialog(qtbot, monkeypatch):
     assert dialog.parent() is None
 
     with qtbot.waitSignal(dialog.rejected, timeout=1000):
-        dialog.keyPressEvent(QKeyEvent(QEvent.Type.KeyPress, Qt.Key.Key_Escape, QtModNone))
+        dialog.keyPressEvent(QKeyEvent(QEvent.Type.KeyPress, QtKeyEscape, QtModNone))
         assert dialog.result() == QtRejected
 
 

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -2635,6 +2635,41 @@ def testGuiEditor_TypewriterScrolling(qtbot, nwGUI, projPath, mockRnd):
 
 
 @pytest.mark.gui
+def testGuiEditor_LineHeight(qtbot, nwGUI, projPath, mockRnd):
+    """Test that CONFIG.lineHeight is applied to all blocks in the
+    document, both on load and when settings are refreshed. The last
+    block is deliberately excluded (see setLineHeight docstring) and
+    keeps its previous height until the document is reloaded.
+    """
+    buildTestProject(nwGUI, projPath)
+    docEditor = nwGUI.docEditor
+    document = docEditor.document()
+
+    def blocksExceptLastHaveLineHeight(height: int) -> bool:
+        block = document.firstBlock()
+        last = document.lastBlock()
+        while block.isValid() and block != last:
+            if block.blockFormat().lineHeight() != height:
+                return False
+            block = block.next()
+        return True
+
+    CONFIG.lineHeight = 1.50
+    assert docEditor.loadText(C.hSceneDoc) is True
+    assert blocksExceptLastHaveLineHeight(150)
+
+    CONFIG.lineHeight = 2.00
+    docEditor.initEditor()
+    assert blocksExceptLastHaveLineHeight(200)
+    assert document.lastBlock().blockFormat().lineHeight() == 0.0
+
+    # A fresh reload picks up the current height for all blocks except
+    # whatever is the last one at that point
+    assert docEditor.loadText(C.hSceneDoc) is True
+    assert blocksExceptLastHaveLineHeight(200)
+
+
+@pytest.mark.gui
 def testGuiEditor_CursorVisibility(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test the custom ensure cursor visible feature."""
     buildTestProject(nwGUI, projPath)

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -2637,18 +2637,15 @@ def testGuiEditor_TypewriterScrolling(qtbot, nwGUI, projPath, mockRnd):
 @pytest.mark.gui
 def testGuiEditor_LineHeight(qtbot, nwGUI, projPath, mockRnd):
     """Test that CONFIG.lineHeight is applied to all blocks in the
-    document, both on load and when settings are refreshed. The last
-    block is deliberately excluded (see setLineHeight docstring) and
-    keeps its previous height until the document is reloaded.
+    document, both on load and when settings are refreshed.
     """
     buildTestProject(nwGUI, projPath)
     docEditor = nwGUI.docEditor
     document = docEditor.document()
 
-    def blocksExceptLastHaveLineHeight(height: int) -> bool:
+    def allBlocksHaveLineHeight(height: int) -> bool:
         block = document.firstBlock()
-        last = document.lastBlock()
-        while block.isValid() and block != last:
+        while block.isValid():
             if block.blockFormat().lineHeight() != height:
                 return False
             block = block.next()
@@ -2656,17 +2653,35 @@ def testGuiEditor_LineHeight(qtbot, nwGUI, projPath, mockRnd):
 
     CONFIG.lineHeight = 1.50
     assert docEditor.loadText(C.hSceneDoc) is True
-    assert blocksExceptLastHaveLineHeight(150)
+    assert allBlocksHaveLineHeight(150)
 
     CONFIG.lineHeight = 2.00
     docEditor.initEditor()
-    assert blocksExceptLastHaveLineHeight(200)
-    assert document.lastBlock().blockFormat().lineHeight() == 0.0
+    assert allBlocksHaveLineHeight(200)
 
-    # A fresh reload picks up the current height for all blocks except
-    # whatever is the last one at that point
+
+@pytest.mark.gui
+def testGuiEditor_LineHeightDoubleReturn(qtbot, nwGUI, projPath, mockRnd):
+    """Test that a blank-line paragraph break (two consecutive Return
+    presses) works normally with a non-default line height set on
+    every block. Qt's own Return handling otherwise treats the second
+    Return, landing on an empty block whose format isn't bare default,
+    as a request to reset the block back to default formatting instead
+    of inserting a new one (meant for escaping list/heading formatting
+    in rich-text editors), silently eating the keypress.
+    """
+    buildTestProject(nwGUI, projPath)
+    docEditor = nwGUI.docEditor
+
+    CONFIG.lineHeight = 1.50
     assert docEditor.loadText(C.hSceneDoc) is True
-    assert blocksExceptLastHaveLineHeight(200)
+
+    qtbot.keyClicks(docEditor, "# Heading")
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClicks(docEditor, "Body text.")
+
+    assert docEditor.getText().startswith("# Heading\n\nBody text.")
 
 
 @pytest.mark.gui

--- a/tests/test_gui/test_doceditor.py
+++ b/tests/test_gui/test_doceditor.py
@@ -62,6 +62,11 @@ from novelwriter.types import (
     QtImCurrentSelection,
     QtImCursorRectangle,
     QtKeepAnchor,
+    QtKeyBackspace,
+    QtKeyDown,
+    QtKeyEscape,
+    QtKeyReturn,
+    QtKeyTab,
     QtModCtrl,
     QtModNone,
     QtMouseLeft,
@@ -2437,8 +2442,8 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     nwGUI.docEditor.setFocus()
     for c in "### Scene One":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Type Keyword @
     qtbot.keyClick(docEditor, "@", delay=KEY_DELAY)
@@ -2453,7 +2458,7 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     assert len(completer.actions()) == 0
 
     # Delete character and go select @char
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
     assert len(completer.actions()) == 2
     completer.actions()[0].trigger()
     assert docEditor.getText() == ("### Scene One\n\n@char:")
@@ -2467,7 +2472,7 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     assert [a.text() for a in completer.actions()] == []
 
     # Deleting it and typing "a", should leave "Jane"
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
     qtbot.keyClick(docEditor, "a", delay=KEY_DELAY)
     assert [a.text() for a in completer.actions()] == ["Jane"]
 
@@ -2481,70 +2486,70 @@ def testGuiEditor_Completer(qtbot, nwGUI, projPath, mockRnd):
     assert [a.text() for a in completer.actions()] == ["Jane", "John"]
 
     # Pressing return without selecting anything should just close it
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyReturn, delay=KEY_DELAY)
     assert [a.text() for a in completer.actions()] == []
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
 
     # Start a new line with a nonsense keyword, which should be handled
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@: ":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
 
     # Send keypresses to the completer object
     qtbot.keyClick(docEditor, "@", delay=KEY_DELAY)
     assert len(completer.actions()) == len(nwKeyWords.VALID_KEYS)
     qtbot.keyClick(completer, "f", delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyReturn, delay=KEY_DELAY)
     qtbot.keyClick(completer, " ", delay=KEY_DELAY)
     qtbot.keyClick(completer, "h", delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Escape, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyEscape, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     assert docEditor.getText() == ("### Scene One\n\n@char: Jane\n@focus: John\n")
 
     # Send keypresses to the completer object for a comment
     qtbot.keyClick(docEditor, "%", delay=KEY_DELAY)
     assert len(completer.actions()) == 4
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     assert docEditor.getText() == ("### Scene One\n\n@char: Jane\n@focus: John\n%Synopsis: \n")
 
     # Auto-complete story comment
     SHARED.project.index._itemIndex._cache.story.add("Resolution")
     qtbot.keyClick(docEditor, "%", delay=KEY_DELAY)
     assert len(completer.actions()) == 4
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyReturn, delay=KEY_DELAY)
     qtbot.keyClick(completer, ".", delay=KEY_DELAY)
     assert len(completer.actions()) == 1
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     assert docEditor.getText() == ("### Scene One\n\n@char: Jane\n@focus: John\n%Synopsis: \n%Story.Resolution: \n")
 
     # Auto-complete note comment, but select with Tab
     SHARED.project.index._itemIndex._cache.note.add("Consistency")
     qtbot.keyClick(docEditor, "%", delay=KEY_DELAY)
     assert len(completer.actions()) == 4
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Tab, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyTab, delay=KEY_DELAY)
     qtbot.keyClick(completer, ".", delay=KEY_DELAY)
     assert len(completer.actions()) == 1
-    qtbot.keyClick(completer, Qt.Key.Key_Down, delay=KEY_DELAY)
-    qtbot.keyClick(completer, Qt.Key.Key_Tab, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyDown, delay=KEY_DELAY)
+    qtbot.keyClick(completer, QtKeyTab, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     assert docEditor.getText() == (
         "### Scene One\n\n@char: Jane\n@focus: John\n%Synopsis: \n%Story.Resolution: \n%Note.Consistency: \n"
     )
@@ -2628,7 +2633,7 @@ def testGuiEditor_TypewriterScrolling(qtbot, nwGUI, projPath, mockRnd):
     # newlines, which advances the cursor without hitting the MOVE_KEYS
     # exclusion used for arrow-key navigation
     for _ in range(30):
-        qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+        qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     qtbot.wait(200)  # Let the scroll animation finish
     assert vBar.value() > 0
@@ -2677,8 +2682,8 @@ def testGuiEditor_LineHeightDoubleReturn(qtbot, nwGUI, projPath, mockRnd):
     assert docEditor.loadText(C.hSceneDoc) is True
 
     qtbot.keyClicks(docEditor, "# Heading")
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     qtbot.keyClicks(docEditor, "Body text.")
 
     assert docEditor.getText().startswith("# Heading\n\nBody text.")
@@ -2892,7 +2897,7 @@ def testGuiEditor_Search(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     # Find next by enter key
     monkeypatch.setattr(docSearch.searchBox, "hasFocus", lambda: True)
-    qtbot.keyClick(docSearch.searchBox, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docSearch.searchBox, QtKeyReturn, delay=KEY_DELAY)
     assert abs(docEditor.getCursorPosition() - 1317) < 3
 
     # Find next by button
@@ -3346,7 +3351,7 @@ def testGuiEditor_Vim_EnableVimMode(qtbot, nwGUI, projPath, mockRnd):
     # Enter insert mode with "i"
     qtbot.keyClick(docEditor, "i", delay=inputDelay)
     qtbot.keyClicks(docEditor, "TEST", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape)
+    qtbot.keyClick(docEditor, QtKeyEscape)
 
     # Text must have changed now
     new_text = docEditor.getText()
@@ -3394,17 +3399,17 @@ def testGuiEditor_Vim_InsertMode(qtbot, nwGUI, projPath, mockRnd):
     resetText()
     qtbot.keyClick(docEditor, "i", delay=inputDelay)
     qtbot.keyClicks(docEditor, "X", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape)
+    qtbot.keyClick(docEditor, QtKeyEscape)
     assert "X" in docEditor.getText()
 
     # I: Insert at beginning of line
     resetText()
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape)
+    qtbot.keyClick(docEditor, QtKeyEscape)
     qtbot.keyClick(docEditor, "h", delay=inputDelay)  # Move forward 1
     qtbot.keyClick(docEditor, "h", delay=inputDelay)  # Move forward 1
     qtbot.keyClick(docEditor, "I", delay=inputDelay)
     qtbot.keyClicks(docEditor, "START", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape)
+    qtbot.keyClick(docEditor, QtKeyEscape)
     lines = docEditor.getText().splitlines()
     assert lines[0].startswith("START")
 
@@ -3412,7 +3417,7 @@ def testGuiEditor_Vim_InsertMode(qtbot, nwGUI, projPath, mockRnd):
     resetText()
     qtbot.keyClick(docEditor, "A", delay=inputDelay)
     qtbot.keyClicks(docEditor, "END", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape)
+    qtbot.keyClick(docEditor, QtKeyEscape)
     lines = docEditor.getText().splitlines()
     assert lines[0].endswith("END")
 
@@ -3420,7 +3425,7 @@ def testGuiEditor_Vim_InsertMode(qtbot, nwGUI, projPath, mockRnd):
     resetText()
     qtbot.keyClick(docEditor, "o", delay=inputDelay)
     qtbot.keyClicks(docEditor, "below", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape)
+    qtbot.keyClick(docEditor, QtKeyEscape)
     lines = docEditor.getText().splitlines()
     assert "below" in lines[1]  # Inserted after Line1
 
@@ -3428,7 +3433,7 @@ def testGuiEditor_Vim_InsertMode(qtbot, nwGUI, projPath, mockRnd):
     resetText()
     qtbot.keyClick(docEditor, "O", delay=inputDelay)
     qtbot.keyClicks(docEditor, "above", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape)
+    qtbot.keyClick(docEditor, QtKeyEscape)
     lines = docEditor.getText().splitlines()
     assert "above" in lines[0]  # Inserted before Line1
 
@@ -3439,21 +3444,21 @@ def testGuiEditor_Vim_InsertMode(qtbot, nwGUI, projPath, mockRnd):
     resetText()
     qtbot.keyClick(docEditor, "i", delay=inputDelay)
     qtbot.keyClicks(docEditor, "TEST", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape, delay=inputDelay)
+    qtbot.keyClick(docEditor, QtKeyEscape, delay=inputDelay)
     assert "TEST" in docEditor.getText()
 
     # aX: Append after cursor
     resetText()
     qtbot.keyClick(docEditor, "a", delay=inputDelay)
     qtbot.keyClicks(docEditor, "X", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape, delay=inputDelay)
+    qtbot.keyClick(docEditor, QtKeyEscape, delay=inputDelay)
     assert "X" in docEditor.getText()
 
     # New line below
     resetText()
     qtbot.keyClick(docEditor, "o", delay=inputDelay)
     qtbot.keyClicks(docEditor, "below", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape, delay=inputDelay)
+    qtbot.keyClick(docEditor, QtKeyEscape, delay=inputDelay)
     lines = docEditor.getText().splitlines()
     assert "below" in lines[1]
 
@@ -3461,7 +3466,7 @@ def testGuiEditor_Vim_InsertMode(qtbot, nwGUI, projPath, mockRnd):
     resetText()
     qtbot.keyClick(docEditor, "O", delay=inputDelay)
     qtbot.keyClicks(docEditor, "above", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape, delay=inputDelay)
+    qtbot.keyClick(docEditor, QtKeyEscape, delay=inputDelay)
     lines = docEditor.getText().splitlines()
     assert "above" in lines[0]
 
@@ -3848,7 +3853,7 @@ def testGuiEditor_Vim_NormalMode(qtbot, nwGUI, projPath, mockRnd):
     assert cursorPos == 1
     # Insert some text
     qtbot.keyClicks(docEditor, "TEST", delay=inputDelay)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Escape, delay=inputDelay)
+    qtbot.keyClick(docEditor, QtKeyEscape, delay=inputDelay)
     newText = docEditor.getText()
     assert newText.startswith(("LTESSTine1", "LTESTine1"))
 

--- a/tests/test_gui/test_guimain.py
+++ b/tests/test_gui/test_guimain.py
@@ -48,7 +48,16 @@ from novelwriter.shared import _GuiAlert
 from novelwriter.tools.manuscript import GuiManuscript
 from novelwriter.tools.welcome import GuiWelcome
 from novelwriter.tools.writingstats import GuiWritingStats
-from novelwriter.types import QtModCtrl, QtModShift
+from novelwriter.types import (
+    QtKeyBackspace,
+    QtKeyEnter,
+    QtKeyEscape,
+    QtKeyLeft,
+    QtKeyReturn,
+    QtKeyRight,
+    QtModCtrl,
+    QtModShift,
+)
 
 from tests.mocked import causeOSError
 from tests.tools import NWD_IGNORE, XML_IGNORE, C, buildTestProject, cmpFiles
@@ -386,15 +395,15 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Jane Doe":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@tag: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "This is a file about Jane.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Add a Plot File
     nwGUI.projView.projTree.expandAll()
@@ -409,15 +418,15 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Main Plot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@tag: MainPlot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "This is a file [i]detailing[/i] the main plot.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Add a World File
     nwGUI.projView.projTree.expandAll()
@@ -437,15 +446,15 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Main Location":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@tag: Home":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "This is a file describing Jane's home.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Trigger autosaves before making more changes
     nwGUI._autoSaveDocument()
@@ -462,64 +471,64 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     qtbot.keyClick(docEditor, "a", modifier=QtModCtrl, delay=KEY_DELAY)
     for c in "# Novel":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "## Chapter":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "@pov: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@plot: MainPlot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "### Scene":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "% How about a comment?":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@pov: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@plot: MainPlot":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
     for c in "@location: Home":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "#### Some Section":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "@char: Jane":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "This is a paragraph of nonsense text.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Don't allow Shift+Enter to insert a line separator (issue #1150)
     for c in "This is another paragraph":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Enter, modifier=QtModShift, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyEnter, modifier=QtModShift, delay=KEY_DELAY)
     for c in "with a line separator in it.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Auto-Replace
     # ============
@@ -540,36 +549,36 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
     for c in "How about three hyphens - -":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Left, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Right, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyLeft, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyRight, delay=KEY_DELAY)
     for c in "- for long dash? It works too. ":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
     for c in "Even four hyphens - - -":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Left, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Left, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Backspace, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Right, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Right, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyLeft, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyLeft, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyBackspace, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyRight, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyRight, delay=KEY_DELAY)
     for c in "- for a horizontal works!":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Dialogue
     # ========
 
     for c in '"Full line double quoted text."':
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "'Full line single quoted text.'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Insert spaces before and after quotes
     CONFIG.fmtPadBefore = "\u201d"
@@ -581,16 +590,16 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     # Check that we can insert a line break in the text without
     # triggering the padding (Issue #2586)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Left, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Left, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Left, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Right, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Right, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Right, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyLeft, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyLeft, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyLeft, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyRight, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyRight, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyRight, delay=KEY_DELAY)
 
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     CONFIG.fmtPadBefore = ""
     CONFIG.fmtPadAfter = ""
@@ -599,8 +608,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     # Dialogue Line
     for c in "-- Hi, I am a character speaking.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Narrator Break
     CONFIG.narratorBreak = "–"
@@ -609,8 +618,8 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     for c in "-- Hi, I am also a character speaking, -- said another character. -- How are you?":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     # Special Formatting
     # ==================
@@ -621,28 +630,28 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
 
     for c in "@object: NoSpaceAdded":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "% synopsis: Space before this is OK.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "%Footnote.abc: A simple footnote.":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "Add space before this colon: See?":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "But don't add a double space : See?":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     CONFIG.fmtPadBefore = ""
     docEditor.initEditor()
@@ -653,33 +662,33 @@ def testGuiMain_Editing(qtbot, monkeypatch, nwGUI, projPath, tstPaths, mockRnd):
     nwGUI._switchFocus(nwView.EDITOR)
     for c in '\t"Tab-indented text"':
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in '>"Paragraph-indented text"':
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in '>>"Right-aligned text"':
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in "\t'Tab-indented text'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in ">'Paragraph-indented text'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     for c in ">>'Right-aligned text'":
         qtbot.keyClick(docEditor, c, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
-    qtbot.keyClick(docEditor, Qt.Key.Key_Return, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
+    qtbot.keyClick(docEditor, QtKeyReturn, delay=KEY_DELAY)
 
     docEditor._wCounterDoc.run()
 
@@ -799,7 +808,7 @@ def testGuiMain_Viewing(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     nwGUI.projView.setSelectedHandle(C.hSceneDoc)
     with monkeypatch.context() as mp:
         mp.setattr(nwGUI.projView.projTree, "hasFocus", lambda *a: True)
-        qtbot.keyClick(nwGUI.projView.projTree, Qt.Key.Key_Return, modifier=QtModShift, delay=KEY_DELAY)
+        qtbot.keyClick(nwGUI.projView.projTree, QtKeyReturn, modifier=QtModShift, delay=KEY_DELAY)
     assert nwGUI.docViewer.docHandle == C.hSceneDoc
 
     # If the viewer fails to load the document, nothing else happens
@@ -898,14 +907,14 @@ def testGuiMain_Features(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     # Pressing Escape turns off focus mode
     nwGUI.toggleFocusMode()
     assert SHARED.focusMode is True
-    qtbot.keyClick(nwGUI, Qt.Key.Key_Escape)
+    qtbot.keyClick(nwGUI, QtKeyEscape)
     assert SHARED.focusMode is False
 
     # If search is active, Escape is redirected to editor
     nwGUI.toggleFocusMode()
     assert SHARED.focusMode is True
     nwGUI.docEditor.beginSearch()
-    qtbot.keyClick(nwGUI, Qt.Key.Key_Escape)
+    qtbot.keyClick(nwGUI, QtKeyEscape)
     assert SHARED.focusMode is True
 
     # With search closed, Vim mode off, and Focus Mode inactive, Escape

--- a/tests/test_gui/test_guimain.py
+++ b/tests/test_gui/test_guimain.py
@@ -38,6 +38,7 @@ from novelwriter.common import jsonEncode
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT
 from novelwriter.constants import nwFiles
 from novelwriter.dialogs.editlabel import GuiEditLabel
+from novelwriter.dialogs.preferences import GuiNeedsUpdate
 from novelwriter.enum import nwDocAction, nwDocMode, nwFocus, nwItemClass, nwItemType, nwState, nwTheme, nwView
 from novelwriter.gui.doceditor import GuiDocEditor
 from novelwriter.gui.noveltree import GuiNovelView
@@ -284,8 +285,8 @@ def testGuiMain_UpdateTheme(qtbot, nwGUI):
     theme.loadTheme()
     assert theme.isDarkTheme is True
 
-    nwGUI._processConfigChanges(False, True, False, False)
-    nwGUI._processConfigChanges(True, True, True, True)
+    nwGUI._processConfigChanges(GuiNeedsUpdate(False, True, False, False, False, False))
+    nwGUI._processConfigChanges(GuiNeedsUpdate(True, True, True, True, True, True))
 
     # Check editor syntax
     syntax = SHARED.theme.syntaxTheme

--- a/tests/test_gui/test_search.py
+++ b/tests/test_gui/test_search.py
@@ -30,6 +30,7 @@ from PyQt6.QtGui import QAction
 
 from novelwriter.enum import nwChange, nwDocMode, nwView
 from novelwriter.gui.search import GuiProjectSearch
+from novelwriter.types import QtKeyDown, QtKeyReturn, QtKeyRight, QtKeyUp
 
 
 @pytest.mark.gui
@@ -60,15 +61,15 @@ def testGuiDocSearch_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
 
     # Move down
     search.searchText.setFocus()
-    qtbot.keyClick(search, Qt.Key.Key_Down)
+    qtbot.keyClick(search, QtKeyDown)
     assert firstDoc.isSelected() is True
 
     # Move up
-    qtbot.keyClick(search, Qt.Key.Key_Up)
+    qtbot.keyClick(search, QtKeyUp)
     assert firstDoc.isSelected() is False
 
     # Move right does nothing
-    qtbot.keyClick(search, Qt.Key.Key_Right)
+    qtbot.keyClick(search, QtKeyRight)
     assert firstDoc.isSelected() is False
 
     # Selecting updates details
@@ -85,10 +86,10 @@ def testGuiDocSearch_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
     with monkeypatch.context() as mp:
         mp.setattr(search.searchResult, "hasFocus", lambda *a: True)
         with qtbot.waitSignal(search.openDocumentSelectRequest, timeout=1000) as signal:
-            qtbot.keyClick(search, Qt.Key.Key_Return)
+            qtbot.keyClick(search, QtKeyReturn)
             assert signal.args == [handle, 3, 5, False]
         with qtbot.waitSignal(search.openDocumentRequest, timeout=1000) as signal:
-            qtbot.keyClick(search, Qt.Key.Key_Return, Qt.KeyboardModifier.ShiftModifier)
+            qtbot.keyClick(search, QtKeyReturn, Qt.KeyboardModifier.ShiftModifier)
             assert signal.args == [handle, nwDocMode.VIEW, "", True]
 
     assert nwGUI.docEditor.docHandle == handle
@@ -108,7 +109,7 @@ def testGuiDocSearch_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
     with monkeypatch.context() as mp:
         mp.setattr(search.searchResult, "hasFocus", lambda *a: True)
         with qtbot.assertNotEmitted(search.openDocumentSelectRequest):
-            qtbot.keyClick(search, Qt.Key.Key_Return)
+            qtbot.keyClick(search, QtKeyReturn)
 
     # Case Sensitive
     search.toggleCase.setChecked(True)
@@ -121,7 +122,7 @@ def testGuiDocSearch_Main(qtbot, monkeypatch, nwGUI, prjLipsum):
     search.searchText.setText("dolor")
     with monkeypatch.context() as mp:
         mp.setattr(search.searchText, "hasFocus", lambda *a: True)
-        qtbot.keyClick(search, Qt.Key.Key_Return)
+        qtbot.keyClick(search, QtKeyReturn)
 
     assert search.searchResult.topLevelItemCount() == 10
     assert totalCount() == 34

--- a/tests/test_tools/test_welcome.py
+++ b/tests/test_tools/test_welcome.py
@@ -27,7 +27,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from PyQt6.QtCore import QPoint, Qt
+from PyQt6.QtCore import QPoint
 from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import QFileDialog, QMenu
 
@@ -43,6 +43,10 @@ from novelwriter.types import (
     QtDecorationRole,
     QtDisplayRole,
     QtFontRole,
+    QtKeyDown,
+    QtKeyLeft,
+    QtKeyRight,
+    QtKeyUp,
     QtMouseLeft,
     QtTextAlignmentRole,
     QtToolTipRole,
@@ -194,17 +198,17 @@ def testToolWelcome_Open(qtbot, monkeypatch, nwGUI):
 
     # Change selection with arrow keys
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
-    qtbot.keyClick(tabOpen, Qt.Key.Key_Left)  # Does nothing
+    qtbot.keyClick(tabOpen, QtKeyLeft)  # Does nothing
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
-    qtbot.keyClick(tabOpen, Qt.Key.Key_Right)  # Does nothing
+    qtbot.keyClick(tabOpen, QtKeyRight)  # Does nothing
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
-    qtbot.keyClick(tabOpen, Qt.Key.Key_Down)  # Selects lower
+    qtbot.keyClick(tabOpen, QtKeyDown)  # Selects lower
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_one"
-    qtbot.keyClick(tabOpen, Qt.Key.Key_Down)  # Does nothing (already on last)
+    qtbot.keyClick(tabOpen, QtKeyDown)  # Does nothing (already on last)
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_one"
-    qtbot.keyClick(tabOpen, Qt.Key.Key_Up)  # Selects upper
+    qtbot.keyClick(tabOpen, QtKeyUp)  # Selects upper
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
-    qtbot.keyClick(tabOpen, Qt.Key.Key_Up)  # Does nothing (already on first)
+    qtbot.keyClick(tabOpen, QtKeyUp)  # Does nothing (already on first)
     assert tabOpen.selectedPath.text() == "Path: /stuff/project_two"
 
     # Single click item


### PR DESCRIPTION
**Summary:**

With the editor back to being a rich text editor running in plain text mode (rather than a full plain text editor) the line height setting can now be implemented. This PR does so, but it need real life testing to ensure it works in all corner cases.

**Related Issue(s):**

Closes #654

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
