### PR TITLE
Add a text format check framework

### DIFF
--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -63,6 +63,7 @@ class nwConst:
     # Gui Settings
     STATUS_MSG_TIMEOUT = 15000  # milliseconds
     MAX_SEARCH_RESULT = 1000
+    CHECK_PASS_CHUNK = 100  # Chunk size for spell and format checking
 
 
 class nwRegEx:

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -1275,7 +1275,7 @@ class GuiPreferences(NDialog):
         updateSyntax |= CONFIG.altDialogClose != altDialogClose
         updateSyntax |= CONFIG.highlightEmph != highlightEmph
         updateSyntax |= CONFIG.dottedModCodes != dottedModCodes
-        updateSyntax |= CONFIG.showMultiSpaces != showMultiSpaces
+        initEditor |= CONFIG.showMultiSpaces != showMultiSpaces
 
         CONFIG.dialogStyle = dialogueStyle
         CONFIG.allowOpenDial = allowOpenDial

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -75,7 +75,7 @@ from novelwriter.editor.editordocument import GuiTextDocument
 from novelwriter.editor.editsearch import GuiDocEditSearch
 from novelwriter.editor.edittoolbar import GuiDocToolBar
 from novelwriter.editor.highlighter import BLOCK_META, BLOCK_TITLE
-from novelwriter.editor.runnables import BackgroundSpellCheck, BackgroundWordCounter
+from novelwriter.editor.runnables import BackgroundTextCheck, BackgroundWordCounter
 from novelwriter.editor.textblock import TextBlockData
 from novelwriter.enum import (
     nwChange,
@@ -140,7 +140,7 @@ class _SelectAction(Enum):
     MOVE_AFTER = 3
 
 
-SPELL_PASS_CHUNK = 100
+CHECK_PASS_CHUNK = 100
 
 
 class _TagAction(IntFlag):
@@ -154,13 +154,17 @@ class GuiDocEditor(QTextEdit):
 
     __slots__ = (
         "_autoReplace",
+        "_checkJob",
+        "_checkJobId",
+        "_checkPassNo",
         "_completer",
-        "_dirtySpell",
+        "_dirtyBlocks",
         "_doReplace",
         "_docChanged",
         "_docHandle",
         "_followTagEdit",
         "_followTagView",
+        "_formatSelections",
         "_keyContext",
         "_lastActive",
         "_lastEdit",
@@ -175,18 +179,14 @@ class GuiDocEditor(QTextEdit):
         "_searchFormat",
         "_searchSelections",
         "_selection",
-        "_spaceSelections",
         "_spellFormat",
-        "_spellJob",
-        "_spellJobId",
-        "_spellPassNo",
         "_spellPassNotify",
         "_spellSelections",
         "_suppressed",
         "_timerDoc",
         "_timerSel",
         "_timerSpell",
-        "_timerSpellCheck",
+        "_timerTextCheck",
         "_trActions",
         "_trAddWord",
         "_trCopy",
@@ -262,18 +262,18 @@ class GuiDocEditor(QTextEdit):
         self._searchFormat = QTextCharFormat()
         self._searchSelections: list[QTextEdit.ExtraSelection] = []
 
-        # Spell and Space Check Variables
+        # Spell and Format Check Variables
         self._spellFormat = QTextCharFormat()
         self._mspaceFormat = QTextCharFormat()
         self._trailFormat = QTextCharFormat()
         self._spellSelections: list[QTextEdit.ExtraSelection] = []
-        self._spaceSelections: list[QTextEdit.ExtraSelection] = []
-        self._dirtySpell: dict[int, QTextBlock] = {}
+        self._formatSelections: list[QTextEdit.ExtraSelection] = []
+        self._dirtyBlocks: dict[int, QTextBlock] = {}
         self._suppressed = False
-        self._spellPassNo = -1
+        self._checkPassNo = -1
         self._spellPassNotify = False
-        self._spellJob: tuple[int, list[tuple[QTextBlock, TextBlockData, int]]] | None = None
-        self._spellJobId = 0
+        self._checkJob: tuple[int, list[tuple[QTextBlock, TextBlockData, int]]] | None = None
+        self._checkJobId = 0
 
         # Context Menu Translation
         self._trSetName = self.tr("Set as Document Name")
@@ -379,7 +379,7 @@ class GuiDocEditor(QTextEdit):
 
         # Set Up Spell Underline Refresh
         self._timerSpell = QTimer(self)
-        self._timerSpell.timeout.connect(self._updateSpellSelections)
+        self._timerSpell.timeout.connect(self._updateCheckSelections)
         self._timerSpell.setSingleShot(True)
         self._timerSpell.setInterval(0)
 
@@ -387,10 +387,10 @@ class GuiDocEditor(QTextEdit):
             vBar.valueChanged.connect(qtLambda(self._timerSpell.start))
 
         # Set Up Spell Check Debounce
-        self._timerSpellCheck = QTimer(self)
-        self._timerSpellCheck.timeout.connect(self._dispatchSpellCheck)
-        self._timerSpellCheck.setSingleShot(True)
-        self._timerSpellCheck.setInterval(300)
+        self._timerTextCheck = QTimer(self)
+        self._timerTextCheck.timeout.connect(self._dispatchTextCheck)
+        self._timerTextCheck.setSingleShot(True)
+        self._timerTextCheck.setInterval(300)
 
         # Install Event Filter for Mouse Wheel
         self.wheelEventFilter = WheelEventFilter(self)
@@ -460,13 +460,13 @@ class GuiDocEditor(QTextEdit):
         self.docToolBar.setVisible(False)
 
         self._timerSpell.stop()
-        self._timerSpellCheck.stop()
-        self._spellPassNo = -1
+        self._timerTextCheck.stop()
+        self._checkPassNo = -1
         self._spellPassNotify = False
-        self._spellJob = None
-        self._dirtySpell.clear()
+        self._checkJob = None
+        self._dirtyBlocks.clear()
         self._spellSelections.clear()
-        self._spaceSelections.clear()
+        self._formatSelections.clear()
         self._searchSelections.clear()
         self.setExtraSelections([])
 
@@ -575,7 +575,7 @@ class GuiDocEditor(QTextEdit):
         self.setTabStopDistance(CONFIG.tabWidth)
         self.setCursorWidth(CONFIG.cursorWidth)
         self._spellSelections.clear()
-        self._spaceSelections.clear()
+        self._formatSelections.clear()
         self.setExtraSelections([])
         self._cursorMoved()
 
@@ -586,7 +586,7 @@ class GuiDocEditor(QTextEdit):
             self._qDocument.setLineHeight(CONFIG.lineHeight)
             self._qDocument.syntaxHighlighter.rehighlight()
             self._qDocument.markContentsDirty(0, self._qDocument.characterCount())
-            self._beginSpellPass()
+            self._beginCheckPass()
             self.docHeader.setHandle(self._docHandle)
         else:
             self.clearEditor()
@@ -621,7 +621,7 @@ class GuiDocEditor(QTextEdit):
         self._allowAutoReplace(False)
         self._qDocument.setTextContent(text, tHandle)
         self._allowAutoReplace(True)
-        self._beginSpellPass()
+        self._beginCheckPass()
         QApplication.processEvents()
 
         self._lastEdit = time()
@@ -898,7 +898,7 @@ class GuiDocEditor(QTextEdit):
         """
         logger.debug("Running spell checker")
         self._spellPassNotify = SHARED.project.data.spellCheck
-        self._beginSpellPass()
+        self._beginCheckPass()
 
     ##
     #  General Class Methods
@@ -1347,12 +1347,12 @@ class GuiDocEditor(QTextEdit):
             self._timerDoc.start()
 
         if SHARED.project.data.spellCheck or CONFIG.showMultiSpaces:
-            # Flag the affected blocks for the debounced spell/space check
+            # Flag the affected blocks for the debounced spell/format check
             block = self._qDocument.findBlock(pos)
             while block.isValid() and block.position() <= pos + added:
-                self._dirtySpell[block.blockNumber()] = block
+                self._dirtyBlocks[block.blockNumber()] = block
                 block = block.next()
-            self._timerSpellCheck.start()
+            self._timerTextCheck.start()
 
         self._timerSpell.start()
 
@@ -1392,17 +1392,17 @@ class GuiDocEditor(QTextEdit):
             self._applyExtraSelections()
 
     @pyqtSlot()
-    def _updateSpellSelections(self) -> None:
-        """Rebuild the spell and space error markers for all visible
+    def _updateCheckSelections(self) -> None:
+        """Rebuild the spell and format error markers for all visible
         blocks. Both are cached per block, so a single pass over the
         visible blocks is enough to build both sets of markers.
         """
         checkSpell = SHARED.project.data.spellCheck
-        checkSpace = CONFIG.showMultiSpaces
+        checkFormat = CONFIG.showMultiSpaces
         spellSelections = []
-        spaceSelections = []
+        formatSelections = []
         suppressed = False
-        if (checkSpell or checkSpace) and (viewport := self.viewport()):
+        if (checkSpell or checkFormat) and (viewport := self.viewport()):
             cPos = self.textCursor().position()
             last = self.cursorForPosition(viewport.rect().bottomLeft()).blockNumber()
             block = self.cursorForPosition(viewport.rect().topLeft()).block()
@@ -1422,85 +1422,85 @@ class GuiDocEditor(QTextEdit):
                             selection.format = self._spellFormat
                             selection.cursor = cursor
                             spellSelections.append(selection)
-                    if checkSpace:
-                        for start, end, kind in data.spaceErrors:
+                    if checkFormat:
+                        for start, end, kind in data.formatErrors:
                             cursor = QTextCursor(self._qDocument)
                             cursor.setPosition(position + start)
                             cursor.setPosition(position + end, QtKeepAnchor)
                             selection = QTextEdit.ExtraSelection()
                             selection.format = self._mspaceFormat if kind == "multi" else self._trailFormat
                             selection.cursor = cursor
-                            spaceSelections.append(selection)
+                            formatSelections.append(selection)
                 block = block.next()
         self._suppressed = suppressed
         self._spellSelections = spellSelections
-        self._spaceSelections = spaceSelections
+        self._formatSelections = formatSelections
         self._applyExtraSelections()
 
     @pyqtSlot()
-    def _dispatchSpellCheck(self) -> None:
-        """Send the next batch of text blocks to the spell check worker.
+    def _dispatchTextCheck(self) -> None:
+        """Send the next batch of text blocks to the text check worker.
         Modified blocks are prioritised, then the blocks queued for the
         background document pass. The pass position is tracked by block
         number, which may drift when the document is edited during the
         pass, but modified blocks are covered by the debounce anyway.
         """
-        if self._spellJob is not None:
+        if self._checkJob is not None:
             # There is already a job running, and a new dispatch is
             # made when its results come in
             return
 
         job = []
         payload = []
-        while self._dirtySpell and len(job) < SPELL_PASS_CHUNK:
-            _, block = self._dirtySpell.popitem()
+        while self._dirtyBlocks and len(job) < CHECK_PASS_CHUNK:
+            _, block = self._dirtyBlocks.popitem()
             if block.isValid() and isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
                 payload.append((len(job), *data.checkData()))
                 job.append((block, data, data.revision))
 
-        while self._spellPassNo >= 0 and len(job) < SPELL_PASS_CHUNK:
-            block = self._qDocument.findBlockByNumber(self._spellPassNo)
+        while self._checkPassNo >= 0 and len(job) < CHECK_PASS_CHUNK:
+            block = self._qDocument.findBlockByNumber(self._checkPassNo)
             if block.isValid():
                 if isinstance(data := block.userData(), TextBlockData):
                     payload.append((len(job), *data.checkData()))
                     job.append((block, data, data.revision))
-                self._spellPassNo += 1
+                self._checkPassNo += 1
             else:
-                self._spellPassNo = -1
+                self._checkPassNo = -1
 
         if job:
-            self._spellJobId += 1
-            self._spellJob = (self._spellJobId, job)
-            runnable = BackgroundSpellCheck(
-                self._spellJobId,
+            self._checkJobId += 1
+            self._checkJob = (self._checkJobId, job)
+            runnable = BackgroundTextCheck(
+                self._checkJobId,
                 payload,
                 checkSpell=SHARED.project.data.spellCheck,
-                checkSpace=CONFIG.showMultiSpaces,
+                checkFormat=CONFIG.showMultiSpaces,
             )
-            runnable.signals.resultsReady.connect(self._spellCheckResults)
+            runnable.signals.resultsReady.connect(self._textCheckResults)
             SHARED.runInThreadPool(runnable)
         elif self._spellPassNotify:
             self._spellPassNotify = False
             SHARED.newStatusMessage(self.tr("Spell check complete"))
 
     @pyqtSlot(int, object)
-    def _spellCheckResults(
+    def _textCheckResults(
         self, jobId: int, results: list[tuple[int, list[tuple[int, int, str]], list[tuple[int, int, str]]]]
     ) -> None:
-        """Process the results from the spell/space check worker.
+        """Process the results from the spell/format check worker.
         Results are discarded if the job was cancelled, or per block if
         the block was modified or removed while the worker was running.
         """
-        if self._spellJob and self._spellJob[0] == jobId:
-            job = self._spellJob[1]
-            self._spellJob = None
-            for index, spellErrors, spaceErrors in results:
+        if self._checkJob and self._checkJob[0] == jobId:
+            job = self._checkJob[1]
+            self._checkJob = None
+            for index, spellErrors, formatErrors in results:
                 block, data, revision = job[index]
                 if block.isValid() and block.userData() is data and data.revision == revision:
                     data.setSpellErrors(spellErrors)
-                    data.setSpaceErrors(spaceErrors)
+                    data.setFormatErrors(formatErrors)
             self._timerSpell.start()
-            self._dispatchSpellCheck()
+            self._dispatchTextCheck()
 
     @pyqtSlot(int, int, str)
     def _insertCompletion(self, pos: int, length: int, text: str) -> None:
@@ -2687,28 +2687,28 @@ class GuiDocEditor(QTextEdit):
 
     def _applyExtraSelections(self) -> None:
         """Set the editor's extra selections from the line highlight
-        and the cached spell and space error markers.
+        and the cached spell and format error markers.
         """
         selections = []
         if CONFIG.lineHighlight:
             selections.append(self._selection)
         selections.extend(self._searchSelections)
         selections.extend(self._spellSelections)
-        selections.extend(self._spaceSelections)
+        selections.extend(self._formatSelections)
         self.setExtraSelections(selections)
 
-    def _beginSpellPass(self) -> None:
-        """Spell and space check the visible blocks, and start a chunked
+    def _beginCheckPass(self) -> None:
+        """Spell and format check the visible blocks, and start a chunked
         check of the entire document on the worker thread. If neither
         check is enabled, only the markers are cleared.
         """
         checkSpell = SHARED.project.data.spellCheck
-        checkSpace = CONFIG.showMultiSpaces
-        self._timerSpellCheck.stop()
-        self._dirtySpell.clear()
-        self._spellJob = None
-        self._spellPassNo = -1
-        if checkSpell or checkSpace:
+        checkFormat = CONFIG.showMultiSpaces
+        self._timerTextCheck.stop()
+        self._dirtyBlocks.clear()
+        self._checkJob = None
+        self._checkPassNo = -1
+        if checkSpell or checkFormat:
             if viewport := self.viewport():  # pragma: no branch
                 # Check the visible blocks first so that their result
                 # is available immediately
@@ -2718,12 +2718,12 @@ class GuiDocEditor(QTextEdit):
                     if isinstance(data := block.userData(), TextBlockData):
                         if checkSpell:
                             data.spellCheck()
-                        if checkSpace:
-                            data.spaceCheck()
+                        if checkFormat:
+                            data.formatCheck()
                     block = block.next()
-            self._spellPassNo = 0
-            self._dispatchSpellCheck()
-        self._updateSpellSelections()
+            self._checkPassNo = 0
+            self._dispatchTextCheck()
+        self._updateCheckSelections()
 
     def _completerToCursor(self) -> None:
         """Make sure the completer menu is positioned by the cursor."""
@@ -2751,7 +2751,7 @@ class GuiDocEditor(QTextEdit):
         SHARED.spelling.addWord(word, save=save)
         if isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
             data.spellCheck()
-        self._updateSpellSelections()
+        self._updateCheckSelections()
 
     def _processTag(
         self,

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -182,9 +182,9 @@ class GuiDocEditor(QTextEdit):
         "_spellPassNotify",
         "_spellSelections",
         "_suppressed",
+        "_timerCheck",
         "_timerDoc",
         "_timerSel",
-        "_timerSpell",
         "_timerTextCheck",
         "_trActions",
         "_trAddWord",
@@ -375,13 +375,13 @@ class GuiDocEditor(QTextEdit):
         self._wCounterSel.signals.countsReady.connect(self._updateSelCounts)
 
         # Set Up Spell Underline Refresh
-        self._timerSpell = QTimer(self)
-        self._timerSpell.timeout.connect(self._updateCheckSelections)
-        self._timerSpell.setSingleShot(True)
-        self._timerSpell.setInterval(0)
+        self._timerCheck = QTimer(self)
+        self._timerCheck.timeout.connect(self._updateCheckSelections)
+        self._timerCheck.setSingleShot(True)
+        self._timerCheck.setInterval(0)
 
         if vBar := self.verticalScrollBar():  # pragma: no branch
-            vBar.valueChanged.connect(qtLambda(self._timerSpell.start))
+            vBar.valueChanged.connect(qtLambda(self._timerCheck.start))
 
         # Set Up Spell Check Debounce
         self._timerTextCheck = QTimer(self)
@@ -456,7 +456,7 @@ class GuiDocEditor(QTextEdit):
         self.docFooter.setHandle(self._docHandle)
         self.docToolBar.setVisible(False)
 
-        self._timerSpell.stop()
+        self._timerCheck.stop()
         self._timerTextCheck.stop()
         self._checkPassNo = -1
         self._spellPassNotify = False
@@ -1242,7 +1242,7 @@ class GuiDocEditor(QTextEdit):
         has its margins adjusted according to user preferences.
         """
         self.updateDocMargins()
-        self._timerSpell.start()
+        self._timerCheck.start()
         super().resizeEvent(event)
 
     def inputMethodEvent(self, event: QInputMethodEvent) -> None:
@@ -1348,7 +1348,7 @@ class GuiDocEditor(QTextEdit):
                 block = block.next()
             self._timerTextCheck.start()
 
-        self._timerSpell.start()
+        self._timerCheck.start()
 
         if (block := self._qDocument.findBlock(pos)).isValid():
             text = block.text()
@@ -1379,7 +1379,7 @@ class GuiDocEditor(QTextEdit):
         if self._suppressed:
             # An underline was suppressed at the previous cursor
             # position, so the underlines must be refreshed
-            self._timerSpell.start()
+            self._timerCheck.start()
         if CONFIG.lineHighlight:
             self._selection.cursor = self.textCursor()
             self._selection.cursor.clearSelection()
@@ -1500,7 +1500,7 @@ class GuiDocEditor(QTextEdit):
                 if block.isValid() and block.userData() is data and data.revision == revision:
                     data.setSpellErrors(spellErrors)
                     data.setFormatErrors(formatErrors)
-            self._timerSpell.start()
+            self._timerCheck.start()
             self._dispatchTextCheck()
 
     @pyqtSlot(int, int, str)

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -359,6 +359,7 @@ class GuiDocEditor(QTextEdit):
         # Set Up Document Word Counter
         self._timerDoc = QTimer(self)
         self._timerDoc.timeout.connect(self._runDocumentTasks)
+        self._timerDoc.setSingleShot(True)
         self._timerDoc.setInterval(5000)
 
         self._wCounterDoc = BackgroundWordCounter(self)
@@ -368,6 +369,7 @@ class GuiDocEditor(QTextEdit):
         # Set Up Selection Word Counter
         self._timerSel = QTimer(self)
         self._timerSel.timeout.connect(self._runSelCounter)
+        self._timerSel.setSingleShot(True)
         self._timerSel.setInterval(500)
 
         self._wCounterSel = BackgroundWordCounter(self, forSelection=True)
@@ -621,7 +623,6 @@ class GuiDocEditor(QTextEdit):
         self._lastEdit = time()
         self._lastActive = time()
         self._runDocumentTasks()
-        self._timerDoc.start()
 
         self.setReadOnly(False)
         self.updateDocMargins()
@@ -1611,10 +1612,7 @@ class GuiDocEditor(QTextEdit):
     @pyqtSlot()
     def _runDocumentTasks(self) -> None:
         """Run timer document tasks."""
-        if self._docHandle is None:
-            return
-
-        if time() - self._lastEdit < 25.0:
+        if self._docHandle:
             logger.debug("Running document tasks")
             if not self._wCounterDoc.isRunning():
                 SHARED.runInThreadPool(self._wCounterDoc)
@@ -1625,8 +1623,6 @@ class GuiDocEditor(QTextEdit):
 
             if self._docChanged:
                 self.docTextChanged.emit(self._docHandle, self._lastEdit)
-
-        return
 
     @pyqtSlot()
     def _moveTextToNewDocument(self) -> None:

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -41,7 +41,6 @@ from PyQt6.QtCore import (
     pyqtSlot,
 )
 from PyQt6.QtGui import (
-    QBrush,
     QCursor,
     QDragEnterEvent,
     QDragMoveEvent,
@@ -164,13 +163,13 @@ class GuiDocEditor(QTextEdit):
         "_docHandle",
         "_followTagEdit",
         "_followTagView",
+        "_formatErrFormat",
         "_formatSelections",
         "_keyContext",
         "_lastActive",
         "_lastEdit",
         "_lastFind",
         "_lineColor",
-        "_mspaceFormat",
         "_nextLine",
         "_nwDocument",
         "_nwItem",
@@ -179,7 +178,7 @@ class GuiDocEditor(QTextEdit):
         "_searchFormat",
         "_searchSelections",
         "_selection",
-        "_spellFormat",
+        "_spellErrFormat",
         "_spellPassNotify",
         "_spellSelections",
         "_suppressed",
@@ -205,7 +204,6 @@ class GuiDocEditor(QTextEdit):
         "_trSpellSuggest",
         "_trSplitDoc",
         "_trViewTag",
-        "_trailFormat",
         "_vim",
         "_vpMargin",
         "_wCounterDoc",
@@ -263,9 +261,8 @@ class GuiDocEditor(QTextEdit):
         self._searchSelections: list[QTextEdit.ExtraSelection] = []
 
         # Spell and Format Check Variables
-        self._spellFormat = QTextCharFormat()
-        self._mspaceFormat = QTextCharFormat()
-        self._trailFormat = QTextCharFormat()
+        self._spellErrFormat = QTextCharFormat()
+        self._formatErrFormat = QTextCharFormat()
         self._spellSelections: list[QTextEdit.ExtraSelection] = []
         self._formatSelections: list[QTextEdit.ExtraSelection] = []
         self._dirtyBlocks: dict[int, QTextBlock] = {}
@@ -504,16 +501,13 @@ class GuiDocEditor(QTextEdit):
         self._selection.format.setBackground(self._lineColor)
         self._selection.format.setProperty(QTextFormat.Property.FullWidthSelection, True)
 
-        self._spellFormat = QTextCharFormat()
-        self._spellFormat.setUnderlineColor(syntax.spell)
-        self._spellFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)
+        self._spellErrFormat = QTextCharFormat()
+        self._spellErrFormat.setUnderlineColor(syntax.spell)
+        self._spellErrFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)
 
-        self._mspaceFormat = QTextCharFormat()
-        self._mspaceFormat.setUnderlineColor(syntax.error)
-        self._mspaceFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)
-
-        self._trailFormat = QTextCharFormat()
-        self._trailFormat.setBackground(QBrush(syntax.space, Qt.BrushStyle.SolidPattern))
+        self._formatErrFormat = QTextCharFormat()
+        self._formatErrFormat.setUnderlineColor(syntax.error)
+        self._formatErrFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SingleUnderline)
 
         searchColor = self.palette().color(QPalette.ColorRole.Highlight)
         searchColor.setAlpha(128)
@@ -1419,16 +1413,16 @@ class GuiDocEditor(QTextEdit):
                             cursor.setPosition(position + start)
                             cursor.setPosition(position + end, QtKeepAnchor)
                             selection = QTextEdit.ExtraSelection()
-                            selection.format = self._spellFormat
+                            selection.format = self._spellErrFormat
                             selection.cursor = cursor
                             spellSelections.append(selection)
                     if checkFormat:
-                        for start, end, kind in data.formatErrors:
+                        for start, end, _ in data.formatErrors:
                             cursor = QTextCursor(self._qDocument)
                             cursor.setPosition(position + start)
                             cursor.setPosition(position + end, QtKeepAnchor)
                             selection = QTextEdit.ExtraSelection()
-                            selection.format = self._mspaceFormat if kind == "multi" else self._trailFormat
+                            selection.format = self._formatErrFormat
                             selection.cursor = cursor
                             formatSelections.append(selection)
                 block = block.next()

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -41,6 +41,7 @@ from PyQt6.QtCore import (
     pyqtSlot,
 )
 from PyQt6.QtGui import (
+    QBrush,
     QCursor,
     QDragEnterEvent,
     QDragMoveEvent,
@@ -165,6 +166,7 @@ class GuiDocEditor(QTextEdit):
         "_lastEdit",
         "_lastFind",
         "_lineColor",
+        "_mspaceFormat",
         "_nextLine",
         "_nwDocument",
         "_nwItem",
@@ -173,6 +175,7 @@ class GuiDocEditor(QTextEdit):
         "_searchFormat",
         "_searchSelections",
         "_selection",
+        "_spaceSelections",
         "_spellFormat",
         "_spellJob",
         "_spellJobId",
@@ -202,6 +205,7 @@ class GuiDocEditor(QTextEdit):
         "_trSpellSuggest",
         "_trSplitDoc",
         "_trViewTag",
+        "_trailFormat",
         "_vim",
         "_vpMargin",
         "_wCounterDoc",
@@ -258,9 +262,12 @@ class GuiDocEditor(QTextEdit):
         self._searchFormat = QTextCharFormat()
         self._searchSelections: list[QTextEdit.ExtraSelection] = []
 
-        # Spell Check Variables
+        # Spell and Space Check Variables
         self._spellFormat = QTextCharFormat()
+        self._mspaceFormat = QTextCharFormat()
+        self._trailFormat = QTextCharFormat()
         self._spellSelections: list[QTextEdit.ExtraSelection] = []
+        self._spaceSelections: list[QTextEdit.ExtraSelection] = []
         self._dirtySpell: dict[int, QTextBlock] = {}
         self._suppressed = False
         self._spellPassNo = -1
@@ -459,6 +466,7 @@ class GuiDocEditor(QTextEdit):
         self._spellJob = None
         self._dirtySpell.clear()
         self._spellSelections.clear()
+        self._spaceSelections.clear()
         self._searchSelections.clear()
         self.setExtraSelections([])
 
@@ -499,6 +507,13 @@ class GuiDocEditor(QTextEdit):
         self._spellFormat = QTextCharFormat()
         self._spellFormat.setUnderlineColor(syntax.spell)
         self._spellFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)
+
+        self._mspaceFormat = QTextCharFormat()
+        self._mspaceFormat.setUnderlineColor(syntax.error)
+        self._mspaceFormat.setUnderlineStyle(QTextCharFormat.UnderlineStyle.SpellCheckUnderline)
+
+        self._trailFormat = QTextCharFormat()
+        self._trailFormat.setBackground(QBrush(syntax.space, Qt.BrushStyle.SolidPattern))
 
         searchColor = self.palette().color(QPalette.ColorRole.Highlight)
         searchColor.setAlpha(128)
@@ -560,6 +575,7 @@ class GuiDocEditor(QTextEdit):
         self.setTabStopDistance(CONFIG.tabWidth)
         self.setCursorWidth(CONFIG.cursorWidth)
         self._spellSelections.clear()
+        self._spaceSelections.clear()
         self.setExtraSelections([])
         self._cursorMoved()
 
@@ -1330,8 +1346,8 @@ class GuiDocEditor(QTextEdit):
         if not self._timerDoc.isActive():
             self._timerDoc.start()
 
-        if SHARED.project.data.spellCheck:
-            # Flag the affected blocks for the debounced spell check
+        if SHARED.project.data.spellCheck or CONFIG.showMultiSpaces:
+            # Flag the affected blocks for the debounced spell/space check
             block = self._qDocument.findBlock(pos)
             while block.isValid() and block.position() <= pos + added:
                 self._dirtySpell[block.blockNumber()] = block
@@ -1377,31 +1393,48 @@ class GuiDocEditor(QTextEdit):
 
     @pyqtSlot()
     def _updateSpellSelections(self) -> None:
-        """Rebuild the spell error underlines for all visible blocks."""
-        selections = []
+        """Rebuild the spell and space error markers for all visible
+        blocks. Both are cached per block, so a single pass over the
+        visible blocks is enough to build both sets of markers.
+        """
+        checkSpell = SHARED.project.data.spellCheck
+        checkSpace = CONFIG.showMultiSpaces
+        spellSelections = []
+        spaceSelections = []
         suppressed = False
-        if SHARED.project.data.spellCheck and (viewport := self.viewport()):
+        if (checkSpell or checkSpace) and (viewport := self.viewport()):
             cPos = self.textCursor().position()
             last = self.cursorForPosition(viewport.rect().bottomLeft()).blockNumber()
             block = self.cursorForPosition(viewport.rect().topLeft()).block()
             while block.isValid() and block.blockNumber() <= last:
                 if isinstance(data := block.userData(), TextBlockData):
                     position = block.position()
-                    for start, end, _ in data.spellErrors:
-                        if position + start < cPos <= position + end:
-                            # Don't underline the word under the caret
-                            suppressed = True
-                            continue
-                        cursor = QTextCursor(self._qDocument)
-                        cursor.setPosition(position + start)
-                        cursor.setPosition(position + end, QtKeepAnchor)
-                        selection = QTextEdit.ExtraSelection()
-                        selection.format = self._spellFormat
-                        selection.cursor = cursor
-                        selections.append(selection)
+                    if checkSpell:
+                        for start, end, _ in data.spellErrors:
+                            if position + start < cPos <= position + end:
+                                # Don't underline the word under the caret
+                                suppressed = True
+                                continue
+                            cursor = QTextCursor(self._qDocument)
+                            cursor.setPosition(position + start)
+                            cursor.setPosition(position + end, QtKeepAnchor)
+                            selection = QTextEdit.ExtraSelection()
+                            selection.format = self._spellFormat
+                            selection.cursor = cursor
+                            spellSelections.append(selection)
+                    if checkSpace:
+                        for start, end, kind in data.spaceErrors:
+                            cursor = QTextCursor(self._qDocument)
+                            cursor.setPosition(position + start)
+                            cursor.setPosition(position + end, QtKeepAnchor)
+                            selection = QTextEdit.ExtraSelection()
+                            selection.format = self._mspaceFormat if kind == "multi" else self._trailFormat
+                            selection.cursor = cursor
+                            spaceSelections.append(selection)
                 block = block.next()
         self._suppressed = suppressed
-        self._spellSelections = selections
+        self._spellSelections = spellSelections
+        self._spaceSelections = spaceSelections
         self._applyExtraSelections()
 
     @pyqtSlot()
@@ -1422,14 +1455,14 @@ class GuiDocEditor(QTextEdit):
         while self._dirtySpell and len(job) < SPELL_PASS_CHUNK:
             _, block = self._dirtySpell.popitem()
             if block.isValid() and isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
-                payload.append((len(job), *data.spellData()))
+                payload.append((len(job), *data.checkData()))
                 job.append((block, data, data.revision))
 
         while self._spellPassNo >= 0 and len(job) < SPELL_PASS_CHUNK:
             block = self._qDocument.findBlockByNumber(self._spellPassNo)
             if block.isValid():
                 if isinstance(data := block.userData(), TextBlockData):
-                    payload.append((len(job), *data.spellData()))
+                    payload.append((len(job), *data.checkData()))
                     job.append((block, data, data.revision))
                 self._spellPassNo += 1
             else:
@@ -1438,7 +1471,12 @@ class GuiDocEditor(QTextEdit):
         if job:
             self._spellJobId += 1
             self._spellJob = (self._spellJobId, job)
-            runnable = BackgroundSpellCheck(self._spellJobId, payload)
+            runnable = BackgroundSpellCheck(
+                self._spellJobId,
+                payload,
+                checkSpell=SHARED.project.data.spellCheck,
+                checkSpace=CONFIG.showMultiSpaces,
+            )
             runnable.signals.resultsReady.connect(self._spellCheckResults)
             SHARED.runInThreadPool(runnable)
         elif self._spellPassNotify:
@@ -1446,18 +1484,21 @@ class GuiDocEditor(QTextEdit):
             SHARED.newStatusMessage(self.tr("Spell check complete"))
 
     @pyqtSlot(int, object)
-    def _spellCheckResults(self, jobId: int, results: list[tuple[int, list[tuple[int, int, str]]]]) -> None:
-        """Process the results from the spell check worker. Results are
-        discarded if the job was cancelled, or per block if the block
-        was modified or removed while the worker was running.
+    def _spellCheckResults(
+        self, jobId: int, results: list[tuple[int, list[tuple[int, int, str]], list[tuple[int, int, str]]]]
+    ) -> None:
+        """Process the results from the spell/space check worker.
+        Results are discarded if the job was cancelled, or per block if
+        the block was modified or removed while the worker was running.
         """
         if self._spellJob and self._spellJob[0] == jobId:
             job = self._spellJob[1]
             self._spellJob = None
-            for index, errors in results:
+            for index, spellErrors, spaceErrors in results:
                 block, data, revision = job[index]
                 if block.isValid() and block.userData() is data and data.revision == revision:
-                    data.setSpellErrors(errors)
+                    data.setSpellErrors(spellErrors)
+                    data.setSpaceErrors(spaceErrors)
             self._timerSpell.start()
             self._dispatchSpellCheck()
 
@@ -2646,25 +2687,28 @@ class GuiDocEditor(QTextEdit):
 
     def _applyExtraSelections(self) -> None:
         """Set the editor's extra selections from the line highlight
-        and the cached spell error underlines.
+        and the cached spell and space error markers.
         """
         selections = []
         if CONFIG.lineHighlight:
             selections.append(self._selection)
         selections.extend(self._searchSelections)
         selections.extend(self._spellSelections)
+        selections.extend(self._spaceSelections)
         self.setExtraSelections(selections)
 
     def _beginSpellPass(self) -> None:
-        """Spell check the visible blocks, and start a chunked check of
-        the entire document on the worker thread. If spell checking is
-        disabled, only the underlines are updated.
+        """Spell and space check the visible blocks, and start a chunked
+        check of the entire document on the worker thread. If neither
+        check is enabled, only the markers are cleared.
         """
+        checkSpell = SHARED.project.data.spellCheck
+        checkSpace = CONFIG.showMultiSpaces
         self._timerSpellCheck.stop()
         self._dirtySpell.clear()
         self._spellJob = None
         self._spellPassNo = -1
-        if SHARED.project.data.spellCheck:
+        if checkSpell or checkSpace:
             if viewport := self.viewport():  # pragma: no branch
                 # Check the visible blocks first so that their result
                 # is available immediately
@@ -2672,7 +2716,10 @@ class GuiDocEditor(QTextEdit):
                 block = self.cursorForPosition(viewport.rect().topLeft()).block()
                 while block.isValid() and block.blockNumber() <= last:
                     if isinstance(data := block.userData(), TextBlockData):
-                        data.spellCheck()
+                        if checkSpell:
+                            data.spellCheck()
+                        if checkSpace:
+                            data.spaceCheck()
                     block = block.next()
             self._spellPassNo = 0
             self._dispatchSpellCheck()

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -1389,7 +1389,10 @@ class GuiDocEditor(QTextEdit):
     def _updateCheckSelections(self) -> None:
         """Rebuild the spell and format error markers for all visible
         blocks. Both are cached per block, so a single pass over the
-        visible blocks is enough to build both sets of markers.
+        visible blocks is enough to build both sets of markers. A
+        trailing space under the caret is not flagged, since it is a
+        natural, transient state while the line is still being typed.
+        See issue discussion #1347.
         """
         checkSpell = SHARED.project.data.spellCheck
         checkFormat = CONFIG.showMultiSpaces
@@ -1417,7 +1420,11 @@ class GuiDocEditor(QTextEdit):
                             selection.cursor = cursor
                             spellSelections.append(selection)
                     if checkFormat:
-                        for start, end, _ in data.formatErrors:
+                        for start, end, kind in data.formatErrors:
+                            if kind == "trail" and position + start < cPos <= position + end:
+                                # Not yet a real trailing space, still being typed
+                                suppressed = True
+                                continue
                             cursor = QTextCursor(self._qDocument)
                             cursor.setPosition(position + start)
                             cursor.setPosition(position + end, QtKeepAnchor)

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -139,9 +139,6 @@ class _SelectAction(Enum):
     MOVE_AFTER = 3
 
 
-CHECK_PASS_CHUNK = 100
-
-
 class _TagAction(IntFlag):
     NONE = 0b00
     FOLLOW = 0b01
@@ -1454,13 +1451,13 @@ class GuiDocEditor(QTextEdit):
 
         job = []
         payload = []
-        while self._dirtyBlocks and len(job) < CHECK_PASS_CHUNK:
+        while self._dirtyBlocks and len(job) < nwConst.CHECK_PASS_CHUNK:
             _, block = self._dirtyBlocks.popitem()
             if block.isValid() and isinstance(data := block.userData(), TextBlockData):  # pragma: no branch
                 payload.append((len(job), *data.checkData()))
                 job.append((block, data, data.revision))
 
-        while self._checkPassNo >= 0 and len(job) < CHECK_PASS_CHUNK:
+        while self._checkPassNo >= 0 and len(job) < nwConst.CHECK_PASS_CHUNK:
             block = self._qDocument.findBlockByNumber(self._checkPassNo)
             if block.isValid():
                 if isinstance(data := block.userData(), TextBlockData):

--- a/novelwriter/editor/highlighter.py
+++ b/novelwriter/editor/highlighter.py
@@ -110,7 +110,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._addCharFormat("italic", colEmph, "i")
         self._addCharFormat("strike", syntax.hidden, "s")
         self._addCharFormat("mark", syntax.mark, "bg")
-        self._addCharFormat("mspaces", syntax.error, "err")
         self._addCharFormat("nobreak", syntax.space, "bg")
         self._addCharFormat("altdialog", syntax.dialA)
         self._addCharFormat("dialog", syntax.dialN)
@@ -131,16 +130,6 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         self._cmnRules.clear()
 
         self._dialogParser.initParser()
-
-        # Multiple Spaces
-        if CONFIG.showMultiSpaces:
-            rxRule = re.compile(r"[ ]{2,}")
-            hlRule = {
-                0: self._hStyles["mspaces"],
-            }
-            self._minRules.append((rxRule, hlRule))
-            self._txtRules.append((rxRule, hlRule))
-            self._cmnRules.append((rxRule, hlRule))
 
         # Non-Breaking Spaces
         rxRule = re.compile(f"[{nwUnicode.U_NBSP}{nwUnicode.U_THNBSP}]+")

--- a/novelwriter/editor/runnables.py
+++ b/novelwriter/editor/runnables.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QObject, QRunnable, pyqtSignal, pyqtSlot
 
-from novelwriter.editor.textblock import spellCheckText
+from novelwriter.editor.textblock import spaceCheckText, spellCheckText
 from novelwriter.text.counting import standardCounter
 
 if TYPE_CHECKING:
@@ -79,31 +79,42 @@ class BackgroundWordCounterSignals(QObject):
 
 
 class BackgroundSpellCheck(QRunnable):
-    """The Off-GUI Thread Spell Checker.
+    """The Off-GUI Thread Spell and Space Checker.
 
-    A runnable that spell checks a batch of text block snapshots in the
-    thread pool off the main GUI thread. It only receives plain text
-    snapshots, and never touches the text document itself.
+    A runnable that spell and/or space checks a batch of text block
+    snapshots in the thread pool off the main GUI thread. It only
+    receives plain text snapshots, and never touches the text document
+    itself.
     """
 
-    def __init__(self, jobId: int, payload: list[tuple[int, str, int, list[int] | None]]) -> None:
+    def __init__(
+        self,
+        jobId: int,
+        payload: list[tuple[int, str, str, int, list[int] | None]],
+        checkSpell: bool,
+        checkSpace: bool,
+    ) -> None:
         super().__init__()
         self._jobId = jobId
         self._payload = payload
+        self._checkSpell = checkSpell
+        self._checkSpace = checkSpace
         self.signals = BackgroundSpellCheckSignals()
 
     @pyqtSlot()
     def run(self) -> None:
-        """Spell check the text snapshots and emit the results."""
-        self.signals.resultsReady.emit(
-            self._jobId,
-            [(index, spellCheckText(text, offset, utf16Map)) for index, text, offset, utf16Map in self._payload],
-        )
+        """Spell and space check the text snapshots and emit the results."""
+        results = []
+        for index, spellText, spaceText, offset, utf16Map in self._payload:
+            spellErrors = spellCheckText(spellText, offset, utf16Map) if self._checkSpell else []
+            spaceErrors = spaceCheckText(spaceText, offset, utf16Map) if self._checkSpace else []
+            results.append((index, spellErrors, spaceErrors))
+        self.signals.resultsReady.emit(self._jobId, results)
 
 
 class BackgroundSpellCheckSignals(QObject):
     """The QRunnable cannot emit a signal, so we need a simple QObject
-    to hold the spell check result signal.
+    to hold the spell and space check result signal.
     """
 
     resultsReady = pyqtSignal(int, object)

--- a/novelwriter/editor/runnables.py
+++ b/novelwriter/editor/runnables.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QObject, QRunnable, pyqtSignal, pyqtSlot
 
-from novelwriter.editor.textblock import spaceCheckText, spellCheckText
+from novelwriter.editor.textblock import formatCheckText, spellCheckText
 from novelwriter.text.counting import standardCounter
 
 if TYPE_CHECKING:
@@ -78,10 +78,10 @@ class BackgroundWordCounterSignals(QObject):
     countsReady = pyqtSignal(int, int, int)
 
 
-class BackgroundSpellCheck(QRunnable):
-    """The Off-GUI Thread Spell and Space Checker.
+class BackgroundTextCheck(QRunnable):
+    """The Off-GUI Thread Text Checker.
 
-    A runnable that spell and/or space checks a batch of text block
+    A runnable that spell and/or format checks a batch of text block
     snapshots in the thread pool off the main GUI thread. It only
     receives plain text snapshots, and never touches the text document
     itself.
@@ -92,29 +92,29 @@ class BackgroundSpellCheck(QRunnable):
         jobId: int,
         payload: list[tuple[int, str, str, int, list[int] | None]],
         checkSpell: bool,
-        checkSpace: bool,
+        checkFormat: bool,
     ) -> None:
         super().__init__()
         self._jobId = jobId
         self._payload = payload
         self._checkSpell = checkSpell
-        self._checkSpace = checkSpace
-        self.signals = BackgroundSpellCheckSignals()
+        self._checkFormat = checkFormat
+        self.signals = BackgroundTextCheckSignals()
 
     @pyqtSlot()
     def run(self) -> None:
-        """Spell and space check the text snapshots and emit the results."""
+        """Spell and format check the text snapshots and emit the results."""
         results = []
-        for index, spellText, spaceText, offset, utf16Map in self._payload:
+        for index, spellText, formatText, offset, utf16Map in self._payload:
             spellErrors = spellCheckText(spellText, offset, utf16Map) if self._checkSpell else []
-            spaceErrors = spaceCheckText(spaceText, offset, utf16Map) if self._checkSpace else []
-            results.append((index, spellErrors, spaceErrors))
+            formatErrors = formatCheckText(formatText, offset, utf16Map) if self._checkFormat else []
+            results.append((index, spellErrors, formatErrors))
         self.signals.resultsReady.emit(self._jobId, results)
 
 
-class BackgroundSpellCheckSignals(QObject):
+class BackgroundTextCheckSignals(QObject):
     """The QRunnable cannot emit a signal, so we need a simple QObject
-    to hold the spell and space check result signal.
+    to hold the text check result signal.
     """
 
     resultsReady = pyqtSignal(int, object)

--- a/novelwriter/editor/textblock.py
+++ b/novelwriter/editor/textblock.py
@@ -19,6 +19,8 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 """  # noqa
 
+import re
+
 from PyQt6.QtGui import QTextBlockUserData
 
 from novelwriter import SHARED
@@ -28,6 +30,8 @@ RX_URL = REGEX_PATTERNS.url
 RX_WORDS = REGEX_PATTERNS.wordSplit
 RX_FMT_SC = REGEX_PATTERNS.shortcodePlain
 RX_FMT_SV = REGEX_PATTERNS.shortcodeValue
+RX_MULTI_SPACE = re.compile(r" {2,}")
+RX_TRAIL_SPACE = re.compile(r"[ \t]+$")
 
 
 class TextBlockData(QTextBlockUserData):
@@ -38,16 +42,27 @@ class TextBlockData(QTextBlockUserData):
     positions are in UTF-16 units, matching Qt document positions.
     """
 
-    __slots__ = ("_metaData", "_offset", "_revision", "_spellErrors", "_text", "_utf16Map")
+    __slots__ = (
+        "_metaData",
+        "_offset",
+        "_rawText",
+        "_revision",
+        "_spaceErrors",
+        "_spellErrors",
+        "_text",
+        "_utf16Map",
+    )
 
     def __init__(self) -> None:
         super().__init__()
         self._text = ""
+        self._rawText = ""
         self._offset = 0
         self._revision = 0
         self._utf16Map: list[int] | None = None
         self._metaData: list[tuple[int, int, str, str]] = []
         self._spellErrors: list[tuple[int, int, str]] = []
+        self._spaceErrors: list[tuple[int, int, str]] = []
 
     @property
     def metaData(self) -> list[tuple[int, int, str, str]]:
@@ -60,6 +75,11 @@ class TextBlockData(QTextBlockUserData):
         return self._spellErrors
 
     @property
+    def spaceErrors(self) -> list[tuple[int, int, str]]:
+        """Return space error data from last check."""
+        return self._spaceErrors
+
+    @property
     def revision(self) -> int:
         """Return the revision number of the cached text."""
         return self._revision
@@ -67,25 +87,35 @@ class TextBlockData(QTextBlockUserData):
     def clear(self) -> None:
         """Clear all cached data."""
         self._text = ""
+        self._rawText = ""
         self._offset = 0
         self._revision += 1
         self._utf16Map = None
         self._metaData = []
         self._spellErrors = []
+        self._spaceErrors = []
 
-    def spellData(self) -> tuple[str, int, list[int] | None]:
-        """Return a snapshot of the text for external spell checking."""
-        return self._text, self._offset, self._utf16Map
+    def checkData(self) -> tuple[str, str, int, list[int] | None]:
+        """Return a snapshot of the text for external spell and space
+        checking. The spell text has shortcodes and URLs stripped, while
+        the space text is the raw, unmodified block text.
+        """
+        return self._text, self._rawText, self._offset, self._utf16Map
 
     def setSpellErrors(self, errors: list[tuple[int, int, str]]) -> None:
         """Store spell error data computed from a text snapshot."""
         self._spellErrors = errors
+
+    def setSpaceErrors(self, errors: list[tuple[int, int, str]]) -> None:
+        """Store space error data computed from a text snapshot."""
+        self._spaceErrors = errors
 
     def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
         """Extract meta data from the text. The map, when set, converts
         cached positions to UTF-16 units.
         """
         self._metaData = []
+        self._rawText = text
         if "[" in text:
             # Strip shortcodes
             for regEx in [RX_FMT_SC, RX_FMT_SV]:
@@ -117,6 +147,13 @@ class TextBlockData(QTextBlockUserData):
         self._spellErrors = spellCheckText(self._text, self._offset, self._utf16Map)
         return self._spellErrors
 
+    def spaceCheck(self) -> list[tuple[int, int, str]]:
+        """Run the multi-space and trailing-space check and cache the
+        result, and return the list of space errors.
+        """
+        self._spaceErrors = spaceCheckText(self._rawText, self._offset, self._utf16Map)
+        return self._spaceErrors
+
 
 def spellCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
     """Spell check a piece of text and return the list of errors. This
@@ -135,3 +172,25 @@ def spellCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[t
         for r in RX_WORDS.finditer(text, offset)
         if (w := r.group(0)) and not (w.isnumeric() or w.isupper() or spell.checkWord(w))
     ]
+
+
+def spaceCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
+    """Check a piece of text for runs of multiple spaces and trailing
+    whitespace, and return the list of matches. This function does not
+    touch any Qt document classes, so it is safe to call from a worker
+    thread.
+    """
+    results = []
+    for res in RX_MULTI_SPACE.finditer(text, offset):
+        s, e = res.start(0), res.end(0)
+        if utf16Map:
+            s, e = utf16Map[s], utf16Map[e]
+        results.append((s, e, "multi"))
+
+    if res := RX_TRAIL_SPACE.search(text, offset):
+        s, e = res.start(0), res.end(0)
+        if utf16Map:
+            s, e = utf16Map[s], utf16Map[e]
+        results.append((s, e, "trail"))
+
+    return results

--- a/novelwriter/editor/textblock.py
+++ b/novelwriter/editor/textblock.py
@@ -43,11 +43,11 @@ class TextBlockData(QTextBlockUserData):
     """
 
     __slots__ = (
+        "_formatErrors",
         "_metaData",
         "_offset",
         "_rawText",
         "_revision",
-        "_spaceErrors",
         "_spellErrors",
         "_text",
         "_utf16Map",
@@ -62,7 +62,7 @@ class TextBlockData(QTextBlockUserData):
         self._utf16Map: list[int] | None = None
         self._metaData: list[tuple[int, int, str, str]] = []
         self._spellErrors: list[tuple[int, int, str]] = []
-        self._spaceErrors: list[tuple[int, int, str]] = []
+        self._formatErrors: list[tuple[int, int, str]] = []
 
     @property
     def metaData(self) -> list[tuple[int, int, str, str]]:
@@ -75,9 +75,9 @@ class TextBlockData(QTextBlockUserData):
         return self._spellErrors
 
     @property
-    def spaceErrors(self) -> list[tuple[int, int, str]]:
-        """Return space error data from last check."""
-        return self._spaceErrors
+    def formatErrors(self) -> list[tuple[int, int, str]]:
+        """Return format error data from last check."""
+        return self._formatErrors
 
     @property
     def revision(self) -> int:
@@ -93,12 +93,12 @@ class TextBlockData(QTextBlockUserData):
         self._utf16Map = None
         self._metaData = []
         self._spellErrors = []
-        self._spaceErrors = []
+        self._formatErrors = []
 
     def checkData(self) -> tuple[str, str, int, list[int] | None]:
-        """Return a snapshot of the text for external spell and space
+        """Return a snapshot of the text for external spell and format
         checking. The spell text has shortcodes and URLs stripped, while
-        the space text is the raw, unmodified block text.
+        the format text is the raw, unmodified block text.
         """
         return self._text, self._rawText, self._offset, self._utf16Map
 
@@ -106,9 +106,9 @@ class TextBlockData(QTextBlockUserData):
         """Store spell error data computed from a text snapshot."""
         self._spellErrors = errors
 
-    def setSpaceErrors(self, errors: list[tuple[int, int, str]]) -> None:
-        """Store space error data computed from a text snapshot."""
-        self._spaceErrors = errors
+    def setFormatErrors(self, errors: list[tuple[int, int, str]]) -> None:
+        """Store format error data computed from a text snapshot."""
+        self._formatErrors = errors
 
     def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
         """Extract meta data from the text. The map, when set, converts
@@ -147,12 +147,12 @@ class TextBlockData(QTextBlockUserData):
         self._spellErrors = spellCheckText(self._text, self._offset, self._utf16Map)
         return self._spellErrors
 
-    def spaceCheck(self) -> list[tuple[int, int, str]]:
+    def formatCheck(self) -> list[tuple[int, int, str]]:
         """Run the multi-space and trailing-space check and cache the
-        result, and return the list of space errors.
+        result, and return the list of format errors.
         """
-        self._spaceErrors = spaceCheckText(self._rawText, self._offset, self._utf16Map)
-        return self._spaceErrors
+        self._formatErrors = formatCheckText(self._rawText, self._offset, self._utf16Map)
+        return self._formatErrors
 
 
 def spellCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
@@ -174,7 +174,7 @@ def spellCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[t
     ]
 
 
-def spaceCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
+def formatCheckText(text: str, offset: int, utf16Map: list[int] | None) -> list[tuple[int, int, str]]:
     """Check a piece of text for runs of multiple spaces and trailing
     whitespace, and return the list of matches. This function does not
     touch any Qt document classes, so it is safe to call from a worker

--- a/novelwriter/editor/textblock.py
+++ b/novelwriter/editor/textblock.py
@@ -113,8 +113,17 @@ class TextBlockData(QTextBlockUserData):
     def processText(self, text: str, offset: int, utf16Map: list[int] | None) -> None:
         """Extract meta data from the text. The map, when set, converts
         cached positions to UTF-16 units.
+
+        The cached spell and format errors are also invalidated here,
+        since they may hold positions from before this edit that no
+        longer fit within the block's new, possibly shorter, text. They
+        are recomputed by the debounced background check shortly after.
+        Leaving them in place until then risks briefly rendering marker
+        selections that spill into the following block.
         """
         self._metaData = []
+        self._spellErrors = []
+        self._formatErrors = []
         self._rawText = text
         if "[" in text:
             # Strip shortcodes

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -863,6 +863,17 @@ def testGuiEditor_FormatCheckText():
     assert formatCheckText(data._text, 0, None) == [(3, 23, "multi"), (35, 37, "multi"), (35, 37, "trail")]
     assert data.formatCheck() == [(35, 37, "multi"), (35, 37, "trail")]
 
+    # A cached spell/format error may hold a position past the end of a
+    # shortened block, e.g. right after an undo removes previously typed
+    # text. processText() must drop the stale cache immediately, rather
+    # than waiting for the debounced recheck, or the stale, out-of-range
+    # positions can briefly render into the following block
+    data.setSpellErrors([(0, 100, "wrong")])
+    data.setFormatErrors([(0, 100, "multi")])
+    data.processText("short", 0, None)
+    assert data.spellErrors == []
+    assert data.formatErrors == []
+
 
 @pytest.mark.gui
 def testGuiEditor_FormatChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -794,7 +794,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     # Background Spell Pass
     # =====================
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.editor.editor.CHECK_PASS_CHUNK", 2)
+        mp.setattr("novelwriter.constants.nwConst.CHECK_PASS_CHUNK", 2)
 
         # A full pass runs chunked worker jobs until the document is
         # done, which with a synchronous worker completes immediately

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -918,6 +918,22 @@ def testGuiEditor_FormatChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     assert formatSel[1].cursor.selectionStart() == blockPos + 37
     assert formatSel[1].cursor.selectionEnd() == blockPos + 38
 
+    # A trailing space right under the caret is not yet flagged, since
+    # it's a natural, transient state while the line is still being
+    # typed. Other errors in the same block remain visible
+    docEditor.setCursorPosition(blockPos + 38)
+    docEditor._updateCheckSelections()
+    assert docEditor._suppressed is True
+    assert len(docEditor._formatSelections) == 1
+    assert docEditor._formatSelections[0].cursor.selectionStart() == blockPos + 1
+
+    # Moving the caret elsewhere in the same block, away from the
+    # trailing space itself, does not suppress it
+    docEditor.setCursorPosition(blockPos + 5)
+    docEditor._updateCheckSelections()
+    assert docEditor._suppressed is False
+    assert len(docEditor._formatSelections) == 2
+
     # Toggling the feature back off clears the markers
     CONFIG.showMultiSpaces = False
     docEditor._beginCheckPass()

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -46,7 +46,7 @@ from PyQt6.QtGui import (
 from PyQt6.QtWidgets import QApplication, QMenu, QTextEdit
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import decodeMimeHandles
+from novelwriter.common import decodeMimeHandles, utf16CharMap
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.core.item import NWItem
 from novelwriter.core.spellcheck import NWSpellEnchant
@@ -54,7 +54,7 @@ from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.editor.autoreplace import TextAutoReplace
 from novelwriter.editor.completer import CommandCompleter
 from novelwriter.editor.editor import GuiDocEditor, _TagAction
-from novelwriter.editor.textblock import TextBlockData
+from novelwriter.editor.textblock import TextBlockData, spaceCheckText
 from novelwriter.enum import nwComment, nwDocAction, nwDocInsert, nwItemClass, nwItemLayout, nwState, nwVimMode
 from novelwriter.shared import _GuiAlert
 from novelwriter.text.counting import standardCounter
@@ -817,7 +817,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     data._spellErrors = []
     docEditor._spellJobId += 1
     docEditor._spellJob = (docEditor._spellJobId, [(block, data, data.revision - 1)])
-    docEditor._spellCheckResults(docEditor._spellJobId, [(0, [(0, 5, "wrong")])])
+    docEditor._spellCheckResults(docEditor._spellJobId, [(0, [(0, 5, "wrong")], [])])
     assert data.spellErrors == []
     assert docEditor._spellJob is None
 
@@ -830,6 +830,87 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     docEditor._dirtySpell.clear()
 
     # qtbot.stop()
+
+
+def testGuiEditor_SpaceCheckText():
+    """Test the raw multi-space and trailing-space checker function."""
+    # Multiple runs of multiple spaces
+    assert spaceCheckText("one  two   three", 0, None) == [(3, 5, "multi"), (8, 11, "multi")]
+
+    # Trailing space only
+    assert spaceCheckText("one two ", 0, None) == [(7, 8, "trail")]
+
+    # A trailing run is reported as both kinds
+    assert spaceCheckText("one  two  ", 0, None) == [(3, 5, "multi"), (8, 10, "multi"), (8, 10, "trail")]
+
+    # No errors
+    assert spaceCheckText("one two three", 0, None) == []
+
+    # The offset is respected
+    assert spaceCheckText("one  two", 4, None) == []
+
+    # Positions are translated through a UTF-16 map
+    text = "a\U0001f605  b "
+    utf16Map = utf16CharMap(text)
+    assert spaceCheckText(text, 0, utf16Map) == [(3, 5, "multi"), (6, 7, "trail")]
+
+    # A URL padded to spaces of equal length by TextBlockData.processText
+    # must not be mistaken for a real run of multiple spaces, or every
+    # comment/text line containing a URL would be flagged
+    data = TextBlockData()
+    text = "See http://example.com for details.  "
+    data.processText(text, 0, None)
+    assert spaceCheckText(data._text, 0, None) == [(3, 23, "multi"), (35, 37, "multi"), (35, 37, "trail")]
+    assert data.spaceCheck() == [(35, 37, "multi"), (35, 37, "trail")]
+
+
+@pytest.mark.gui
+def testGuiEditor_SpaceChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
+    """Test the document multi-space and trailing-space checker."""
+    buildTestProject(nwGUI, projPath)
+    monkeypatch.setattr(SHARED, "runInThreadPool", lambda r: r.run())
+
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    docEditor = nwGUI.docEditor
+
+    text = "### A Scene\n\nA  double space, and a trailing space \n"
+    docEditor.replaceText(text)
+
+    blockPos = text.index("A  double")
+
+    # With the feature disabled, no markers are generated
+    CONFIG.showMultiSpaces = False
+    docEditor._beginSpellPass()
+    assert docEditor._spaceSelections == []
+
+    # With the feature enabled, both errors are found and rendered as
+    # extra selections with the appropriate format
+    CONFIG.showMultiSpaces = True
+    docEditor._beginSpellPass()
+
+    data = docEditor.textCursor().document().findBlock(blockPos).userData()
+    assert isinstance(data, TextBlockData)
+    assert data.spaceErrors == [(1, 3, "multi"), (37, 38, "trail")]
+
+    trailColor = docEditor._trailFormat.background().color()
+    mspaceSel = [
+        s
+        for s in docEditor.extraSelections()
+        if s.format.underlineStyle() == QTextCharFormat.UnderlineStyle.SpellCheckUnderline
+    ]
+    trailSel = [s for s in docEditor.extraSelections() if s.format.background().color() == trailColor]
+    assert len(mspaceSel) == 1
+    assert mspaceSel[0].cursor.selectionStart() == blockPos + 1
+    assert mspaceSel[0].cursor.selectionEnd() == blockPos + 3
+
+    assert len(trailSel) == 1
+    assert trailSel[0].cursor.selectionStart() == blockPos + 37
+    assert trailSel[0].cursor.selectionEnd() == blockPos + 38
+
+    # Toggling the feature back off clears the markers
+    CONFIG.showMultiSpaces = False
+    docEditor._beginSpellPass()
+    assert docEditor._spaceSelections == []
 
 
 @pytest.mark.gui

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -2974,11 +2974,16 @@ def testGuiEditor_WordCounters(qtbot, monkeypatch, nwGUI, projPath, ipsumText, m
     docEditor._wCounterSel.run()
     assert docEditor.docFooter.wordsText.text() == f"Selected: {wC}"
 
-    # If the last edit is old, no document tasks are run
+    # Document tasks run regardless of how long ago the last edit was,
+    # since the timer is only started in response to an actual edit,
+    # fires once, and then stops rather than polling indefinitely
     threadPool._objID = None
     docEditor._lastEdit = time() - 100.0
     docEditor._runDocumentTasks()
-    assert threadPool.objectID() is None
+    assert threadPool.objectID() == id(docEditor._wCounterDoc)
+
+    assert docEditor._timerDoc.isSingleShot() is True
+    assert docEditor._timerSel.isSingleShot() is True
 
     # qtbot.stop()
 

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -895,7 +895,7 @@ def testGuiEditor_FormatChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     assert docEditor._formatSelections == []
 
     # With the feature enabled, both errors are found and rendered as
-    # extra selections with the appropriate format
+    # extra selections with the same format, regardless of kind
     CONFIG.showMultiSpaces = True
     docEditor._beginCheckPass()
 
@@ -903,20 +903,20 @@ def testGuiEditor_FormatChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     assert isinstance(data, TextBlockData)
     assert data.formatErrors == [(1, 3, "multi"), (37, 38, "trail")]
 
-    trailColor = docEditor._trailFormat.background().color()
-    mspaceSel = [
-        s
-        for s in docEditor.extraSelections()
-        if s.format.underlineStyle() == QTextCharFormat.UnderlineStyle.SpellCheckUnderline
-    ]
-    trailSel = [s for s in docEditor.extraSelections() if s.format.background().color() == trailColor]
-    assert len(mspaceSel) == 1
-    assert mspaceSel[0].cursor.selectionStart() == blockPos + 1
-    assert mspaceSel[0].cursor.selectionEnd() == blockPos + 3
+    formatSel = sorted(
+        (
+            s
+            for s in docEditor.extraSelections()
+            if s.format.underlineStyle() == QTextCharFormat.UnderlineStyle.SingleUnderline
+        ),
+        key=lambda s: s.cursor.selectionStart(),
+    )
+    assert len(formatSel) == 2
+    assert formatSel[0].cursor.selectionStart() == blockPos + 1
+    assert formatSel[0].cursor.selectionEnd() == blockPos + 3
 
-    assert len(trailSel) == 1
-    assert trailSel[0].cursor.selectionStart() == blockPos + 37
-    assert trailSel[0].cursor.selectionEnd() == blockPos + 38
+    assert formatSel[1].cursor.selectionStart() == blockPos + 37
+    assert formatSel[1].cursor.selectionEnd() == blockPos + 38
 
     # Toggling the feature back off clears the markers
     CONFIG.showMultiSpaces = False

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -54,7 +54,7 @@ from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.editor.autoreplace import TextAutoReplace
 from novelwriter.editor.completer import CommandCompleter
 from novelwriter.editor.editor import GuiDocEditor, _TagAction
-from novelwriter.editor.textblock import TextBlockData, spaceCheckText
+from novelwriter.editor.textblock import TextBlockData, formatCheckText
 from novelwriter.enum import nwComment, nwDocAction, nwDocInsert, nwItemClass, nwItemLayout, nwState, nwVimMode
 from novelwriter.shared import _GuiAlert
 from novelwriter.text.counting import standardCounter
@@ -687,7 +687,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
     data._spellErrors = [(0, 5, "Lorem")]
 
     # The spell error should be rendered as an extra selection
-    docEditor._updateSpellSelections()
+    docEditor._updateCheckSelections()
     spellSel = [
         s
         for s in docEditor.extraSelections()
@@ -699,7 +699,7 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
 
     # With spell check disabled, the selections should be cleared
     SHARED.project.data.setSpellCheck(False)
-    docEditor._updateSpellSelections()
+    docEditor._updateCheckSelections()
     assert docEditor._spellSelections == []
     SHARED.project.data.setSpellCheck(True)
 
@@ -765,94 +765,94 @@ def testGuiEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumText, 
         ctxMenu.deleteLater()
 
     # Editing a block flags it for the debounced spell check
-    docEditor._dirtySpell.clear()
+    docEditor._dirtyBlocks.clear()
     docEditor.setCursorPosition(blockPos + 5)
     docEditor.textCursor().insertText("x")
-    assert docEditor._dirtySpell != {}
-    assert docEditor._timerSpellCheck.isActive()
+    assert docEditor._dirtyBlocks != {}
+    assert docEditor._timerTextCheck.isActive()
 
     # Running the check dispatches the dirty blocks to the worker
-    docEditor._dispatchSpellCheck()
-    assert docEditor._dirtySpell == {}
-    assert docEditor._spellJob is None
+    docEditor._dispatchTextCheck()
+    assert docEditor._dirtyBlocks == {}
+    assert docEditor._checkJob is None
 
     # An error under the caret is not underlined
     data = docEditor.textCursor().block().userData()
     assert isinstance(data, TextBlockData)
     data._spellErrors = [(0, 5, "Lorem")]
     docEditor.setCursorPosition(blockPos + 3)
-    docEditor._updateSpellSelections()
+    docEditor._updateCheckSelections()
     assert docEditor._suppressed is True
     assert docEditor._spellSelections == []
 
     # Moving the caret out of the word restores the underline
     docEditor.setCursorPosition(blockPos + 10)
-    docEditor._updateSpellSelections()
+    docEditor._updateCheckSelections()
     assert docEditor._suppressed is False
     assert len(docEditor._spellSelections) == 1
 
     # Background Spell Pass
     # =====================
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.editor.editor.SPELL_PASS_CHUNK", 2)
+        mp.setattr("novelwriter.editor.editor.CHECK_PASS_CHUNK", 2)
 
         # A full pass runs chunked worker jobs until the document is
         # done, which with a synchronous worker completes immediately
-        docEditor._beginSpellPass()
-        assert docEditor._spellPassNo == -1
-        assert docEditor._spellJob is None
+        docEditor._beginCheckPass()
+        assert docEditor._checkPassNo == -1
+        assert docEditor._checkJob is None
 
         # A full spell check notifies when the pass completes
         docEditor.spellCheckDocument()
         assert docEditor._spellPassNotify is False
 
     # Results from a cancelled job are dropped
-    docEditor._spellCheckResults(docEditor._spellJobId + 1, [])
-    assert docEditor._spellJob is None
+    docEditor._textCheckResults(docEditor._checkJobId + 1, [])
+    assert docEditor._checkJob is None
 
     # Results for blocks modified while checking are discarded
     block = docEditor.textCursor().block()
     data = block.userData()
     assert isinstance(data, TextBlockData)
     data._spellErrors = []
-    docEditor._spellJobId += 1
-    docEditor._spellJob = (docEditor._spellJobId, [(block, data, data.revision - 1)])
-    docEditor._spellCheckResults(docEditor._spellJobId, [(0, [(0, 5, "wrong")], [])])
+    docEditor._checkJobId += 1
+    docEditor._checkJob = (docEditor._checkJobId, [(block, data, data.revision - 1)])
+    docEditor._textCheckResults(docEditor._checkJobId, [(0, [(0, 5, "wrong")], [])])
     assert data.spellErrors == []
-    assert docEditor._spellJob is None
+    assert docEditor._checkJob is None
 
     # No new dispatch is made while a job is still in flight
-    docEditor._dirtySpell[block.blockNumber()] = block
-    docEditor._spellJob = (docEditor._spellJobId, [])
-    docEditor._dispatchSpellCheck()
-    assert docEditor._dirtySpell != {}
-    docEditor._spellJob = None
-    docEditor._dirtySpell.clear()
+    docEditor._dirtyBlocks[block.blockNumber()] = block
+    docEditor._checkJob = (docEditor._checkJobId, [])
+    docEditor._dispatchTextCheck()
+    assert docEditor._dirtyBlocks != {}
+    docEditor._checkJob = None
+    docEditor._dirtyBlocks.clear()
 
     # qtbot.stop()
 
 
-def testGuiEditor_SpaceCheckText():
+def testGuiEditor_FormatCheckText():
     """Test the raw multi-space and trailing-space checker function."""
     # Multiple runs of multiple spaces
-    assert spaceCheckText("one  two   three", 0, None) == [(3, 5, "multi"), (8, 11, "multi")]
+    assert formatCheckText("one  two   three", 0, None) == [(3, 5, "multi"), (8, 11, "multi")]
 
     # Trailing space only
-    assert spaceCheckText("one two ", 0, None) == [(7, 8, "trail")]
+    assert formatCheckText("one two ", 0, None) == [(7, 8, "trail")]
 
     # A trailing run is reported as both kinds
-    assert spaceCheckText("one  two  ", 0, None) == [(3, 5, "multi"), (8, 10, "multi"), (8, 10, "trail")]
+    assert formatCheckText("one  two  ", 0, None) == [(3, 5, "multi"), (8, 10, "multi"), (8, 10, "trail")]
 
     # No errors
-    assert spaceCheckText("one two three", 0, None) == []
+    assert formatCheckText("one two three", 0, None) == []
 
     # The offset is respected
-    assert spaceCheckText("one  two", 4, None) == []
+    assert formatCheckText("one  two", 4, None) == []
 
     # Positions are translated through a UTF-16 map
     text = "a\U0001f605  b "
     utf16Map = utf16CharMap(text)
-    assert spaceCheckText(text, 0, utf16Map) == [(3, 5, "multi"), (6, 7, "trail")]
+    assert formatCheckText(text, 0, utf16Map) == [(3, 5, "multi"), (6, 7, "trail")]
 
     # A URL padded to spaces of equal length by TextBlockData.processText
     # must not be mistaken for a real run of multiple spaces, or every
@@ -860,12 +860,12 @@ def testGuiEditor_SpaceCheckText():
     data = TextBlockData()
     text = "See http://example.com for details.  "
     data.processText(text, 0, None)
-    assert spaceCheckText(data._text, 0, None) == [(3, 23, "multi"), (35, 37, "multi"), (35, 37, "trail")]
-    assert data.spaceCheck() == [(35, 37, "multi"), (35, 37, "trail")]
+    assert formatCheckText(data._text, 0, None) == [(3, 23, "multi"), (35, 37, "multi"), (35, 37, "trail")]
+    assert data.formatCheck() == [(35, 37, "multi"), (35, 37, "trail")]
 
 
 @pytest.mark.gui
-def testGuiEditor_SpaceChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
+def testGuiEditor_FormatChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test the document multi-space and trailing-space checker."""
     buildTestProject(nwGUI, projPath)
     monkeypatch.setattr(SHARED, "runInThreadPool", lambda r: r.run())
@@ -880,17 +880,17 @@ def testGuiEditor_SpaceChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # With the feature disabled, no markers are generated
     CONFIG.showMultiSpaces = False
-    docEditor._beginSpellPass()
-    assert docEditor._spaceSelections == []
+    docEditor._beginCheckPass()
+    assert docEditor._formatSelections == []
 
     # With the feature enabled, both errors are found and rendered as
     # extra selections with the appropriate format
     CONFIG.showMultiSpaces = True
-    docEditor._beginSpellPass()
+    docEditor._beginCheckPass()
 
     data = docEditor.textCursor().document().findBlock(blockPos).userData()
     assert isinstance(data, TextBlockData)
-    assert data.spaceErrors == [(1, 3, "multi"), (37, 38, "trail")]
+    assert data.formatErrors == [(1, 3, "multi"), (37, 38, "trail")]
 
     trailColor = docEditor._trailFormat.background().color()
     mspaceSel = [
@@ -909,8 +909,8 @@ def testGuiEditor_SpaceChecking(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Toggling the feature back off clears the markers
     CONFIG.showMultiSpaces = False
-    docEditor._beginSpellPass()
-    assert docEditor._spaceSelections == []
+    docEditor._beginCheckPass()
+    assert docEditor._formatSelections == []
 
 
 @pytest.mark.gui


### PR DESCRIPTION
**Summary:**

This PR extends the spell checker that runs off-thread to also include a basic format checker that now handles the multiple spaces feature, as well as re-introduce the trailing space checker. However, now it no longer alerts on the trailing spaces by the cursor, which was why it was removed.

**Related Issue(s):**

Closes #2800

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
