### PR TITLE
Rename things

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -796,7 +796,7 @@ def openExternalPath(path: Path) -> bool:
 _T_Enum = TypeVar("_T_Enum", bound=Enum)
 
 
-class NWConfigParser(ConfigParser):
+class NConfigParser(ConfigParser):
     """Common: Adapted Config Parser.
 
     This is a subclass of the standard config parser that adds type safe

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -47,7 +47,7 @@ from PyQt6.QtGui import QFont, QFontDatabase, QFontMetrics
 from PyQt6.QtWidgets import QApplication
 
 from novelwriter.common import (
-    NWConfigParser,
+    NConfigParser,
     checkInt,
     checkPath,
     describeFont,
@@ -743,7 +743,7 @@ class Config:
 
         logger.debug("Loading config file")
 
-        conf = NWConfigParser()
+        conf = NConfigParser()
         cnfPath = self._confPath / nwFiles.CONF_FILE
 
         if not safeExists(cnfPath):
@@ -894,7 +894,7 @@ class Config:
         """Save the current preferences to file."""
         logger.debug("Saving config file")
 
-        conf = NWConfigParser()
+        conf = NConfigParser()
 
         conf["Meta"] = {
             "timestamp": formatTimeStamp(time()),

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -67,7 +67,7 @@ from novelwriter.error import formatException, logException
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from novelwriter.core.projectdata import NWProjectData
+    from novelwriter.core.projectdata import ProjectData
     from novelwriter.splash import NSplashScreen
 
 logger = logging.getLogger(__name__)
@@ -1107,7 +1107,7 @@ class RecentProjects:
             (str(k), str(e["title"]), checkInt(e["words"], 0), checkInt(e["time"], 0)) for k, e in self._data.items()
         ]
 
-    def update(self, path: str | Path, data: NWProjectData, saved: float | int) -> None:
+    def update(self, path: str | Path, data: ProjectData, saved: float | int) -> None:
         """Add or update recent cache information on a given project."""
         try:
             if (remove := self._map.get(data.uuid)) and (remove != str(path)):

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -41,7 +41,7 @@ from novelwriter.core.storage import ProjectStorageCreate
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from novelwriter.core.item import NWItem
+    from novelwriter.core.item import ProjectItem
 
 logger = logging.getLogger(__name__)
 
@@ -303,7 +303,9 @@ class DocSearch:
         """Set the escape flag to the opposite state."""
         self._escape = not state
 
-    def iterSearch(self, project: NWProject, search: str) -> Iterable[tuple[NWItem, list[tuple[int, int, str]], bool]]:
+    def iterSearch(
+        self, project: NWProject, search: str
+    ) -> Iterable[tuple[ProjectItem, list[tuple[int, int, str]], bool]]:
         """Iterate through documents in a project and apply search."""
         self._regEx = re.compile(self._buildPattern(search), self._opts)
         logger.debug("Searching with pattern '%s'", self._regEx.pattern)

--- a/novelwriter/core/coretools.py
+++ b/novelwriter/core/coretools.py
@@ -36,7 +36,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import isHandle, minmax, safeExists, safeIsFile, simplified
 from novelwriter.constants import nwConst, nwFiles, nwItemClass, nwStats
 from novelwriter.core.project import NWProject
-from novelwriter.core.storage import NWStorageCreate
+from novelwriter.core.storage import ProjectStorageCreate
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -392,10 +392,10 @@ class ProjectBuilder:
         """Build a blank project from a data dictionary."""
         project = NWProject()
         status = project.storage.createNewProject(path)
-        if status == NWStorageCreate.NOT_EMPTY:
+        if status == ProjectStorageCreate.NOT_EMPTY:
             SHARED.error(self.tr("The target folder is not empty. Please choose another folder."))
             return False
-        elif status == NWStorageCreate.OS_ERROR:
+        elif status == ProjectStorageCreate.OS_ERROR:
             SHARED.error(
                 self.tr("An error occurred while trying to create the project."),
                 exc=project.storage.exc,

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -33,7 +33,7 @@ from novelwriter.enum import nwItemClass, nwItemLayout
 from novelwriter.error import formatException, logException
 
 if TYPE_CHECKING:
-    from novelwriter.core.item import NWItem
+    from novelwriter.core.item import ProjectItem
     from novelwriter.core.project import NWProject
 
 logger = logging.getLogger(__name__)
@@ -99,8 +99,8 @@ class ProjectDocument:
         return self._docMeta.get("updated", "Unknown")
 
     @property
-    def nwItem(self) -> NWItem | None:
-        """Return a pointer to the currently open NWItem."""
+    def nwItem(self) -> ProjectItem | None:
+        """Return a pointer to the currently open ProjectItem."""
         return self._item
 
     ##

--- a/novelwriter/core/document.py
+++ b/novelwriter/core/document.py
@@ -39,8 +39,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class NWDocument:
-    """Core: Document Class.
+class ProjectDocument:
+    """Core: Project Document Class.
 
     A Class wrapping a single novelWriter document file. It represents
     a project item of nwItemType FILE. The file is not guaranteed to
@@ -68,7 +68,7 @@ class NWDocument:
 
     def __repr__(self) -> str:
         """Return a string representation of the document."""
-        return f"<NWDocument handle={self._handle}>"
+        return f"<ProjectDocument handle={self._handle}>"
 
     def __bool__(self) -> bool:
         """Return True if the document has a valid handle and item."""

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -42,7 +42,7 @@ from novelwriter.text.formats import processComment, processHeading
 if TYPE_CHECKING:
     from collections.abc import ItemsView, Iterable
 
-    from novelwriter.core.item import NWItem
+    from novelwriter.core.item import ProjectItem
     from novelwriter.core.project import NWProject
 
 logger = logging.getLogger(__name__)
@@ -58,14 +58,15 @@ class Index:
     contains the data that isn't stored in the project items themselves.
     The content of the index is updated every time a file item is saved.
 
-    Some information needed by the NWItem object of a project item can
-    only be known after a text file has been scanned by the indexer, so
-    this data is set directly by the indexer class in the NWItem object.
+    Some information needed by the ProjectItem object of a project item
+    can only be known after a text file has been scanned by the indexer,
+    so this data is set directly by the indexer class in the ProjectItem
+    object.
 
     The primary index data is contained in a single instance of the
     ItemIndex class. This object contains an IndexNode representing each
-    NWItem of the project. Each IndexNode holds an IndexHeading object
-    for each heading of the item's text.
+    ProjectItem of the project. Each IndexNode holds an IndexHeading
+    object for each heading of the item's text.
 
     A reverse index of all tags is contained in a single instance of the
     TagsIndex class. This is duplicate information used for quicker
@@ -218,7 +219,7 @@ class Index:
             self._appendSubTreeToModel(tHandle, model)
             model.endResetModel()
 
-    def updateNovelModelData(self, nwItem: NWItem) -> bool:
+    def updateNovelModelData(self, nwItem: ProjectItem) -> bool:
         """Refresh a novel model."""
         if (
             (rHandle := nwItem.itemRoot)
@@ -374,7 +375,7 @@ class Index:
     #  Internal Indexer Helpers
     ##
 
-    def _scanActive(self, tHandle: str, nwItem: NWItem, text: str, tags: dict[str, bool]) -> None:
+    def _scanActive(self, tHandle: str, nwItem: ProjectItem, text: str, tags: dict[str, bool]) -> None:
         """Scan an active document for meta data."""
         nTitle = 0  # Line Number of the previous title
         cTitle = TT_NONE  # Tag of the current title
@@ -438,7 +439,7 @@ class Index:
             if updated or deleted:  # pragma: no branch
                 SHARED.emitIndexChangedTags(self._project, updated, deleted)
 
-    def _scanInactive(self, nwItem: NWItem, text: str) -> None:
+    def _scanInactive(self, nwItem: ProjectItem, text: str) -> None:
         """Scan an inactive document for meta data."""
         for line in text.splitlines():
             if line.startswith("#"):
@@ -965,7 +966,7 @@ class ItemIndex:
         """Clear the index."""
         self._items = {}
 
-    def add(self, tHandle: str, nwItem: NWItem) -> None:
+    def add(self, tHandle: str, nwItem: ProjectItem) -> None:
         """Add a new item to the index. This will overwrite the item if
         it already exists.
         """

--- a/novelwriter/core/indexdata.py
+++ b/novelwriter/core/indexdata.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import ItemsView, Sequence
 
     from novelwriter.core.index import IndexCache
-    from novelwriter.core.item import NWItem
+    from novelwriter.core.item import ProjectItem
     from novelwriter.enum import nwComment
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ NOTE_TYPES: list[T_NoteTypes] = ["footnotes", "comments"]
 class IndexNode:
     """Core: Single Index Item Node Class.
 
-    This object represents the index data of a project item (NWItem).
+    This object represents the index data of a project item.
     It holds a record of all the headings in the text, and the meta data
     associated with each heading. It also holds a pointer to the project
     item. The main heading level of the item is also held here since it
@@ -56,7 +56,7 @@ class IndexNode:
 
     __slots__ = ("_cache", "_count", "_handle", "_headings", "_item", "_notes")
 
-    def __init__(self, cache: IndexCache, tHandle: str, nwItem: NWItem) -> None:
+    def __init__(self, cache: IndexCache, tHandle: str, nwItem: ProjectItem) -> None:
         self._cache = cache
         self._handle = tHandle
         self._item = nwItem
@@ -90,7 +90,7 @@ class IndexNode:
         return self._handle
 
     @property
-    def item(self) -> NWItem:
+    def item(self) -> ProjectItem:
         """Return the project item of the index item."""
         return self._item
 

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -43,8 +43,8 @@ class NWItem:
 
     This class holds all the project information about a project item.
     Each item must be associated with a project and have a valid handle.
-    Only the NWTree class should create instances of this class, and
-    must ensure that the handle is valid for all items in the tree.
+    Only the ProjectTree class should create instances of this class,
+    and must ensure that the handle is valid for all items in the tree.
     """
 
     __slots__ = (
@@ -103,7 +103,7 @@ class NWItem:
         """Check the truthiness of the class. The handle used to be
         initiated to None, but this is no longer the case. It should
         always evaluate to True since 2.1-beta1, although unpack and the
-        NWTree class can leave it as an empty string.
+        ProjectTree class can leave it as an empty string.
         """
         return bool(self._handle)
 

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Item Class
-================================
+novelWriter – Project Item
+==========================
 
 This file is a part of novelWriter
 Copyright (C) 2018 Veronica Berglyd Olsen and novelWriter contributors

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class NWItem:
+class ProjectItem:
     """Core: Item Data Class.
 
     This class holds all the project information about a project item.
@@ -97,7 +97,7 @@ class NWItem:
 
     def __repr__(self) -> str:
         """Return a string representation of the item."""
-        return f"<NWItem handle={self._handle}, parent={self._parent}, name='{self._name}'>"
+        return f"<ProjectItem handle={self._handle}, parent={self._parent}, name='{self._name}'>"
 
     def __bool__(self) -> bool:
         """Check the truthiness of the class. The handle used to be
@@ -276,7 +276,7 @@ class NWItem:
         return True
 
     @classmethod
-    def duplicate(cls, source: NWItem, handle: str) -> NWItem:
+    def duplicate(cls, source: ProjectItem, handle: str) -> ProjectItem:
         """Make a copy of an item."""
         new = cls(source._project, handle)
         new._name = source._name

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -31,7 +31,7 @@ from PyQt6.QtGui import QFont, QIcon
 from novelwriter import CONFIG
 from novelwriter.common import decodeMimeHandles, encodeMimeHandles, minmax
 from novelwriter.constants import nwConst
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.enum import nwItemClass
 from novelwriter.types import (
     QtAccessibleTextRole,
@@ -79,18 +79,18 @@ class ProjectNode:
     The project tree structure is saved as nodes in a tree, starting
     from a root node. This class makes up these nodes.
 
-    Each node is a wrapper around an NWItem object. The NWItem is the
-    object representing a single item in the project, and it only
+    Each node is a wrapper around an ProjectItem object. The ProjectItem
+    is the object representing a single item in the project, and it only
     contains a reference to its parent as well as it top level root, but
     is itself not structured in a hierarchy in memory.
 
     This class provides the necessary hierarchical structure, as well as
     the data entries needed for populating the GUI project tree. It also
-    handles pushing and pulling information from its NWItem when
+    handles pushing and pulling information from its ProjectItem when
     necessary.
 
     The data to be displayed could in principle be pulled from the
-    NWItem whenever it is needed, but for performance reason it is
+    ProjectItem whenever it is needed, but for performance reason it is
     cached, as the GUI will pull this information often.
     """
 
@@ -101,7 +101,7 @@ class ProjectNode:
 
     __slots__ = ("_cache", "_children", "_count", "_flags", "_item", "_parent", "_row")
 
-    def __init__(self, item: NWItem) -> None:
+    def __init__(self, item: ProjectItem) -> None:
         self._item = item
         self._children: list[ProjectNode] = []
         self._parent: ProjectNode | None = None
@@ -131,7 +131,7 @@ class ProjectNode:
     ##
 
     @property
-    def item(self) -> NWItem:
+    def item(self) -> ProjectItem:
         """The project item of the node."""
         return self._item
 
@@ -309,7 +309,7 @@ class ProjectModel(QAbstractItemModel):
     def __init__(self, tree: ProjectTree) -> None:
         super().__init__()
         self._tree = tree
-        self._root = ProjectNode(NWItem(tree.project, INV_ROOT))
+        self._root = ProjectNode(ProjectItem(tree.project, INV_ROOT))
         self._root.item.setName("Invisible Root")
         logger.debug("Ready: ProjectModel")
 

--- a/novelwriter/core/itemmodel.py
+++ b/novelwriter/core/itemmodel.py
@@ -44,7 +44,7 @@ from novelwriter.types import (
 )
 
 if TYPE_CHECKING:
-    from novelwriter.core.tree import NWTree
+    from novelwriter.core.tree import ProjectTree
 
 logger = logging.getLogger(__name__)
 
@@ -306,7 +306,7 @@ class ProjectModel(QAbstractItemModel):
 
     __slots__ = ("_root", "_tree")
 
-    def __init__(self, tree: NWTree) -> None:
+    def __init__(self, tree: ProjectTree) -> None:
         super().__init__()
         self._tree = tree
         self._root = ProjectNode(NWItem(tree.project, INV_ROOT))

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-NWEnum = TypeVar("NWEnum", bound=Enum)
+_T_Enum = TypeVar("_T_Enum", bound=Enum)
 
 VALID_MAP: dict[str, set[str]] = {
     "GuiWritingStats": {
@@ -248,7 +248,7 @@ class OptionState:
             return checkBool(self._state[group].get(name, default), default)
         return default
 
-    def getEnum(self, group: str, name: str, lookup: type, default: NWEnum) -> NWEnum:
+    def getEnum(self, group: str, name: str, lookup: type, default: _T_Enum) -> _T_Enum:
         """Return the value mapped to an enum. Otherwise return the
         default value.
         """

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -49,7 +49,7 @@ from novelwriter.core.options import OptionState
 from novelwriter.core.projectdata import ProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.sessions import SessionLog
-from novelwriter.core.storage import NWStorage, NWStorageOpen
+from novelwriter.core.storage import ProjectStorage, ProjectStorageOpen
 from novelwriter.core.tree import ProjectTree
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 from novelwriter.error import logException
@@ -94,7 +94,7 @@ class NWProject:
 
         # Core Elements
         self._options = OptionState(self)  # Project-specific GUI options
-        self._storage = NWStorage(self)  # The project storage handler
+        self._storage = ProjectStorage(self)  # The project storage handler
         self._data = ProjectData(self)  # The project settings
         self._tree = ProjectTree(self)  # The project tree
         self._index = Index(self)  # The project index
@@ -129,7 +129,7 @@ class NWProject:
         return self._options
 
     @property
-    def storage(self) -> NWStorage:
+    def storage(self) -> ProjectStorage:
         return self._storage
 
     @property
@@ -301,24 +301,24 @@ class NWProject:
         logger.info("Opening project: %s", projPath)
 
         status = self._storage.initProjectStorage(projPath, clearLock)
-        if status != NWStorageOpen.READY:
-            if status == NWStorageOpen.UNKOWN:
+        if status != ProjectStorageOpen.READY:
+            if status == ProjectStorageOpen.UNKOWN:
                 SHARED.error(
                     self.tr("Not a known project file format."),
                     info=self.tr("Path: {0}").format(str(projPath)),
                 )
-            elif status == NWStorageOpen.NOT_FOUND:
+            elif status == ProjectStorageOpen.NOT_FOUND:
                 SHARED.error(
                     self.tr("Project file not found."),
                     info=self.tr("Path: {0}").format(str(projPath)),
                 )
-            elif status == NWStorageOpen.FAILED:
+            elif status == ProjectStorageOpen.FAILED:
                 SHARED.error(
                     self.tr("Failed to open project."),
                     info=self.tr("Path: {0}").format(str(projPath)),
                     exc=self._storage.exc,
                 )
-            elif status == NWStorageOpen.LOCKED:
+            elif status == ProjectStorageOpen.LOCKED:
                 self._state = NWProjectState.LOCKED
             else:  # pragma: no cover
                 pass

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -563,7 +563,7 @@ class NWProject:
 
     def countStatus(self) -> None:
         """Count how many times the various status flags are used in the
-        project tree. The counts themselves are kept in the NWStatus
+        project tree. The counts themselves are kept in the ItemStatus
         objects. This is essentially a refresh.
         """
         self._data.itemStatus.resetCounts()

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -50,7 +50,7 @@ from novelwriter.core.projectdata import ProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.sessions import SessionLog
 from novelwriter.core.storage import NWStorage, NWStorageOpen
-from novelwriter.core.tree import NWTree
+from novelwriter.core.tree import ProjectTree
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 from novelwriter.error import logException
 
@@ -96,7 +96,7 @@ class NWProject:
         self._options = OptionState(self)  # Project-specific GUI options
         self._storage = NWStorage(self)  # The project storage handler
         self._data = ProjectData(self)  # The project settings
-        self._tree = NWTree(self)  # The project tree
+        self._tree = ProjectTree(self)  # The project tree
         self._index = Index(self)  # The project index
         self._session = SessionLog(self)  # The session record
 
@@ -137,7 +137,7 @@ class NWProject:
         return self._data
 
     @property
-    def tree(self) -> NWTree:
+    def tree(self) -> ProjectTree:
         return self._tree
 
     @property

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -48,7 +48,7 @@ from novelwriter.core.index import Index
 from novelwriter.core.options import OptionState
 from novelwriter.core.projectdata import NWProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
-from novelwriter.core.sessions import NWSessionLog
+from novelwriter.core.sessions import SessionLog
 from novelwriter.core.storage import NWStorage, NWStorageOpen
 from novelwriter.core.tree import NWTree
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
@@ -98,7 +98,7 @@ class NWProject:
         self._data = NWProjectData(self)  # The project settings
         self._tree = NWTree(self)  # The project tree
         self._index = Index(self)  # The project index
-        self._session = NWSessionLog(self)  # The session record
+        self._session = SessionLog(self)  # The session record
 
         # Project Status
         self._langData = {}  # Localisation data
@@ -145,7 +145,7 @@ class NWProject:
         return self._index
 
     @property
-    def session(self) -> NWSessionLog:
+    def session(self) -> SessionLog:
         return self._session
 
     @property

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -46,7 +46,7 @@ from novelwriter.common import (
 from novelwriter.constants import nwLabels, trConst
 from novelwriter.core.index import Index
 from novelwriter.core.options import OptionState
-from novelwriter.core.projectdata import NWProjectData
+from novelwriter.core.projectdata import ProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.sessions import SessionLog
 from novelwriter.core.storage import NWStorage, NWStorageOpen
@@ -95,7 +95,7 @@ class NWProject:
         # Core Elements
         self._options = OptionState(self)  # Project-specific GUI options
         self._storage = NWStorage(self)  # The project storage handler
-        self._data = NWProjectData(self)  # The project settings
+        self._data = ProjectData(self)  # The project settings
         self._tree = NWTree(self)  # The project tree
         self._index = Index(self)  # The project index
         self._session = SessionLog(self)  # The session record
@@ -133,7 +133,7 @@ class NWProject:
         return self._storage
 
     @property
-    def data(self) -> NWProjectData:
+    def data(self) -> ProjectData:
         return self._data
 
     @property
@@ -331,7 +331,7 @@ class NWProject:
         if not isinstance(xmlReader, ProjectXMLReader):
             return False
 
-        self._data = NWProjectData(self)
+        self._data = ProjectData(self)
         projContent = []
         xmlParsed = xmlReader.read(self._data, projContent)
         appVersion = xmlReader.appVersion or self.tr("Unknown")

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Data Class
-================================
+novelWriter – Project Data
+==========================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 T_LastHandle = Literal["editor", "viewer", "novel", "outline"]
 
 
-class NWProjectData:
+class ProjectData:
     """Core: Project Data Class.
 
     The class holds all project data from the main XML file, aside from

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -27,7 +27,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, Literal
 
 from novelwriter.common import checkBool, checkInt, checkStringNone, checkUuid, isHandle, makeFileNameSafe, simplified
-from novelwriter.core.status import NWStatus
+from novelwriter.core.status import ItemStatus
 
 if TYPE_CHECKING:
     from novelwriter.core.project import NWProject
@@ -80,8 +80,8 @@ class ProjectData:
             "section": "",
         }
 
-        self._status = NWStatus(NWStatus.STATUS)
-        self._import = NWStatus(NWStatus.IMPORT)
+        self._status = ItemStatus(ItemStatus.STATUS)
+        self._import = ItemStatus(ItemStatus.IMPORT)
 
     ##
     #  Properties
@@ -169,12 +169,12 @@ class ProjectData:
         return self._autoReplace
 
     @property
-    def itemStatus(self) -> NWStatus:
+    def itemStatus(self) -> ItemStatus:
         """Return the status settings object."""
         return self._status
 
     @property
-    def itemImport(self) -> NWStatus:
+    def itemImport(self) -> ItemStatus:
         """Return the importance settings object."""
         return self._import
 

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -43,7 +43,7 @@ from novelwriter.common import (
 )
 
 if TYPE_CHECKING:
-    from novelwriter.core.projectdata import NWProjectData
+    from novelwriter.core.projectdata import ProjectData
     from novelwriter.core.status import NWStatus
 
 logger = logging.getLogger(__name__)
@@ -77,7 +77,7 @@ class XMLReadState(Enum):
 class ProjectXMLReader:
     """Core: Project XML Reader.
 
-    All data is read into a NWProjectData instance, which must be
+    All data is read into a ProjectData instance, which must be
     provided.
 
     File Format Version Change History
@@ -171,7 +171,7 @@ class ProjectXMLReader:
     #  Methods
     ##
 
-    def read(self, data: NWProjectData, content: list) -> bool:
+    def read(self, data: ProjectData, content: list) -> bool:
         """Read and parse the project XML file."""
         tStart = time()
         logger.debug("Reading project XML")
@@ -229,7 +229,7 @@ class ProjectXMLReader:
     #  Internal Functions
     ##
 
-    def _parseProjectMeta(self, xSection: ET.Element, data: NWProjectData) -> None:
+    def _parseProjectMeta(self, xSection: ET.Element, data: ProjectData) -> None:
         """Parse the project section of the XML file."""
         logger.debug("Parsing <project> section")
 
@@ -256,7 +256,7 @@ class ProjectXMLReader:
                 elif xItem.tag == "editTime":  # Moved to attribute in 1.5
                     data.setEditTime(xItem.text)
 
-    def _parseProjectSettings(self, xSection: ET.Element, data: NWProjectData) -> None:
+    def _parseProjectSettings(self, xSection: ET.Element, data: ProjectData) -> None:
         """Parse the settings section of the XML file."""
         logger.debug("Parsing <settings> section")
 
@@ -294,7 +294,7 @@ class ProjectXMLReader:
                 elif xItem.tag == "notesWordCount":  # Moved to content attribute in 1.5
                     data.setInitCounts(wNotes=xItem.text)
 
-    def _parseProjectContent(self, xSection: ET.Element, data: NWProjectData, content: list) -> None:
+    def _parseProjectContent(self, xSection: ET.Element, data: ProjectData, content: list) -> None:
         """Parse the content section of the XML file."""
         logger.debug("Parsing <content> section")
 
@@ -352,7 +352,7 @@ class ProjectXMLReader:
                 "nameAttr": name,
             })
 
-    def _parseProjectContentLegacy(self, xSection: ET.Element, data: NWProjectData, content: list) -> None:
+    def _parseProjectContentLegacy(self, xSection: ET.Element, data: ProjectData, content: list) -> None:
         """Parse the content section of the XML file for older versions."""
         logger.debug("Parsing <content> section (legacy format)")
 
@@ -470,7 +470,7 @@ class ProjectXMLWriter:
     #  Methods
     ##
 
-    def write(self, data: NWProjectData, content: list, saveTime: float, editTime: int) -> bool:
+    def write(self, data: ProjectData, content: list, saveTime: float, editTime: int) -> bool:
         """Write the project data and content to the XML files."""
         tStart = time()
         logger.debug("Writing project XML")

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -44,7 +44,7 @@ from novelwriter.common import (
 
 if TYPE_CHECKING:
     from novelwriter.core.projectdata import ProjectData
-    from novelwriter.core.status import NWStatus
+    from novelwriter.core.status import ItemStatus
 
 logger = logging.getLogger(__name__)
 
@@ -424,7 +424,7 @@ class ProjectXMLReader:
                 "nameAttr": name,
             })
 
-    def _parseStatusImport(self, xItem: ET.Element, sObject: NWStatus) -> None:
+    def _parseStatusImport(self, xItem: ET.Element, sObject: ItemStatus) -> None:
         """Parse a status or importance entry."""
         for xEntry in xItem:
             if xEntry.tag == "entry":

--- a/novelwriter/core/sessions.py
+++ b/novelwriter/core/sessions.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Session Log Class
-=======================================
+novelWriter – Project Session Log
+=================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class NWSessionLog:
+class SessionLog:
     """Core: Session JSON Lines Log File.
 
     The class that wraps the session log file, which is in JSON Lines

--- a/novelwriter/core/spellcheck.py
+++ b/novelwriter/core/spellcheck.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Spell Check Classes
-=================================
+novelWriter – Spell Checks
+==========================
 
 This file is a part of novelWriter
 Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 MAX_CACHE_SIZE = 100_000
 
 
-class NWSpellEnchant:
+class SpellEnchant:
     """Core: Enchant Spell Checking Wrapper.
 
     This is a wrapper class for Enchant to keep the API consistent
@@ -60,11 +60,11 @@ class NWSpellEnchant:
         self._language = None
         self._requested = None
         self._broker = None
-        logger.debug("Ready: NWSpellEnchant")
+        logger.debug("Ready: SpellEnchant")
 
     def __del__(self) -> None:  # pragma: no cover
         """Class destructor."""
-        logger.debug("Delete: NWSpellEnchant")
+        logger.debug("Delete: SpellEnchant")
 
     ##
     #  Properties

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -70,7 +70,7 @@ T_UpdateEntry = list[tuple[str | None, StatusEntry]]
 T_StatusKind = Literal["s", "i"]
 
 
-class NWStatus:
+class ItemStatus:
     """Core: Status/Importance Label Class."""
 
     STATUS = "s"
@@ -86,7 +86,7 @@ class NWStatus:
 
     def __del__(self) -> None:  # pragma: no cover
         """Class destructor."""
-        logger.debug("Delete: NWStatus")
+        logger.debug("Delete: ItemStatus")
 
     def __len__(self) -> int:
         """Return the number of entries in the status list."""
@@ -185,7 +185,7 @@ class NWStatus:
             shape = nwStatusShape[str(data[0])]
             color = QColor(str(data[1]))
             theme = CUSTOM_COL if data[1].startswith("#") else data[1]
-            icon = NWStatus.createIcon(self._height, color, shape)
+            icon = ItemStatus.createIcon(self._height, color, shape)
             return StatusEntry(simplified(data[2]), color, theme, shape, icon)
         except Exception:
             logger.error("Could not parse entry %s", data)
@@ -196,7 +196,7 @@ class NWStatus:
         for entry in self._store.values():
             if entry.theme != CUSTOM_COL:
                 entry.color = SHARED.theme.parseColor(entry.theme)
-            entry.icon = NWStatus.createIcon(self._height, entry.color, entry.shape)
+            entry.icon = ItemStatus.createIcon(self._height, entry.color, entry.shape)
 
     @staticmethod
     def createIcon(height: int, color: QColor, shape: nwStatusShape) -> QIcon:

--- a/novelwriter/core/status.py
+++ b/novelwriter/core/status.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Item Status Class
-=======================================
+novelWriter – Project Item Status
+=================================
 
 This file is a part of novelWriter
 Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -33,7 +33,7 @@ from zipfile import ZIP_DEFLATED, ZIP_STORED, ZipFile
 from novelwriter import CONFIG
 from novelwriter.common import isHandle, minmax, safeExists, safeIsDir, safeIsFile, safeIterDir
 from novelwriter.constants import nwFiles
-from novelwriter.core.document import NWDocument
+from novelwriter.core.document import ProjectDocument
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter
 from novelwriter.core.spellcheck import UserDictionary
 from novelwriter.error import logException
@@ -275,11 +275,11 @@ class NWStorage:
             return ProjectXMLWriter(self._runtimePath / nwFiles.PROJ_FILE)
         return None
 
-    def getDocument(self, tHandle: str | None) -> NWDocument:
+    def getDocument(self, tHandle: str | None) -> ProjectDocument:
         """Return a document wrapper object."""
         if isinstance(self._runtimePath, Path) and self._ready:
-            return NWDocument(self._project, tHandle)
-        return NWDocument(self._project, None)
+            return ProjectDocument(self._project, tHandle)
+        return ProjectDocument(self._project, None)
 
     def getMetaFile(self, fileName: str) -> Path | None:
         """Return the path to a file in the project meta folder."""
@@ -290,7 +290,7 @@ class NWStorage:
     def getDocumentText(self, tHandle: str) -> str:
         """Return the text of a document in a fast and efficient way."""
         if isinstance(self._runtimePath, Path):
-            return NWDocument.quickReadText(self._runtimePath / "content", tHandle)
+            return ProjectDocument.quickReadText(self._runtimePath / "content", tHandle)
         return ""
 
     def scanContent(self) -> list[str]:

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class NWStorageOpen(Enum):
+class ProjectStorageOpen(Enum):
     """The status of a storage location."""
 
     UNKOWN = 0
@@ -54,7 +54,7 @@ class NWStorageOpen(Enum):
     READY = 4
 
 
-class NWStorageCreate(Enum):
+class ProjectStorageCreate(Enum):
     """The status of a new storage location."""
 
     NOT_EMPTY = 0
@@ -62,7 +62,7 @@ class NWStorageCreate(Enum):
     READY = 2
 
 
-class NWStorage:
+class ProjectStorage:
     """Core: Project Storage Class.
 
     The class that handles all paths related to the project storage.
@@ -134,12 +134,12 @@ class NWStorage:
         """Check if the storage location is open."""
         return self._ready and self._runtimePath is not None
 
-    def createNewProject(self, path: str | Path) -> NWStorageCreate:
+    def createNewProject(self, path: str | Path) -> ProjectStorageCreate:
         """Create a new project at the given location."""
         inPath = Path(path).resolve()
         if safeIsDir(inPath) and len(list(safeIterDir(inPath))) > 0:
             logger.error("Folder is not empty: %s", inPath)
-            return NWStorageCreate.NOT_EMPTY
+            return ProjectStorageCreate.NOT_EMPTY
 
         self._storagePath = inPath
         self._runtimePath = inPath
@@ -157,13 +157,13 @@ class NWStorage:
             self._exception = exc
             logger.error("Failed to create project folders", exc_info=exc)
             self.clear()
-            return NWStorageCreate.OS_ERROR
+            return ProjectStorageCreate.OS_ERROR
 
         self._ready = True
 
-        return NWStorageCreate.READY
+        return ProjectStorageCreate.READY
 
-    def initProjectStorage(self, path: str | Path, clearLock: bool = False) -> NWStorageOpen:
+    def initProjectStorage(self, path: str | Path, clearLock: bool = False) -> ProjectStorageOpen:
         """Initialise a novelWriter project location."""
         inPath = Path(path).resolve()
 
@@ -180,15 +180,15 @@ class NWStorage:
                 nwxFile = inPath
             else:
                 logger.error("Not a novelWriter project")
-                return NWStorageOpen.UNKOWN
+                return ProjectStorageOpen.UNKOWN
         else:
             logger.error("Not found: %s", inPath)
-            return NWStorageOpen.NOT_FOUND
+            return ProjectStorageOpen.NOT_FOUND
 
         if not safeExists(nwxFile, alert=True):
             # The .nwx file must exist to continue
             logger.error("Not found: %s", nwxFile)
-            return NWStorageOpen.NOT_FOUND
+            return ProjectStorageOpen.NOT_FOUND
 
         nwxPath = nwxFile.parent
 
@@ -206,7 +206,7 @@ class NWStorage:
         self._readLockFile()
         if self._lockedBy:
             logger.error("Project is locked, so not opening")
-            return NWStorageOpen.LOCKED
+            return ProjectStorageOpen.LOCKED
         else:
             logger.debug("Project is not locked")
 
@@ -222,7 +222,7 @@ class NWStorage:
         except Exception as exc:
             logger.error("Failed to create project folders", exc_info=exc)
             self.clear()
-            return NWStorageOpen.FAILED
+            return ProjectStorageOpen.FAILED
 
         # Check for legacy data folders
         try:
@@ -234,11 +234,11 @@ class NWStorage:
         except Exception as exc:
             logger.error("Failed to scan project folder content", exc_info=exc)
             self.clear()
-            return NWStorageOpen.FAILED
+            return ProjectStorageOpen.FAILED
 
         self._ready = True
 
-        return NWStorageOpen.READY
+        return ProjectStorageOpen.READY
 
     def runPostSaveTasks(self, autoSave: bool = False) -> bool:  # pragma: no cover
         """Run tasks after the project has been saved.

--- a/novelwriter/core/storage.py
+++ b/novelwriter/core/storage.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Storage Class
-===================================
+novelWriter – Project Storage
+=============================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -32,7 +32,7 @@ from PyQt6.QtCore import QModelIndex
 from novelwriter import SHARED
 from novelwriter.common import safeIsFile
 from novelwriter.constants import nwFiles, nwLabels, nwStyles, trConst
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.itemmodel import ProjectModel, ProjectNode
 from novelwriter.enum import nwChange, nwItemClass, nwItemLayout, nwItemType
 from novelwriter.error import logException
@@ -52,7 +52,7 @@ class ProjectTree:
 
     Only one instance of this class should exist in the project class.
     This class holds all the project items of the project as instances
-    of NWItem.
+    of ProjectItem.
 
     Each item has a handle, which is a random hex string of length 13.
     The handle is the name of the item everywhere in novelWriter, and is
@@ -64,7 +64,7 @@ class ProjectTree:
     def __init__(self, project: NWProject) -> None:
         self._project = project
         self._model = ProjectModel(self)
-        self._items: dict[str, NWItem] = {}
+        self._items: dict[str, ProjectItem] = {}
         self._nodes: dict[str, ProjectNode] = {}
         self._docs: list[str] = []
         self._trash = None
@@ -83,7 +83,7 @@ class ProjectTree:
         """Return True if there are any items in the project."""
         return bool(self._items)
 
-    def __getitem__(self, tHandle: str | None) -> NWItem | None:
+    def __getitem__(self, tHandle: str | None) -> ProjectItem | None:
         """Return a project item based on its handle. Returns None if
         the handle doesn't exist in the project.
         """
@@ -96,7 +96,7 @@ class ProjectTree:
         """Check if a handle exists in the tree."""
         return tHandle in self._items
 
-    def __iter__(self) -> Iterator[NWItem]:
+    def __iter__(self) -> Iterator[ProjectItem]:
         """Iterate through project items."""
         for node in self._model.root.allChildren():
             yield node.item
@@ -146,7 +146,7 @@ class ProjectTree:
         oldModel.deleteLater()
         del oldModel
 
-    def add(self, item: NWItem, pos: int = -1) -> bool:
+    def add(self, item: ProjectItem, pos: int = -1) -> bool:
         """Add a project item into the project tree."""
         if item.itemHandle in self._nodes or item.itemHandle in self._items:
             logger.error("Item handle '%s' already exists in project tree", item.itemHandle)
@@ -232,7 +232,7 @@ class ProjectTree:
         parent = None if itemType == nwItemType.ROOT else parent
         if parent is None or parent in self._nodes:
             tHandle = self._makeHandle()
-            nwItem = NWItem(self._project, tHandle)
+            nwItem = ProjectItem(self._project, tHandle)
             nwItem.setName(label)
             nwItem.setParent(parent)
             nwItem.setType(itemType)
@@ -241,10 +241,10 @@ class ProjectTree:
                 return tHandle
         return None
 
-    def duplicate(self, sHandle: str, pHandle: str | None, putAfter: bool) -> NWItem | None:
+    def duplicate(self, sHandle: str, pHandle: str | None, putAfter: bool) -> ProjectItem | None:
         """Duplicate an item and set a new handle."""
         if sNode := self._nodes.get(sHandle):
-            nItem = NWItem.duplicate(sNode.item, self._makeHandle())
+            nItem = ProjectItem.duplicate(sNode.item, self._makeHandle())
             nItem.setParent(pHandle)
             if self.add(nItem, (sNode.row() + 1) if putAfter else -1):
                 logger.info("Duplicated item '%s' -> '%s'", sHandle, nItem.itemHandle)
@@ -265,9 +265,9 @@ class ProjectTree:
         project tree.
         """
         self.clear()
-        items: dict[str, NWItem] = self._items.copy()
+        items: dict[str, ProjectItem] = self._items.copy()
         for item in data:
-            nwItem = NWItem(self._project, "")
+            nwItem = ProjectItem(self._project, "")
             if nwItem.unpack(item):
                 items[nwItem.itemHandle] = nwItem
 
@@ -383,7 +383,7 @@ class ProjectTree:
             assert oParent is not None  # Otherwise there's an issue with self.create()
 
             # Create a new item
-            newItem = NWItem(self._project, cHandle)
+            newItem = ProjectItem(self._project, cHandle)
             newItem.setName(f"[{prefix}] {oName}")
             newItem.setParent(oParent)
             newItem.setType(nwItemType.FILE)
@@ -504,7 +504,7 @@ class ProjectTree:
             rootClasses.add(node.item.itemClass)
         return rootClasses
 
-    def iterRoots(self, itemClass: nwItemClass | None) -> Iterable[tuple[str, NWItem]]:
+    def iterRoots(self, itemClass: nwItemClass | None) -> Iterable[tuple[str, ProjectItem]]:
         """Iterate over all root items of a given class in order."""
         for node in self._model.root.children:
             if node.item.isRootType() and (itemClass is None or node.item.itemClass == itemClass):
@@ -522,7 +522,7 @@ class ProjectTree:
     #  Internal Functions
     ##
 
-    def _itemChange(self, item: NWItem, change: nwChange) -> None:
+    def _itemChange(self, item: ProjectItem, change: nwChange) -> None:
         """Signal item change and notify project."""
         tHandle = item.itemHandle
         logger.debug("Item change: %s -> %s", tHandle, change.name)
@@ -541,11 +541,11 @@ class ProjectTree:
             return self._nodes.get(handle)
         return None
 
-    def _addItems(self, items: dict[str, NWItem]) -> dict[str, NWItem]:
+    def _addItems(self, items: dict[str, ProjectItem]) -> dict[str, ProjectItem]:
         """Add a dictionary of items to the project tree. Returns a new
         dictionary of items that could not be added yet, but can be.
         """
-        remains: dict[str, NWItem] = {}
+        remains: dict[str, ProjectItem] = {}
         for handle, item in items.items():
             if handle in self._nodes or handle in self._items:
                 logger.warning("Skipping duplicate item handle '%s' while unpacking project tree", handle)

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 MAX_DEPTH = 999  # Cap of tree traversing for loops (recursion limit)
 
 
-class NWTree:
+class ProjectTree:
     """Core: Project Tree Data Class.
 
     Only one instance of this class should exist in the project class.
@@ -69,11 +69,11 @@ class NWTree:
         self._docs: list[str] = []
         self._trash = None
         self._ready = False
-        logger.debug("Ready: NWTree")
+        logger.debug("Ready: ProjectTree")
 
     def __del__(self) -> None:  # pragma: no cover
         """Class destructor."""
-        logger.debug("Delete: NWTree")
+        logger.debug("Delete: ProjectTree")
 
     def __len__(self) -> int:
         """Return the number of items in the project."""

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Tree Class
-================================
+novelWriter – Project Tree
+==========================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI About Box
-===========================
+novelWriter – GUI About Dialog
+==============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -49,7 +49,7 @@ from PyQt6.QtWidgets import (
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatFileFilter, qtAddAction, qtLambda, simplified
 from novelwriter.constants import nwLabels, trConst
-from novelwriter.core.status import CUSTOM_COL, NWStatus, StatusEntry
+from novelwriter.core.status import CUSTOM_COL, ItemStatus, StatusEntry
 from novelwriter.enum import nwStandardButton, nwStatusShape, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel, NFixedPage, NScrollableForm
 from novelwriter.extensions.modified import NComboBox, NDialog, NIconToolButton
@@ -420,7 +420,7 @@ class _StatusPage(NFixedPage):
         def buildMenu(menu: QMenu | None, items: dict[nwStatusShape, str]) -> None:
             if menu is not None:  # pragma: no branch
                 for shape, label in items.items():
-                    icon = NWStatus.createIcon(self._iPx, iColor, shape)
+                    icon = ItemStatus.createIcon(self._iPx, iColor, shape)
                     action = qtAddAction(menu, trConst(label))
                     action.setIcon(icon)
                     action.triggered.connect(qtLambda(self._selectShape, shape))
@@ -537,7 +537,7 @@ class _StatusPage(NFixedPage):
         """Create a new status item."""
         color = QColor(100, 100, 100)
         shape = nwStatusShape.SQUARE
-        icon = NWStatus.createIcon(self._iPx, color, shape)
+        icon = ItemStatus.createIcon(self._iPx, color, shape)
         theme = str(self.iconColor.currentData())
         self._addItem(None, StatusEntry(self.tr("New Item"), color, theme, shape, icon, 0))
         self._changed = True
@@ -639,7 +639,7 @@ class _StatusPage(NFixedPage):
     def _updateIcon(self) -> None:
         """Apply changes made to a status icon."""
         if item := self._getSelectedItem():
-            icon = NWStatus.createIcon(self._iPx, self._pickColor(), self._shape)
+            icon = ItemStatus.createIcon(self._iPx, self._pickColor(), self._shape)
             entry: StatusEntry = item.data(self.C_DATA, self.D_ENTRY)
             entry.color = self._color
             entry.shape = self._shape
@@ -687,7 +687,7 @@ class _StatusPage(NFixedPage):
 
     def _setButtonIcons(self) -> None:
         """Set the colour of the colour button."""
-        icon = NWStatus.createIcon(self._iPx, self._pickColor(), nwStatusShape.SQUARE)
+        icon = ItemStatus.createIcon(self._iPx, self._pickColor(), nwStatusShape.SQUARE)
         self.iconColor.setCurrentData(self._theme, CUSTOM_COL)
         self.colorButton.setIcon(icon)
         self.shapeButton.setIcon(self._icons[self._shape])

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -65,7 +65,7 @@ from PyQt6.QtWidgets import QApplication, QFrame, QMenu, QTextEdit, QWidget
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import decodeMimeHandles, fontMatcher, minmax, qtAddAction, qtAddMenu, qtLambda, transferCase
 from novelwriter.constants import nwConst, nwKeyWords, nwShortcode, nwStyles, nwUnicode
-from novelwriter.core.document import NWDocument
+from novelwriter.core.document import ProjectDocument
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.editor.autoreplace import TextAutoReplace
 from novelwriter.editor.completer import CommandCompleter
@@ -672,7 +672,7 @@ class GuiDocEditor(QTextEdit):
         QApplication.restoreOverrideCursor()
 
     def saveText(self) -> bool:
-        """Save the text currently in the editor to the NWDocument
+        """Save the text currently in the editor to the ProjectDocument
         object, and update the NWItem meta data.
         """
         if self._nwItem is None or self._nwDocument is None:
@@ -1035,7 +1035,7 @@ class GuiDocEditor(QTextEdit):
         """Tell the user where on the file system the file in the editor
         is saved.
         """
-        if isinstance(self._nwDocument, NWDocument):
+        if isinstance(self._nwDocument, ProjectDocument):
             SHARED.info(
                 [
                     self.tr("Document Details"),

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -673,7 +673,7 @@ class GuiDocEditor(QTextEdit):
 
     def saveText(self) -> bool:
         """Save the text currently in the editor to the ProjectDocument
-        object, and update the NWItem meta data.
+        object, and update the ProjectItem meta data.
         """
         if self._nwItem is None or self._nwDocument is None:
             logger.error("Cannot save text as no document is open")

--- a/novelwriter/error.py
+++ b/novelwriter/error.py
@@ -60,12 +60,12 @@ def formatException(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {exc!s}"
 
 
-class NWErrorMessage(QDialog):
+class ErrorMessage(QDialog):
     """GUI: Error Dialog."""
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
-        self.setObjectName("NWErrorMessage")
+        self.setObjectName("ErrorMessage")
 
         # Widgets
         self.msgIcon = QLabel()
@@ -192,7 +192,7 @@ def exceptionHandler(exType: type, exValue: BaseException, exTrace: TracebackTyp
             logger.warning("Could not find main GUI window so cannot open error dialog")
             return
 
-        errMsg = NWErrorMessage(nwGUI)
+        errMsg = ErrorMessage(nwGUI)
         errMsg.setMessage(exType, exValue, exTrace)
         errMsg.exec()
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -43,7 +43,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import qtAddAction, qtAddMenu, qtLambda, qtWeakLambda
 from novelwriter.constants import nwLabels, nwStyles, nwUnicode, trConst
 from novelwriter.core.coretools import DocDuplicator, DocMerger, DocSplitter
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.itemmodel import ProjectModel, ProjectNode
 from novelwriter.dialogs.docmerge import GuiDocMerge
 from novelwriter.dialogs.docsplit import GuiDocSplit
@@ -408,7 +408,7 @@ class GuiProjectToolBar(QWidget):
         actually be added.
         """
         nwItem = SHARED.project.tree[tHandle]
-        allowDoc = isinstance(nwItem, NWItem) and nwItem.documentAllowed()
+        allowDoc = isinstance(nwItem, ProjectItem) and nwItem.documentAllowed()
         self.aAddScene.setVisible(allowDoc)
         self.aAddChap.setVisible(allowDoc)
         self.aAddPart.setVisible(allowDoc)

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -59,7 +59,7 @@ from novelwriter.types import (
 )
 
 if TYPE_CHECKING:
-    from novelwriter.core.item import NWItem
+    from novelwriter.core.item import ProjectItem
 
 logger = logging.getLogger(__name__)
 
@@ -324,7 +324,7 @@ class GuiProjectSearch(QWidget):
     #  Internal Functions
     ##
 
-    def _displayResultSet(self, nwItem: NWItem | None, results: list[tuple[int, int, str]], capped: bool) -> None:
+    def _displayResultSet(self, nwItem: ProjectItem | None, results: list[tuple[int, int, str]], capped: bool) -> None:
         """Populate the result tree."""
         if results and nwItem:
             tHandle = nwItem.itemHandle

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI Main Window SideBar
-=====================================
+novelWriter – GUI Main Window Side Bar
+======================================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/novelwriter/manuscript/docbuild.py
+++ b/novelwriter/manuscript/docbuild.py
@@ -29,7 +29,7 @@ from PyQt6.QtGui import QFont
 
 from novelwriter import CONFIG
 from novelwriter.constants import nwLabels
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.enum import nwBuildFmt, nwComment
 from novelwriter.error import formatException, logException
 from novelwriter.formats.todocx import ToDocX
@@ -364,7 +364,7 @@ class DocumentBuilder:
     def _doBuild(self, bldObj: Tokenizer, tHandle: str, convert: bool = True) -> bool:
         """Build a single document and add it to the build object."""
         tItem = self._project.tree[tHandle]
-        if isinstance(tItem, NWItem):
+        if isinstance(tItem, ProjectItem):
             try:
                 if tItem.isRootType():
                     if tItem.isNovelLike():

--- a/novelwriter/manuscript/docbuild.py
+++ b/novelwriter/manuscript/docbuild.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class NWBuildDocument:
+class DocumentBuilder:
     """Core: Manuscript Document Build Class.
 
     This is the core tool that assembles a project and outputs a

--- a/novelwriter/manuscript/manusbuild.py
+++ b/novelwriter/manuscript/manusbuild.py
@@ -53,6 +53,7 @@ from novelwriter.enum import nwBuildFmt, nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel
 from novelwriter.extensions.modified import NDialog, NIconToolButton, NPushButton
 from novelwriter.extensions.progressbars import NProgressSimple
+from novelwriter.manuscript.docbuild import DocumentBuilder
 from novelwriter.types import QtAlignCenter, QtRoleAction, QtRoleDestruct, QtUserRole
 
 if TYPE_CHECKING:

--- a/novelwriter/manuscript/manusbuild.py
+++ b/novelwriter/manuscript/manusbuild.py
@@ -53,7 +53,6 @@ from novelwriter.enum import nwBuildFmt, nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel
 from novelwriter.extensions.modified import NDialog, NIconToolButton, NPushButton
 from novelwriter.extensions.progressbars import NProgressSimple
-from novelwriter.manuscript.docbuild import NWBuildDocument
 from novelwriter.types import QtAlignCenter, QtRoleAction, QtRoleDestruct, QtUserRole
 
 if TYPE_CHECKING:
@@ -332,7 +331,7 @@ class GuiManuscriptBuild(NDialog):
 
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
 
-        docBuild = NWBuildDocument(SHARED.project, self._build)
+        docBuild = DocumentBuilder(SHARED.project, self._build)
         docBuild.queueAll()
 
         self.buildProgress.setMaximum(len(docBuild))

--- a/novelwriter/manuscript/manusbuild.py
+++ b/novelwriter/manuscript/manusbuild.py
@@ -48,7 +48,7 @@ from PyQt6.QtWidgets import (
 from novelwriter import SHARED
 from novelwriter.common import makeFileNameSafe, openExternalPath, safeExists, safeIsDir
 from novelwriter.constants import nwLabels
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.enum import nwBuildFmt, nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel
 from novelwriter.extensions.modified import NDialog, NIconToolButton, NPushButton
@@ -382,7 +382,7 @@ class GuiManuscriptBuild(NDialog):
             if filtered.get(tHandle, (False, 0))[0]:
                 if rHandle not in rootMap:
                     rItem = SHARED.project.tree[rHandle]
-                    if isinstance(rItem, NWItem):
+                    if isinstance(rItem, ProjectItem):
                         rootMap[rHandle] = rItem.itemName
 
                 rootName = rootMap.get(rHandle, "??????")

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -69,7 +69,6 @@ from novelwriter.formats.tokenizer import HeadingFormatter
 from novelwriter.formats.toqdoc import ToQTextDocument
 from novelwriter.gui.theme import STYLES_FLAT_TABS, STYLES_MIN_TOOLBUTTON
 from novelwriter.manuscript.buildsettings import BuildCollection, BuildSettings
-from novelwriter.manuscript.docbuild import NWBuildDocument
 from novelwriter.manuscript.manusbuild import GuiManuscriptBuild
 from novelwriter.manuscript.manussettings import GuiBuildSettings
 from novelwriter.types import QtAlignCenter, QtAlignRight, QtAlignTop, QtSizeExpanding, QtSizeIgnored, QtUserRole
@@ -392,7 +391,7 @@ class GuiManuscript(NToolDialog):
         # Make sure editor content is saved before we start
         SHARED.saveEditor()
 
-        docBuild = NWBuildDocument(SHARED.project, build)
+        docBuild = DocumentBuilder(SHARED.project, build)
         docBuild.queueAll()
 
         self.docPreview.beginNewBuild(len(docBuild))

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -69,6 +69,7 @@ from novelwriter.formats.tokenizer import HeadingFormatter
 from novelwriter.formats.toqdoc import ToQTextDocument
 from novelwriter.gui.theme import STYLES_FLAT_TABS, STYLES_MIN_TOOLBUTTON
 from novelwriter.manuscript.buildsettings import BuildCollection, BuildSettings
+from novelwriter.manuscript.docbuild import DocumentBuilder
 from novelwriter.manuscript.manusbuild import GuiManuscriptBuild
 from novelwriter.manuscript.manussettings import GuiBuildSettings
 from novelwriter.types import QtAlignCenter, QtAlignRight, QtAlignTop, QtSizeExpanding, QtSizeIgnored, QtUserRole

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-NWWidget = TypeVar("NWWidget", bound=QWidget)
+NWidget = TypeVar("NWidget", bound=QWidget)
 T_Msg = str | list[str]
 
 RX_HTML = re.compile(r"<.*?>")
@@ -322,7 +322,7 @@ class SharedData(QObject):
 
         return NFontDialog.selectFont(current, self.mainGui, self.tr("Select Font"), native)
 
-    def findTopLevelWidget(self, kind: type[NWWidget]) -> NWWidget | None:
+    def findTopLevelWidget(self, kind: type[NWidget]) -> NWidget | None:
         """Find a top level widget."""
         for widget in self.mainGui.children():
             if isinstance(widget, kind):

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -35,7 +35,7 @@ from PyQt6.QtWidgets import QApplication, QFileDialog, QGridLayout, QMessageBox,
 
 from novelwriter.common import appendIfSet, formatFileFilter, joinLines
 from novelwriter.constants import nwFiles
-from novelwriter.core.spellcheck import NWSpellEnchant
+from novelwriter.core.spellcheck import SpellEnchant
 from novelwriter.enum import nwChange, nwItemClass, nwStandardButton
 from novelwriter.types import QtSizeExpanding, QtSizeMinimum
 
@@ -127,7 +127,7 @@ class SharedData(QObject):
         return self._project
 
     @property
-    def spelling(self) -> NWSpellEnchant:
+    def spelling(self) -> SpellEnchant:
         """Return the active NWProject instance."""
         if self._spelling is None:
             raise RuntimeError("SharedData class not fully initialised")
@@ -472,7 +472,7 @@ class SharedData(QObject):
             del self._project
             del self._spelling
         self._project = NWProject()
-        self._spelling = NWSpellEnchant(self._project)
+        self._spelling = SpellEnchant(self._project)
         self.updateSpellCheckLanguage()
         self._focusMode = False
 

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 class GuiWritingStats(NToolDialog):
     """GUI Tools: Writing Statistics.
 
-    Displays data from the NWSessionLog object.
+    Displays data from the SessionLog object.
     """
 
     C_TIME = 0

--- a/tests/core/test_coretools.py
+++ b/tests/core/test_coretools.py
@@ -37,7 +37,6 @@ from novelwriter.core.coretools import DocDuplicator, DocMerger, DocSearch, DocS
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwBuildFmt
 from novelwriter.manuscript.buildsettings import BuildSettings
-from novelwriter.manuscript.docbuild import NWBuildDocument
 
 from tests.helpers import NWD_IGNORE, XML_IGNORE, C, buildTestProject, cmpFiles
 from tests.mocked import causeOSError
@@ -659,7 +658,7 @@ def testCoreTools_ProjectBuilderA(monkeypatch, fncPath, tstPaths, mockGUI, mockR
 
     build = BuildSettings()
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     testFile = tstPaths.outDir / "coreTools_ProjectBuilderA_Project.md"
@@ -707,7 +706,7 @@ def testCoreTools_ProjectBuilderB(monkeypatch, fncPath, tstPaths, mockGUI, mockR
 
     build = BuildSettings()
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     testFile = tstPaths.outDir / "coreTools_ProjectBuilderB_Project.md"

--- a/tests/core/test_coretools.py
+++ b/tests/core/test_coretools.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Document Tools Tester
-===========================================
+novelWriter – Core Tools Tests
+==============================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_coretools.py
+++ b/tests/core/test_coretools.py
@@ -37,6 +37,7 @@ from novelwriter.core.coretools import DocDuplicator, DocMerger, DocSearch, DocS
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwBuildFmt
 from novelwriter.manuscript.buildsettings import BuildSettings
+from novelwriter.manuscript.docbuild import DocumentBuilder
 
 from tests.helpers import NWD_IGNORE, XML_IGNORE, C, buildTestProject, cmpFiles
 from tests.mocked import causeOSError

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWDocument Class Tester
-=====================================
+novelWriter – NWDocument Tests
+==============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWDocument Tests
-==============================
+novelWriter – Project Document Tests
+====================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pytest
 
-from novelwriter.core.document import NWDocument
+from novelwriter.core.document import ProjectDocument
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwItemClass, nwItemLayout
 
@@ -32,8 +32,8 @@ from tests.mocked import causeOSError
 
 
 @pytest.mark.core
-def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
-    """Test loading and saving a document with the NWDocument class."""
+def testProjectDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
+    """Test loading and saving a document with the ProjectDocument class."""
     monkeypatch.setattr("novelwriter.core.document.time", lambda: MOCK_TIME)
 
     project = NWProject()
@@ -44,7 +44,7 @@ def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     # =============
 
     # Not a valid handle
-    doc = NWDocument(project, "stuff")
+    doc = ProjectDocument(project, "stuff")
     assert bool(doc) is False
     assert doc.readDocument() is None
     assert doc.fileExists() is False
@@ -53,7 +53,7 @@ def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     assert doc.updatedDate == "Unknown"
 
     # Non-existent handle
-    doc = NWDocument(project, C.hInvalid)
+    doc = ProjectDocument(project, C.hInvalid)
     assert doc.readDocument() is None
     assert doc._lastHash == ""
     assert doc.fileExists() is False
@@ -61,29 +61,29 @@ def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     # No content path
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.storage.NWStorage.contentPath", property(lambda *a: None))
-        doc = NWDocument(project, C.hSceneDoc)
+        doc = ProjectDocument(project, C.hSceneDoc)
         assert doc.readDocument() is None
         assert doc.fileExists() is False
 
     # Cause open() to fail while loading
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", causeOSError)
-        doc = NWDocument(project, C.hSceneDoc)
+        doc = ProjectDocument(project, C.hSceneDoc)
         assert doc.fileExists() is True
         assert doc.readDocument() is None
         assert doc.getError() == "OSError: Mock OSError"
 
     # Load the text
-    doc = NWDocument(project, C.hSceneDoc)
+    doc = ProjectDocument(project, C.hSceneDoc)
     assert doc.fileExists() is True
     assert doc.readDocument() == "### New Scene\n\n"
 
     # Try to open a new (non-existent) file
     xHandle = project.newFile("New File", C.hNovelRoot)
     assert xHandle is not None
-    doc = NWDocument(project, xHandle)
+    doc = ProjectDocument(project, xHandle)
     assert bool(doc) is True
-    assert repr(doc) == f"<NWDocument handle={xHandle}>"
+    assert repr(doc) == f"<ProjectDocument handle={xHandle}>"
     assert doc.readDocument() == ""
 
     # Write Document
@@ -92,12 +92,12 @@ def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     # No content path
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.storage.NWStorage.contentPath", property(lambda *a: None))
-        doc = NWDocument(project, xHandle)
+        doc = ProjectDocument(project, xHandle)
         assert doc.writeDocument("") is False
 
     # Set handle and save
     text = "### Test File\n\nText ...\n\n"
-    doc = NWDocument(project, xHandle)
+    doc = ProjectDocument(project, xHandle)
     assert doc.writeDocument(text) is True
 
     # Save again to ensure temp file and previous file is handled
@@ -150,7 +150,7 @@ def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     assert doc.writeDocument(text) is False
 
     # Trailing line break
-    doc = NWDocument(project, xHandle)
+    doc = ProjectDocument(project, xHandle)
     assert doc.writeDocument("") is True
     assert doc.readDocument() == ""
     assert doc.writeDocument("Stuff") is True
@@ -163,24 +163,24 @@ def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     # Quick Read
     # ==========
 
-    doc = NWDocument(project, xHandle)
+    doc = ProjectDocument(project, xHandle)
     assert doc.writeDocument("### Test File\n\nText ...\n\n") is True
 
     contPath = fncPath / "content"
-    assert NWDocument.quickReadText(contPath, xHandle) == ("### Test File\n\nText ...\n\n")
+    assert ProjectDocument.quickReadText(contPath, xHandle) == ("### Test File\n\nText ...\n\n")
 
     # Check read text fallback
-    assert NWDocument.quickReadText(contPath, "0000000000000") == ""
+    assert ProjectDocument.quickReadText(contPath, "0000000000000") == ""
     with monkeypatch.context() as mp:
         mp.setattr("builtins.open", causeOSError)
-        assert NWDocument.quickReadText(contPath, xHandle) == ""
+        assert ProjectDocument.quickReadText(contPath, xHandle) == ""
 
     # A document with more than 10 consecutive meta lines returns the 10th line onwards
     (contPath / f"{xHandle}.nwd").write_text("".join(f"%%~meta{i}\n" for i in range(15)), encoding="utf-8")
-    assert NWDocument.quickReadText(contPath, xHandle) == "".join(f"%%~meta{i}\n" for i in range(9, 15))
+    assert ProjectDocument.quickReadText(contPath, xHandle) == "".join(f"%%~meta{i}\n" for i in range(9, 15))
 
     # A document that is all meta data lines returns just the trailing content
-    doc = NWDocument(project, xHandle)
+    doc = ProjectDocument(project, xHandle)
     metaOnly = "".join(f"%%~meta{i}\n" for i in range(9)) + "%%~kind: NOVEL/DOCUMENT\nTrailing Text\n"
     (contPath / f"{xHandle}.nwd").write_text(metaOnly, encoding="utf-8")
     assert doc.readDocument() == "Trailing Text\n"
@@ -196,39 +196,39 @@ def testNWDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
     # ===============
 
     # Delete a non-existing document
-    doc = NWDocument(project, "stuff")
+    doc = ProjectDocument(project, "stuff")
     assert doc.deleteDocument() is False
     assert docPath.exists()
 
     # No content path
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.storage.NWStorage.contentPath", property(lambda *a: None))
-        doc = NWDocument(project, xHandle)
+        doc = ProjectDocument(project, xHandle)
         assert doc.deleteDocument() is False
 
     # Cause the delete to fail
     with monkeypatch.context() as mp:
         mp.setattr("pathlib.Path.unlink", causeOSError)
-        doc = NWDocument(project, xHandle)
+        doc = ProjectDocument(project, xHandle)
         assert doc.deleteDocument() is False
         assert doc.getError() == "OSError: Mock OSError"
 
     # Make the delete pass
-    doc = NWDocument(project, xHandle)
+    doc = ProjectDocument(project, xHandle)
     assert doc.deleteDocument() is True
     assert not docPath.exists()
 
 
 @pytest.mark.core
-def testNWDocument_Methods(monkeypatch, mockGUI, fncPath, mockRnd):
-    """Test other methods of the NWDocument class."""
+def testProjectDocument_Methods(monkeypatch, mockGUI, fncPath, mockRnd):
+    """Test other methods of the ProjectDocument class."""
     monkeypatch.setattr("novelwriter.core.document.time", lambda: MOCK_TIME)
 
     project = NWProject()
     mockRnd.reset()
     buildTestProject(project, fncPath)
 
-    doc = NWDocument(project, C.hSceneDoc)
+    doc = ProjectDocument(project, C.hSceneDoc)
     docPath = fncPath / "content" / f"{C.hSceneDoc}.nwd"
 
     assert doc.readDocument() == "### New Scene\n\n"

--- a/tests/core/test_document.py
+++ b/tests/core/test_document.py
@@ -60,7 +60,7 @@ def testProjectDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
 
     # No content path
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.contentPath", property(lambda *a: None))
+        mp.setattr("novelwriter.core.storage.ProjectStorage.contentPath", property(lambda *a: None))
         doc = ProjectDocument(project, C.hSceneDoc)
         assert doc.readDocument() is None
         assert doc.fileExists() is False
@@ -91,7 +91,7 @@ def testProjectDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
 
     # No content path
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.contentPath", property(lambda *a: None))
+        mp.setattr("novelwriter.core.storage.ProjectStorage.contentPath", property(lambda *a: None))
         doc = ProjectDocument(project, xHandle)
         assert doc.writeDocument("") is False
 
@@ -202,7 +202,7 @@ def testProjectDocument_LoadSave(monkeypatch, mockGUI, fncPath, mockRnd):
 
     # No content path
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.contentPath", property(lambda *a: None))
+        mp.setattr("novelwriter.core.storage.ProjectStorage.contentPath", property(lambda *a: None))
         doc = ProjectDocument(project, xHandle)
         assert doc.deleteDocument() is False
 

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -89,7 +89,7 @@ def testIndex_LoadSave(qtbot, monkeypatch, prjLipsum, nwGUI, tstPaths):
 
     # No folder for saving
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getMetaFile", lambda *a: None)
         assert index.saveIndex() is False
 
     # Make the save fail
@@ -141,7 +141,7 @@ def testIndex_LoadSave(qtbot, monkeypatch, prjLipsum, nwGUI, tstPaths):
 
     # No folder for loading
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getMetaFile", lambda *a: None)
         assert index.loadIndex() is False
 
     # Make the load fail

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Index Class Tester
-================================
+novelWriter – Index Tests
+=========================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -30,7 +30,7 @@ import pytest
 from novelwriter import SHARED
 from novelwriter.constants import nwFiles
 from novelwriter.core.index import Index, TagsIndex
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.novelmodel import NovelModel
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwComment, nwItemClass, nwItemLayout, nwNovelExtra
@@ -277,9 +277,9 @@ def testIndex_CheckThese(nwGUI, fncPath, mockRnd):
     nItem = project.tree[nHandle]
     cItem = project.tree[cHandle]
     wItem = project.tree[wHandle]
-    assert isinstance(nItem, NWItem)
-    assert isinstance(cItem, NWItem)
-    assert isinstance(wItem, NWItem)
+    assert isinstance(nItem, ProjectItem)
+    assert isinstance(cItem, ProjectItem)
+    assert isinstance(wItem, ProjectItem)
 
     assert index.rootChangedSince(C.hNovelRoot, 0) is False
     assert index.rootChangedSince(None, 0) is False
@@ -388,7 +388,7 @@ def testIndex_ScanText(monkeypatch, nwGUI, fncPath, mockRnd):
     assert isinstance(xHandle, str)
 
     xItem = project.tree[xHandle]
-    assert isinstance(xItem, NWItem)
+    assert isinstance(xItem, ProjectItem)
     xItem.setLayout(nwItemLayout.NO_LAYOUT)
 
     # Check invalid data

--- a/tests/core/test_indexdata.py
+++ b/tests/core/test_indexdata.py
@@ -26,7 +26,7 @@ import pytest
 from novelwriter import CONFIG
 from novelwriter.core.index import IndexCache, TagsIndex
 from novelwriter.core.indexdata import IndexHeading, IndexNode
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwComment
 
@@ -36,7 +36,7 @@ def testIndexData_IndexNode(mockGUI):
     """Test the IndexNode class."""
     handle = "0123456789abc"
     project = NWProject()
-    item = NWItem(project, handle)
+    item = ProjectItem(project, handle)
     cache = IndexCache(TagsIndex())
 
     # Defaults
@@ -115,7 +115,7 @@ def testIndexData_IndexNodePackUnpack(mockGUI):
     """Test the pack and unpack methods of the IndexNode class."""
     handle = "0123456789abc"
     project = NWProject()
-    item = NWItem(project, handle)
+    item = ProjectItem(project, handle)
     cache = IndexCache(TagsIndex())
     node = IndexNode(cache, handle, item)
 

--- a/tests/core/test_indexdata.py
+++ b/tests/core/test_indexdata.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Index Data Class Tester
-=====================================
+novelWriter – Index Data Tests
+==============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_item.py
+++ b/tests/core/test_item.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWItem Class Tester
-=================================
+novelWriter – NWItem Tests
+==========================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_item.py
+++ b/tests/core/test_item.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWItem Tests
-==========================
+novelWriter – Project Item Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors
@@ -28,7 +28,7 @@ import pytest
 from PyQt6.QtGui import QIcon
 
 from novelwriter import CONFIG
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 
@@ -36,12 +36,12 @@ from tests.helpers import C, buildTestProject
 
 
 @pytest.mark.core
-def testNWItem_Setters(mockGUI, mockRnd, fncPath):
-    """Test all the simple setters for the NWItem class."""
+def testProjectItem_Setters(mockGUI, mockRnd, fncPath):
+    """Test all the simple setters for the ProjectItem class."""
     project = NWProject()
     mockRnd.reset()
     buildTestProject(project, fncPath)
-    item = NWItem(project, "0000000000000")
+    item = ProjectItem(project, "0000000000000")
     assert item.itemHandle == "0000000000000"
 
     statusKeys = ["s000000", "s000001", "s000002", "s000003"]
@@ -189,12 +189,12 @@ def testNWItem_Setters(mockGUI, mockRnd, fncPath):
 
 
 @pytest.mark.core
-def testNWItem_Methods(mockGUI, mockRnd, fncPath):
-    """Test the simple methods of the NWItem class."""
+def testProjectItem_Methods(mockGUI, mockRnd, fncPath):
+    """Test the simple methods of the ProjectItem class."""
     project = NWProject()
     mockRnd.reset()
     buildTestProject(project, fncPath)
-    item = NWItem(project, "0000000000000")
+    item = ProjectItem(project, "0000000000000")
 
     # Describe Me
     # ===========
@@ -271,14 +271,14 @@ def testNWItem_Methods(mockGUI, mockRnd, fncPath):
 
     item.setName("New Item")
     item.setParent("1111111111111")
-    assert repr(item) == "<NWItem handle=0000000000000, parent=1111111111111, name='New Item'>"
+    assert repr(item) == "<ProjectItem handle=0000000000000, parent=1111111111111, name='New Item'>"
 
     # Truthiness
     # ==========
 
     # Is True if the handle evaluates to True
-    assert bool(NWItem(project, "0000000000000")) is True
-    assert bool(NWItem(project, "")) is False
+    assert bool(ProjectItem(project, "0000000000000")) is True
+    assert bool(ProjectItem(project, "")) is False
 
     # Copy an Item
     # ============
@@ -307,7 +307,7 @@ def testNWItem_Methods(mockGUI, mockRnd, fncPath):
 
     # Get the scene item
     scItem = project.tree[C.hSceneDoc]
-    assert isinstance(scItem, NWItem)
+    assert isinstance(scItem, ProjectItem)
 
     # Duplicate and update the expected content with a new handle
     cpHandle = project.tree._makeHandle()
@@ -315,8 +315,8 @@ def testNWItem_Methods(mockGUI, mockRnd, fncPath):
     cpData["itemAttr"]["handle"] = cpHandle
 
     # Duplicate the scene item
-    cpItem = NWItem.duplicate(scItem, cpHandle)
-    assert isinstance(cpItem, NWItem)
+    cpItem = ProjectItem.duplicate(scItem, cpHandle)
+    assert isinstance(cpItem, ProjectItem)
     assert scItem is not cpItem
 
     # They should both point to the same project instance
@@ -332,12 +332,12 @@ def testNWItem_Methods(mockGUI, mockRnd, fncPath):
 
 
 @pytest.mark.core
-def testNWItem_TypeSetter(mockGUI):
-    """Test the setter for all the nwItemType values for the NWItem
+def testProjectItem_TypeSetter(mockGUI):
+    """Test the setter for all the nwItemType values for the ProjectItem
     class.
     """
     project = NWProject()
-    item = NWItem(project, "0000000000000")
+    item = ProjectItem(project, "0000000000000")
 
     # Type
     item.setType(None)
@@ -359,12 +359,12 @@ def testNWItem_TypeSetter(mockGUI):
 
 
 @pytest.mark.core
-def testNWItem_ClassSetter(mockGUI):
-    """Test the setter for all the nwItemClass values for the NWItem
-    class.
+def testProjectItem_ClassSetter(mockGUI):
+    """Test the setter for all the nwItemClass values for the
+    ProjectItem class.
     """
     project = NWProject()
-    item = NWItem(project, "0000000000000")
+    item = ProjectItem(project, "0000000000000")
     item.setType(nwItemType.FILE)
 
     # Class
@@ -463,12 +463,12 @@ def testNWItem_ClassSetter(mockGUI):
 
 
 @pytest.mark.core
-def testNWItem_LayoutSetter(mockGUI):
-    """Test the setter for all the nwItemLayout values for the NWItem
-    class.
+def testProjectItem_LayoutSetter(mockGUI):
+    """Test the setter for all the nwItemLayout values for the
+    ProjectItem class.
     """
     project = NWProject()
-    item = NWItem(project, "0000000000000")
+    item = ProjectItem(project, "0000000000000")
 
     # Faulty Layouts
     item.setLayout(None)
@@ -490,10 +490,10 @@ def testNWItem_LayoutSetter(mockGUI):
 
 
 @pytest.mark.core
-def testNWItem_ClassDefaults(mockGUI):
-    """Test the setter for the default values."""
+def testProjectItem_ClassDefaults(mockGUI):
+    """Test the setter for the default values for the ProjectItem class."""
     project = NWProject()
-    item = NWItem(project, "0000000000000")
+    item = ProjectItem(project, "0000000000000")
 
     # Root items should not have their class updated
     item.setParent(None)
@@ -543,18 +543,18 @@ def testNWItem_ClassDefaults(mockGUI):
 
 
 @pytest.mark.core
-def testNWItem_PackUnpack(mockGUI, caplog, mockRnd):
-    """Test packing and unpacking entries for the NWItem class."""
+def testProjectItem_PackUnpack(mockGUI, caplog, mockRnd):
+    """Test packing and unpacking entries for the ProjectItem class."""
     project = NWProject()
     project.data.itemStatus.add(None, "New", "#646464", "SQUARE", 0)
     project.data.itemImport.add(None, "New", "#646464", "SQUARE", 0)
 
     # Invalid
-    item = NWItem(project, "0000000000000")
+    item = ProjectItem(project, "0000000000000")
     assert item.unpack({}) is False
 
     # File
-    item = NWItem(project, "")
+    item = ProjectItem(project, "")
     assert (
         item.unpack({
             "name": "A File",
@@ -629,7 +629,7 @@ def testNWItem_PackUnpack(mockGUI, caplog, mockRnd):
     }
 
     # Folder
-    item = NWItem(project, "")
+    item = ProjectItem(project, "")
     assert (
         item.unpack({
             "name": "A Folder",
@@ -697,7 +697,7 @@ def testNWItem_PackUnpack(mockGUI, caplog, mockRnd):
     }
 
     # Root
-    item = NWItem(project, "")
+    item = ProjectItem(project, "")
     assert (
         item.unpack({
             "name": "A Novel",

--- a/tests/core/test_itemmodel.py
+++ b/tests/core/test_itemmodel.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Item Model Tester
-===============================
+novelWriter – Item Model Tests
+==============================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_itemmodel.py
+++ b/tests/core/test_itemmodel.py
@@ -28,7 +28,7 @@ from PyQt6.QtTest import QAbstractItemModelTester
 
 from novelwriter.common import decodeMimeHandles, encodeMimeHandles
 from novelwriter.constants import nwConst
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.itemmodel import INV_ROOT, NODE_FLAGS, ProjectModel, ProjectNode
 from novelwriter.core.project import NWProject
 from novelwriter.enum import nwItemLayout, nwItemType
@@ -41,7 +41,7 @@ from tests.helpers import buildTestProject
 def testProjectNode_Root(mockGUI):
     """Test the project node class for the root."""
     project = NWProject()
-    root = ProjectNode(NWItem(project, INV_ROOT))
+    root = ProjectNode(ProjectItem(project, INV_ROOT))
 
     # Defaults
     assert bool(root) is True
@@ -547,7 +547,7 @@ def testProjectModel_Edit(qtbot, mockGUI, mockRnd, fncPath):
     assert model.removeChild(novelIdx, 99) is None
 
     # _moveNode should return False for detached nodes
-    orphan = ProjectNode(NWItem(project, "123456789abcd"))
+    orphan = ProjectNode(ProjectItem(project, "123456789abcd"))
     orphan.detach()
     assert model._moveNode(orphan, novelIdx, -1) is False
 

--- a/tests/core/test_novelmodel.py
+++ b/tests/core/test_novelmodel.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Novel Model Tester
-================================
+novelWriter – Novel Model Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2025 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_options.py
+++ b/tests/core/test_options.py
@@ -1,6 +1,6 @@
 """
-novelWriter – OptionState Class Tester
-======================================
+novelWriter – OptionState Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -330,7 +330,7 @@ def testNWProject_Open(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
 
     # Fail checking items should still pass
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.tree.NWTree.checkConsistency", lambda *a: (1, 0))
+        mp.setattr("novelwriter.core.tree.ProjectTree.checkConsistency", lambda *a: (1, 0))
         assert project.openProject(fncPath, clearLock=True) is True
 
     # Trigger an index rebuild

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -280,7 +280,7 @@ def testNWProject_Open(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
 
     # Fail getting xml reader
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getXmlReader", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getXmlReader", lambda *a: None)
         assert project.openProject(fncPath, clearLock=True) is False
 
     # Not a novelwriter XML file
@@ -325,7 +325,7 @@ def testNWProject_Open(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
 
     # If the storage path is unavailable, recent projects are not updated
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.storagePath", property(lambda *a: None))
+        mp.setattr("novelwriter.core.storage.ProjectStorage.storagePath", property(lambda *a: None))
         assert project.openProject(fncPath, clearLock=True) is True
 
     # Fail checking items should still pass
@@ -358,7 +358,7 @@ def testNWProject_Save(monkeypatch, mockGUI, mockRnd, fncPath):
 
     # Fail getting xml writer
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getXmlWriter", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getXmlWriter", lambda *a: None)
         assert project.saveProject() is False
 
     # Fail writing
@@ -372,7 +372,7 @@ def testNWProject_Save(monkeypatch, mockGUI, mockRnd, fncPath):
 
     # If the storage path is unavailable, recent projects are not updated
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.storagePath", property(lambda *a: None))
+        mp.setattr("novelwriter.core.storage.ProjectStorage.storagePath", property(lambda *a: None))
         assert project.saveProject() is True
 
     project.closeProject()

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWProject Class Tester
-====================================
+novelWriter – NWProject Tests
+=============================
 
 This file is a part of novelWriter
 Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_projectdata.py
+++ b/tests/core/test_projectdata.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Data Class Tester
-=======================================
+novelWriter – Project Data Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_projectdata.py
+++ b/tests/core/test_projectdata.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pytest
 
-from novelwriter.core.projectdata import NWProjectData
+from novelwriter.core.projectdata import ProjectData
 
 
 class MockProject:
@@ -38,10 +38,10 @@ class MockProject:
 
 
 @pytest.mark.core
-def testNWProjectData_Uuid(mockGUI):
+def testProjectData_Uuid(mockGUI):
     """Test the setUuid setter."""
     project = MockProject()
-    data = NWProjectData(project)  # type: ignore
+    data = ProjectData(project)  # type: ignore
 
     # An empty/invalid value generates a new uuid
     data.setUuid("not-a-uuid")
@@ -61,10 +61,10 @@ def testNWProjectData_Uuid(mockGUI):
 
 
 @pytest.mark.core
-def testNWProjectData_Language(mockGUI):
+def testProjectData_Language(mockGUI):
     """Test the setLanguage setter."""
     project = MockProject()
-    data = NWProjectData(project)  # type: ignore
+    data = ProjectData(project)  # type: ignore
 
     data.setLanguage("en_GB")
     assert data.language == "en_GB"
@@ -77,10 +77,10 @@ def testNWProjectData_Language(mockGUI):
 
 
 @pytest.mark.core
-def testNWProjectData_LastHandle(mockGUI):
+def testProjectData_LastHandle(mockGUI):
     """Test the setLastHandle and setLastHandles setters."""
     project = MockProject()
-    data = NWProjectData(project)  # type: ignore
+    data = ProjectData(project)  # type: ignore
 
     # Setting with a non-string component does nothing
     project.changed = 0
@@ -102,10 +102,10 @@ def testNWProjectData_LastHandle(mockGUI):
 
 
 @pytest.mark.core
-def testNWProjectData_CurrCounts(mockGUI):
+def testProjectData_CurrCounts(mockGUI):
     """Test the setCurrCounts setter."""
     project = MockProject()
-    data = NWProjectData(project)  # type: ignore
+    data = ProjectData(project)  # type: ignore
 
     data.setCurrCounts(1, 2, 3, 4)
     assert data.currCounts == (1, 2, 3, 4)
@@ -116,10 +116,10 @@ def testNWProjectData_CurrCounts(mockGUI):
 
 
 @pytest.mark.core
-def testNWProjectData_AutoReplace(mockGUI):
+def testProjectData_AutoReplace(mockGUI):
     """Test the setAutoReplace setter."""
     project = MockProject()
-    data = NWProjectData(project)  # type: ignore
+    data = ProjectData(project)  # type: ignore
 
     # Requires a dict
     project.changed = 0

--- a/tests/core/test_projectxml.py
+++ b/tests/core/test_projectxml.py
@@ -32,7 +32,7 @@ import pytest
 from novelwriter import SHARED
 from novelwriter.constants import nwFiles
 from novelwriter.core.item import NWItem
-from novelwriter.core.projectdata import NWProjectData
+from novelwriter.core.projectdata import ProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.status import CUSTOM_COL, NWStatus
 from novelwriter.enum import nwStatusShape
@@ -44,7 +44,7 @@ from tests.mocked import causeOSError
 class MockProject:
     """Fake project object."""
 
-    data: NWProjectData
+    data: ProjectData
 
     def setProjectChanged(self, *a):
         """Fake project method."""
@@ -68,7 +68,7 @@ def testProjectXMLReader_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
     xmlReader = ProjectXMLReader(xmlFile)
     assert xmlReader.state == XMLReadState.NO_ACTION
 
-    data = NWProjectData(MockProject())  # type: ignore
+    data = ProjectData(MockProject())  # type: ignore
     content = []
 
     # With no valid files, the read should fail
@@ -134,7 +134,7 @@ def testProjectXMLReader_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
     assert xmlReader.state == XMLReadState.WAS_LEGACY
 
     # Reset data objects
-    data = NWProjectData(MockProject())  # type: ignore
+    data = ProjectData(MockProject())  # type: ignore
     content = []
 
     # Parse a valid, complete file
@@ -283,7 +283,7 @@ def testProjectXMLReader_ReadLegacy10(tstPaths, fncPath, mockGUI, mockRnd):
     xmlReader = ProjectXMLReader(xmlFile)
     assert xmlReader.state == XMLReadState.NO_ACTION
 
-    data = NWProjectData(MockProject())  # type: ignore
+    data = ProjectData(MockProject())  # type: ignore
     content = []
 
     assert xmlReader.read(data, content) is True
@@ -441,7 +441,7 @@ def testProjectXMLReader_ReadLegacy11(tstPaths, fncPath, mockGUI, mockRnd):
     xmlReader = ProjectXMLReader(xmlFile)
     assert xmlReader.state == XMLReadState.NO_ACTION
 
-    data = NWProjectData(MockProject())  # type: ignore
+    data = ProjectData(MockProject())  # type: ignore
     content = []
 
     assert xmlReader.read(data, content) is True
@@ -599,7 +599,7 @@ def testProjectXMLReader_ReadLegacy12(tstPaths, fncPath, mockGUI, mockRnd):
     xmlReader = ProjectXMLReader(xmlFile)
     assert xmlReader.state == XMLReadState.NO_ACTION
 
-    data = NWProjectData(MockProject())  # type: ignore
+    data = ProjectData(MockProject())  # type: ignore
     content = []
 
     assert xmlReader.read(data, content) is True
@@ -760,7 +760,7 @@ def testProjectXMLReader_ReadLegacy13(tstPaths, fncPath, mockGUI, mockRnd):
     xmlReader = ProjectXMLReader(xmlFile)
     assert xmlReader.state == XMLReadState.NO_ACTION
 
-    data = NWProjectData(MockProject())  # type: ignore
+    data = ProjectData(MockProject())  # type: ignore
     content = []
 
     assert xmlReader.read(data, content) is True
@@ -921,7 +921,7 @@ def testProjectXMLReader_ReadLegacy14(tstPaths, fncPath, mockGUI, mockRnd):
     xmlReader = ProjectXMLReader(xmlFile)
     assert xmlReader.state == XMLReadState.NO_ACTION
 
-    data = NWProjectData(MockProject())  # type: ignore
+    data = ProjectData(MockProject())  # type: ignore
     content = []
 
     assert xmlReader.read(data, content) is True

--- a/tests/core/test_projectxml.py
+++ b/tests/core/test_projectxml.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ProjectXMLReader/Writer Class Tester
-==================================================
+novelWriter – Project XML Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_projectxml.py
+++ b/tests/core/test_projectxml.py
@@ -31,7 +31,7 @@ import pytest
 
 from novelwriter import SHARED
 from novelwriter.constants import nwFiles
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.projectdata import ProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
 from novelwriter.core.status import CUSTOM_COL, NWStatus
@@ -244,7 +244,7 @@ def testProjectXMLReader_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
     mockProject = MockProject()
     mockProject.data = data
     for entry in content:
-        item = NWItem(mockProject, "0000000000000")  # type: ignore
+        item = ProjectItem(mockProject, "0000000000000")  # type: ignore
         item.unpack(entry)
         packedContent.append(item.pack())
 
@@ -389,7 +389,7 @@ def testProjectXMLReader_ReadLegacy10(tstPaths, fncPath, mockGUI, mockRnd):
     mockProject.data = data
     status = {}
     for entry in content:
-        item = NWItem(mockProject, "0000000000000")  # type: ignore
+        item = ProjectItem(mockProject, "0000000000000")  # type: ignore
         item.unpack(entry)
         status[item.itemHandle] = item.getImportStatus()[0]
         packedContent.append(item.pack())
@@ -547,7 +547,7 @@ def testProjectXMLReader_ReadLegacy11(tstPaths, fncPath, mockGUI, mockRnd):
     mockProject.data = data
     status = {}
     for entry in content:
-        item = NWItem(mockProject, "0000000000000")  # type: ignore
+        item = ProjectItem(mockProject, "0000000000000")  # type: ignore
         item.unpack(entry)
         status[item.itemHandle] = item.getImportStatus()[0]
         packedContent.append(item.pack())
@@ -705,7 +705,7 @@ def testProjectXMLReader_ReadLegacy12(tstPaths, fncPath, mockGUI, mockRnd):
     mockProject.data = data
     status = {}
     for entry in content:
-        item = NWItem(mockProject, "0000000000000")  # type: ignore
+        item = ProjectItem(mockProject, "0000000000000")  # type: ignore
         item.unpack(entry)
         status[item.itemHandle] = item.getImportStatus()[0]
         packedContent.append(item.pack())
@@ -866,7 +866,7 @@ def testProjectXMLReader_ReadLegacy13(tstPaths, fncPath, mockGUI, mockRnd):
     mockProject.data = data
     status = {}
     for entry in content:
-        item = NWItem(mockProject, "0000000000000")  # type: ignore
+        item = ProjectItem(mockProject, "0000000000000")  # type: ignore
         item.unpack(entry)
         status[item.itemHandle] = item.getImportStatus()[0]
         packedContent.append(item.pack())
@@ -1026,7 +1026,7 @@ def testProjectXMLReader_ReadLegacy14(tstPaths, fncPath, mockGUI, mockRnd):
     mockProject.data = data
     status = {}
     for entry in content:
-        item = NWItem(mockProject, "0000000000000")  # type: ignore
+        item = ProjectItem(mockProject, "0000000000000")  # type: ignore
         item.unpack(entry)
         status[item.itemHandle] = item.getImportStatus()[0]
         packedContent.append(item.pack())

--- a/tests/core/test_projectxml.py
+++ b/tests/core/test_projectxml.py
@@ -34,7 +34,7 @@ from novelwriter.constants import nwFiles
 from novelwriter.core.item import ProjectItem
 from novelwriter.core.projectdata import ProjectData
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter, XMLReadState
-from novelwriter.core.status import CUSTOM_COL, NWStatus
+from novelwriter.core.status import CUSTOM_COL, ItemStatus
 from novelwriter.enum import nwStatusShape
 
 from tests.helpers import cmpFiles, writeFile
@@ -1079,7 +1079,7 @@ def testProjectXMLReaderWriter_ParsePackHelpers(mockGUI, fncPath):
     xmlWriter = ProjectXMLWriter(fncPath / nwFiles.PROJ_FILE)
 
     # Non-entry elements in a status/importance list are skipped
-    status = NWStatus(NWStatus.STATUS)
+    status = ItemStatus(ItemStatus.STATUS)
     xItem = ET.fromstring('<status><entry key="s000001" color="#ff0000">New</entry><other>Ignored</other></status>')
     xmlReader._parseStatusImport(xItem, status)
     assert len(status) == 1

--- a/tests/core/test_sessions.py
+++ b/tests/core/test_sessions.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWSessionLog Class Tester
-=======================================
+novelWriter – SessionLog Tests
+==============================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors
@@ -28,7 +28,7 @@ import pytest
 
 from novelwriter.constants import nwFiles
 from novelwriter.core.project import NWProject
-from novelwriter.core.sessions import NWSessionLog
+from novelwriter.core.sessions import SessionLog
 
 from tests.helpers import buildTestProject
 from tests.mocked import causeOSError
@@ -36,7 +36,7 @@ from tests.mocked import causeOSError
 
 @pytest.mark.core
 def testNWSessionLog_Main(monkeypatch, mockGUI, fncPath):
-    """Test log file handling of the NWSessionLog class."""
+    """Test log file handling of the SessionLog class."""
     project = NWProject()
     buildTestProject(project, fncPath)
 
@@ -49,7 +49,7 @@ def testNWSessionLog_Main(monkeypatch, mockGUI, fncPath):
 
     # The project init should already have created the session
     sessLog = project.session
-    assert isinstance(sessLog, NWSessionLog)
+    assert isinstance(sessLog, SessionLog)
     assert sessLog.start > 0.0
 
     # Starting the session again should reset the timer

--- a/tests/core/test_sessions.py
+++ b/tests/core/test_sessions.py
@@ -1,6 +1,6 @@
 """
-novelWriter – SessionLog Tests
-==============================
+novelWriter – Session Log Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_sessions.py
+++ b/tests/core/test_sessions.py
@@ -95,7 +95,7 @@ def testNWSessionLog_Main(monkeypatch, mockGUI, fncPath):
 
     # Make file path unresolvable, and try appending another record
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getMetaFile", lambda *a: None)
         assert sessLog.appendSession(1.6) is False
     assert len(list(sessLog.iterRecords())) == 3
 
@@ -112,5 +112,5 @@ def testNWSessionLog_Main(monkeypatch, mockGUI, fncPath):
 
     # Make file path unresolvable
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getMetaFile", lambda *a: None)
         assert len(list(sessLog.iterRecords())) == 0

--- a/tests/core/test_spellcheck.py
+++ b/tests/core/test_spellcheck.py
@@ -30,7 +30,7 @@ import pytest
 
 from novelwriter.constants import nwFiles
 from novelwriter.core.project import NWProject
-from novelwriter.core.spellcheck import FakeEnchant, NWSpellEnchant, UserDictionary
+from novelwriter.core.spellcheck import FakeEnchant, SpellEnchant, UserDictionary
 
 from tests.helpers import buildTestProject
 from tests.mocked import causeOSError
@@ -114,18 +114,18 @@ def testFakeEnchant_Main(monkeypatch, mockGUI, fncPath):
     # Make package import fail
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "enchant", None)
-        spChk = NWSpellEnchant(project)
+        spChk = SpellEnchant(project)
         spChk.setLanguage("en_US")
         assert isinstance(spChk._enchant, FakeEnchant)
 
     # Request a non-existent dictionary
-    spChk = NWSpellEnchant(project)
+    spChk = SpellEnchant(project)
     spChk.setLanguage("whatchamajig")
     assert isinstance(spChk._enchant, FakeEnchant)
 
     # Request an empty language string
     # See issue https://github.com/vkbo/novelWriter/issues/1096
-    spChk = NWSpellEnchant(project)
+    spChk = SpellEnchant(project)
     spChk.setLanguage("")
     assert isinstance(spChk._enchant, FakeEnchant)
 
@@ -139,7 +139,7 @@ def testFakeEnchant_Main(monkeypatch, mockGUI, fncPath):
 
 
 @pytest.mark.core
-def testNWSpellEnchant_Main(monkeypatch, mockGUI, fncPath):
+def testSpellEnchant_Main(monkeypatch, mockGUI, fncPath):
     """Test the pyenchant spell checker."""
     project = NWProject()
     buildTestProject(project, fncPath)
@@ -147,7 +147,7 @@ def testNWSpellEnchant_Main(monkeypatch, mockGUI, fncPath):
     # Break the enchant package, and check error handling
     with monkeypatch.context() as mp:
         mp.setitem(sys.modules, "enchant", None)
-        spChk = NWSpellEnchant(project)
+        spChk = SpellEnchant(project)
         assert spChk.spellLanguage is None
         assert spChk.listDictionaries() == []
         assert spChk.describeDict() == ("", "")
@@ -163,7 +163,7 @@ def testNWSpellEnchant_Main(monkeypatch, mockGUI, fncPath):
         assert "word" in spChk._userDict
 
     # Set the dict to None, and check enchant error handling
-    spChk = NWSpellEnchant(project)
+    spChk = SpellEnchant(project)
     spChk._enchant = None  # type: ignore
     assert spChk.checkWord("word") is True
     assert spChk.suggestWords("word") == []
@@ -177,7 +177,7 @@ def testNWSpellEnchant_Main(monkeypatch, mockGUI, fncPath):
     assert spChk.describeDict() == ("", "")
 
     # Load the proper enchant package (twice)
-    spChk = NWSpellEnchant(project)
+    spChk = SpellEnchant(project)
     spChk.setLanguage("en_US")
     spChk.setLanguage("en_US")
     assert isinstance(spChk._enchant, enchant.Dict)
@@ -196,7 +196,7 @@ def testNWSpellEnchant_Main(monkeypatch, mockGUI, fncPath):
 
 
 @pytest.mark.core
-def testNWSpellEnchant_Cache(monkeypatch, mockGUI, fncPath):
+def testSpellEnchant_Cache(monkeypatch, mockGUI, fncPath):
     """Test the spell checker word cache."""
     project = NWProject()
     buildTestProject(project, fncPath)
@@ -205,7 +205,7 @@ def testNWSpellEnchant_Cache(monkeypatch, mockGUI, fncPath):
         def check(self, word: str) -> bool:
             return word != "wrod"
 
-    spChk = NWSpellEnchant(project)
+    spChk = SpellEnchant(project)
     spChk._enchant = MockEnchant()
     assert spChk._cache == {}
 

--- a/tests/core/test_spellcheck.py
+++ b/tests/core/test_spellcheck.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Spell Check Classes Tester
-========================================
+novelWriter – Spell Check Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_spellcheck.py
+++ b/tests/core/test_spellcheck.py
@@ -70,7 +70,7 @@ def testUserDictionary_Main(monkeypatch, mockGUI, fncPath):
 
     # Break the path check
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getMetaFile", lambda *a: None)
         userDict.save()
 
     # There should still be no file
@@ -94,7 +94,7 @@ def testUserDictionary_Main(monkeypatch, mockGUI, fncPath):
 
     # Break the path check
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getMetaFile", lambda *a: None)
         userDict.load()
 
     # No words loaded

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWStatus Class Tester
-===================================
+novelWriter – Project Status Tests
+==================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_status.py
+++ b/tests/core/test_status.py
@@ -25,7 +25,7 @@ import pytest
 
 from PyQt6.QtGui import QColor, QIcon
 
-from novelwriter.core.status import CUSTOM_COL, NWStatus, StatusEntry, _ShapeCache
+from novelwriter.core.status import CUSTOM_COL, ItemStatus, StatusEntry, _ShapeCache
 from novelwriter.enum import nwStatusShape
 
 from tests.helpers import C
@@ -35,10 +35,10 @@ importKeys = [C.iNew, C.iMinor, C.iMajor, C.iMain]
 
 
 @pytest.mark.core
-def testNWStatus_StatusEntry():
+def testItemStatus_StatusEntry():
     """Test the StatusEntry class."""
     color = QColor(255, 0, 0)
-    icon = NWStatus.createIcon(24, color, nwStatusShape.CIRCLE)
+    icon = ItemStatus.createIcon(24, color, nwStatusShape.CIRCLE)
     entry = StatusEntry("Test", color, CUSTOM_COL, nwStatusShape.CIRCLE, icon, 42)
 
     # Check values
@@ -64,10 +64,10 @@ def testNWStatus_StatusEntry():
 
 
 @pytest.mark.core
-def testNWStatus_Internal(mockGUI, mockRnd):
-    """Test all the internal functions of the NWStatus class."""
-    nStatus = NWStatus(NWStatus.STATUS)
-    nImport = NWStatus(NWStatus.IMPORT)
+def testItemStatus_Internal(mockGUI, mockRnd):
+    """Test all the internal functions of the ItemStatus class."""
+    nStatus = ItemStatus(ItemStatus.STATUS)
+    nImport = ItemStatus(ItemStatus.IMPORT)
 
     # Generate Key
     # ============
@@ -119,9 +119,9 @@ def testNWStatus_Internal(mockGUI, mockRnd):
 
 
 @pytest.mark.core
-def testNWStatus_Iterator(mockGUI, mockRnd):
-    """Test the iterator functions of the NWStatus class."""
-    nStatus = NWStatus(NWStatus.STATUS)
+def testItemStatus_Iterator(mockGUI, mockRnd):
+    """Test the iterator functions of the ItemStatus class."""
+    nStatus = ItemStatus(ItemStatus.STATUS)
     nStatus.add(None, "New", "#646464", "SQUARE", 0)
     nStatus.add(None, "Note", "#ff3f00", "CIRCLE", 1)
     nStatus.add(None, "Draft", "#ffaf00", "SQUARE", 2)
@@ -165,9 +165,9 @@ def testNWStatus_Iterator(mockGUI, mockRnd):
 
 
 @pytest.mark.core
-def testNWStatus_Entries(mockGUI, mockRnd):
-    """Test all the simple setters for the NWStatus class."""
-    nStatus = NWStatus(NWStatus.STATUS)
+def testItemStatus_Entries(mockGUI, mockRnd):
+    """Test all the simple setters for the ItemStatus class."""
+    nStatus = ItemStatus(ItemStatus.STATUS)
 
     # Add
     # ===
@@ -332,9 +332,9 @@ def testNWStatus_Entries(mockGUI, mockRnd):
 
 
 @pytest.mark.core
-def testNWStatus_RefreshIcons_Theme(mockGUIwithTheme, mockRnd):
+def testItemStatus_RefreshIcons_Theme(mockGUIwithTheme, mockRnd):
     """Test refreshing the icons with theme colours."""
-    nStatus = NWStatus(NWStatus.STATUS)
+    nStatus = ItemStatus(ItemStatus.STATUS)
     nStatus.add(None, "New", "default", "SQUARE", 0)
     nStatus.add(None, "Note", "red", "CIRCLE", 0)
     nStatus.add(None, "Draft", "yellow", "SQUARE", 0)
@@ -355,9 +355,9 @@ def testNWStatus_RefreshIcons_Theme(mockGUIwithTheme, mockRnd):
 
 
 @pytest.mark.core
-def testNWStatus_RefreshIcons_Custom(mockGUIwithTheme, mockRnd):
+def testItemStatus_RefreshIcons_Custom(mockGUIwithTheme, mockRnd):
     """Test refreshing the icons with custom colours."""
-    nStatus = NWStatus(NWStatus.STATUS)
+    nStatus = ItemStatus(ItemStatus.STATUS)
     nStatus.add(None, "New", "#707070", "SQUARE", 0)
     nStatus.add(None, "Note", "#ff0000", "CIRCLE", 0)
     nStatus.add(None, "Draft", "#ffff00", "SQUARE", 0)
@@ -383,9 +383,9 @@ def testNWStatus_RefreshIcons_Custom(mockGUIwithTheme, mockRnd):
 
 
 @pytest.mark.core
-def testNWStatus_Pack(mockGUIwithTheme, mockRnd):
-    """Test data packing of the NWStatus class."""
-    nStatus = NWStatus(NWStatus.STATUS)
+def testItemStatus_Pack(mockGUIwithTheme, mockRnd):
+    """Test data packing of the ItemStatus class."""
+    nStatus = ItemStatus(ItemStatus.STATUS)
     nStatus.add(None, "New", "#646464", "SQUARE", 0)
     nStatus.add(None, "Note", "#c83200", "CIRCLE", 0)
     nStatus.add(None, "Draft", "#c89600", "SQUARE", 0)
@@ -438,7 +438,7 @@ def testNWStatus_Pack(mockGUIwithTheme, mockRnd):
 
 
 @pytest.mark.core
-def testNWStatus_ShapeCache():
+def testItemStatus_ShapeCache():
     """Test the _ShapeCache class."""
     shapes = _ShapeCache()
 

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWStorage Class Tester
-====================================
+novelWriter – Project Storage Tests
+===================================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -30,7 +30,7 @@ import pytest
 
 from novelwriter import CONFIG
 from novelwriter.constants import nwFiles
-from novelwriter.core.document import NWDocument
+from novelwriter.core.document import ProjectDocument
 from novelwriter.core.project import NWProject
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter
 from novelwriter.core.storage import NWStorage, NWStorageCreate, NWStorageOpen, _LegacyStorage
@@ -160,8 +160,8 @@ def testNWStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
     # We should now have access to project resources
     assert isinstance(storage.getXmlReader(), ProjectXMLReader)
     assert isinstance(storage.getXmlWriter(), ProjectXMLWriter)
-    assert isinstance(storage.getDocument(C.hSceneDoc), NWDocument)
-    assert repr(storage.getDocument(C.hSceneDoc)) == f"<NWDocument handle={C.hSceneDoc}>"
+    assert isinstance(storage.getDocument(C.hSceneDoc), ProjectDocument)
+    assert repr(storage.getDocument(C.hSceneDoc)) == f"<ProjectDocument handle={C.hSceneDoc}>"
 
     # We can directly access the content of a document
     assert storage.getDocumentText(C.hSceneDoc) == "### New Scene\n\n"

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -33,7 +33,7 @@ from novelwriter.constants import nwFiles
 from novelwriter.core.document import ProjectDocument
 from novelwriter.core.project import NWProject
 from novelwriter.core.projectxml import ProjectXMLReader, ProjectXMLWriter
-from novelwriter.core.storage import NWStorage, NWStorageCreate, NWStorageOpen, _LegacyStorage
+from novelwriter.core.storage import ProjectStorage, ProjectStorageCreate, ProjectStorageOpen, _LegacyStorage
 
 from tests.helpers import C, buildTestProject
 from tests.mocked import causeOSError
@@ -44,18 +44,18 @@ class MockProject:
 
 
 @pytest.mark.core
-def testNWStorage_CreateNewProject(mockGUI, fncPath):
+def testProjectStorage_CreateNewProject(mockGUI, fncPath):
     """Test creating a project in a folder."""
     project = NWProject()
 
     # Create instance
-    storage = NWStorage(project)
+    storage = ProjectStorage(project)
 
     # Check defaults
     assert storage.storagePath is None
     assert storage.runtimePath is None
     assert storage.contentPath is None
-    assert storage._openMode == NWStorage.MODE_INACTIVE
+    assert storage._openMode == ProjectStorage.MODE_INACTIVE
     assert storage._ready is False
 
     # Check closed project return values
@@ -69,34 +69,34 @@ def testNWStorage_CreateNewProject(mockGUI, fncPath):
 
     # Cannot prepare a non-empty folder
     (fncPath / "foobar.txt").touch()
-    assert storage.createNewProject(fncPath) == NWStorageCreate.NOT_EMPTY
+    assert storage.createNewProject(fncPath) == ProjectStorageCreate.NOT_EMPTY
 
     # Try creating in a non-existent subfolder instead
-    assert storage.createNewProject(fncPath / "project1") == NWStorageCreate.READY
+    assert storage.createNewProject(fncPath / "project1") == ProjectStorageCreate.READY
     assert (fncPath / "project1").is_dir()
     assert (fncPath / "project1" / "meta").is_dir()
     assert (fncPath / "project1" / "content").is_dir()
 
     # However, the parent folder must exist
-    assert storage.createNewProject(fncPath / "foobar" / "project1") == NWStorageCreate.OS_ERROR
+    assert storage.createNewProject(fncPath / "foobar" / "project1") == ProjectStorageCreate.OS_ERROR
     assert isinstance(storage.exc, FileNotFoundError)
 
     project.closeProject()
 
 
 @pytest.mark.core
-def testNWStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
+def testProjectStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
     """Test initialising a project in a folder."""
     project = NWProject()
 
     # Create instance
-    storage = NWStorage(project)
+    storage = ProjectStorage(project)
 
     # Check defaults
     assert storage.storagePath is None
     assert storage.runtimePath is None
     assert storage.contentPath is None
-    assert storage._openMode == NWStorage.MODE_INACTIVE
+    assert storage._openMode == ProjectStorage.MODE_INACTIVE
     assert storage._ready is False
 
     # Check closed project return values
@@ -113,48 +113,48 @@ def testNWStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
     # Init with the wrong file
     foo = fncPath / "foobar.txt"
     foo.touch()
-    assert storage.initProjectStorage(fncPath / "foobar.txt") == NWStorageOpen.UNKOWN
+    assert storage.initProjectStorage(fncPath / "foobar.txt") == ProjectStorageOpen.UNKOWN
     foo.unlink()
     storage._clearLockFile()
     storage.clear()
 
     # Init with the user's home dir
-    assert storage.initProjectStorage(Path.home()) == NWStorageOpen.NOT_FOUND
+    assert storage.initProjectStorage(Path.home()) == ProjectStorageOpen.NOT_FOUND
     storage._clearLockFile()
     storage.clear()
 
     # Init with the project folder is OK
-    assert storage.initProjectStorage(fncPath) == NWStorageOpen.READY
+    assert storage.initProjectStorage(fncPath) == ProjectStorageOpen.READY
     assert storage.runtimePath == fncPath
     assert storage.storagePath == fncPath
     assert storage.contentPath == fncPath / "content"
-    assert storage._openMode == NWStorage.MODE_INPLACE
+    assert storage._openMode == ProjectStorage.MODE_INPLACE
     storage._clearLockFile()
     storage.clear()
 
     # Init with the project main file is OK
-    assert storage.initProjectStorage(fncPath / nwFiles.PROJ_FILE) == NWStorageOpen.READY
+    assert storage.initProjectStorage(fncPath / nwFiles.PROJ_FILE) == ProjectStorageOpen.READY
     assert storage.runtimePath == fncPath
     assert storage.storagePath == fncPath
     assert storage.contentPath == fncPath / "content"
-    assert storage._openMode == NWStorage.MODE_INPLACE
+    assert storage._openMode == ProjectStorage.MODE_INPLACE
     storage._clearLockFile()
     storage.clear()
 
     # Locking does nothing before the storage is ready
-    unreadyStorage = NWStorage(MockProject())  # type: ignore
+    unreadyStorage = ProjectStorage(MockProject())  # type: ignore
     unreadyStorage.lockSession()
 
     # Open twice, where second should fail due to lockfile
     # Note that locking is only possible after a successful open
-    assert storage.initProjectStorage(fncPath) == NWStorageOpen.READY
+    assert storage.initProjectStorage(fncPath) == ProjectStorageOpen.READY
     storage.lockSession()
-    assert storage.initProjectStorage(fncPath) == NWStorageOpen.LOCKED
+    assert storage.initProjectStorage(fncPath) == ProjectStorageOpen.LOCKED
     assert isinstance(storage.lockStatus, list)
     assert len(storage.lockStatus) == 4
 
     # But open again with clear lock file flag set is OK
-    assert storage.initProjectStorage(fncPath, clearLock=True) == NWStorageOpen.READY
+    assert storage.initProjectStorage(fncPath, clearLock=True) == ProjectStorageOpen.READY
     assert storage.lockStatus is None
 
     # We should now have access to project resources
@@ -170,18 +170,18 @@ def testNWStorage_InitProjectStorage(monkeypatch, mockGUI, fncPath, mockRnd):
 
 
 @pytest.mark.core
-def testNWStorage_InitProjectStorage_Invalid(monkeypatch, mockGUI, fncPath):
+def testProjectStorage_InitProjectStorage_Invalid(monkeypatch, mockGUI, fncPath):
     """Test initialising a project in an invalid folder."""
     project = NWProject()
 
     # Create instance
-    storage = NWStorage(project)
+    storage = ProjectStorage(project)
 
     # Check defaults
     assert storage.storagePath is None
     assert storage.runtimePath is None
     assert storage.contentPath is None
-    assert storage._openMode == NWStorage.MODE_INACTIVE
+    assert storage._openMode == ProjectStorage.MODE_INACTIVE
     assert storage._ready is False
 
     # Check closed project return values
@@ -197,28 +197,28 @@ def testNWStorage_InitProjectStorage_Invalid(monkeypatch, mockGUI, fncPath):
     (fncPath / "content").touch()  # These are now files but should be folders
 
     # Try opening the folder, but there is no project file
-    assert storage.initProjectStorage(fncPath) == NWStorageOpen.NOT_FOUND
+    assert storage.initProjectStorage(fncPath) == ProjectStorageOpen.NOT_FOUND
 
     # Add the project file, and we should now fail on the folders
     (fncPath / nwFiles.PROJ_FILE).touch()
-    assert storage.initProjectStorage(fncPath) == NWStorageOpen.FAILED
+    assert storage.initProjectStorage(fncPath) == ProjectStorageOpen.FAILED
 
     # Remove the files blocking the folders, but make the legacy storage scan fail
     (fncPath / "meta").unlink()
     (fncPath / "content").unlink()
     with monkeypatch.context() as mp:
         mp.setattr(_LegacyStorage, "deprecatedFiles", causeOSError)
-        assert storage.initProjectStorage(fncPath) == NWStorageOpen.FAILED
+        assert storage.initProjectStorage(fncPath) == ProjectStorageOpen.FAILED
 
     project.closeProject()
 
 
 @pytest.mark.core
-def testNWStorage_LockFile(monkeypatch, fncPath):
+def testProjectStorage_LockFile(monkeypatch, fncPath):
     """Test the project lock file."""
     monkeypatch.setattr("novelwriter.core.storage.time", lambda: 1000.0)
 
-    storage = NWStorage(MockProject())  # type: ignore
+    storage = ProjectStorage(MockProject())  # type: ignore
     assert storage.isOpen() is False
 
     # Project not open, so cannot read/write lock file
@@ -278,7 +278,7 @@ def testNWStorage_LockFile(monkeypatch, fncPath):
 
 
 @pytest.mark.core
-def testNWStorage_ZipIt(monkeypatch, mockGUI, fncPath, tstPaths, mockRnd):
+def testProjectStorage_ZipIt(monkeypatch, mockGUI, fncPath, tstPaths, mockRnd):
     """Test making a zip archive of a project."""
     zipFile = tstPaths.tmpDir / "project.zip"
 
@@ -317,10 +317,10 @@ def testNWStorage_ZipIt(monkeypatch, mockGUI, fncPath, tstPaths, mockRnd):
 
 
 @pytest.mark.core
-def testNWStorage_LegacyDataFolder(monkeypatch, fncPath):
+def testProjectStorage_LegacyDataFolder(monkeypatch, fncPath):
     """Test project file format 1.0 folder structure conversion."""
     project = MockProject()
-    storage = NWStorage(project)  # type: ignore
+    storage = ProjectStorage(project)  # type: ignore
     assert storage.isOpen() is False
     storage._runtimePath = fncPath
     (fncPath / nwFiles.PROJ_FILE).touch()
@@ -377,16 +377,16 @@ def testNWStorage_LegacyDataFolder(monkeypatch, fncPath):
         assert not (fncPath / "content" / "9000000000009.nwd").exists()
 
     # Run the remaining through the prepare storage call
-    assert storage.initProjectStorage(fncPath, clearLock=True) == NWStorageOpen.READY
+    assert storage.initProjectStorage(fncPath, clearLock=True) == ProjectStorageOpen.READY
     for c in "0123456789abcdef":
         assert (fncPath / "content" / f"{c}00000000000{c}.nwd").exists()
 
 
 @pytest.mark.core
-def testNWStorage_DeprecatedFiles(monkeypatch, fncPath):
+def testProjectStorage_DeprecatedFiles(monkeypatch, fncPath):
     """Test cleanup of deprecated files."""
     project = MockProject()
-    storage = NWStorage(project)  # type: ignore
+    storage = ProjectStorage(project)  # type: ignore
     assert storage.isOpen() is False
     storage._runtimePath = fncPath
     (fncPath / nwFiles.PROJ_FILE).touch()
@@ -424,7 +424,7 @@ def testNWStorage_DeprecatedFiles(monkeypatch, fncPath):
 
 
 @pytest.mark.core
-def testNWStorage_OldFormatConvert(monkeypatch, mockGUI, fncPath):
+def testProjectStorage_OldFormatConvert(monkeypatch, mockGUI, fncPath):
     """Test cleanup of deprecated files that needs to be converted."""
     project = NWProject()
     buildTestProject(project, fncPath)

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import pytest
 
 from novelwriter.constants import nwFiles
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.project import NWProject
 from novelwriter.core.tree import ProjectTree
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
@@ -381,7 +381,7 @@ def testProjectTree_ManipulateTree(monkeypatch, mockGUI, mockItems):
         assert tree.remove(bHandle) is False
 
     # Add item with non-existing parent
-    item = NWItem(project, tree._makeHandle())
+    item = ProjectItem(project, tree._makeHandle())
     item.setParent(tree._makeHandle())
     assert tree.add(item) is False
     assert [n.item.itemName for n in tree.model.root.allChildren()] == [
@@ -400,7 +400,7 @@ def testProjectTree_ManipulateTree(monkeypatch, mockGUI, mockItems):
     ]
 
     # Add item with non parent, that isn't a root
-    item = NWItem(project, tree._makeHandle())
+    item = ProjectItem(project, tree._makeHandle())
     item.setType(nwItemType.FOLDER)
     assert tree.add(item) is False
     assert [n.item.itemName for n in tree.model.root.allChildren()] == [
@@ -741,7 +741,7 @@ def testProjectTree_CheckConsistency(monkeypatch, caplog, mockGUI, fncPath, mock
     assert project.tree.checkConsistency("Recovered") == (1, 1)
     assert xHandle in project.tree
     itemX = project.tree[xHandle]
-    assert isinstance(itemX, NWItem)
+    assert isinstance(itemX, ProjectItem)
 
     # It should by default be added as a Novel file
     assert itemX.itemParent == C.hNovelRoot
@@ -760,7 +760,7 @@ def testProjectTree_CheckConsistency(monkeypatch, caplog, mockGUI, fncPath, mock
     assert project.tree.checkConsistency("Recovered") == (1, 1)
     assert xHandle in project.tree
     itemX = project.tree[xHandle]
-    assert isinstance(itemX, NWItem)
+    assert isinstance(itemX, ProjectItem)
 
     # It should again be added as a Novel file
     assert itemX.itemParent == C.hNovelRoot
@@ -784,7 +784,7 @@ def testProjectTree_CheckConsistency(monkeypatch, caplog, mockGUI, fncPath, mock
     )
     assert project.tree.checkConsistency("Recovered") == (1, 1)
     itemY = project.tree[yHandle]
-    assert isinstance(itemY, NWItem)
+    assert isinstance(itemY, ProjectItem)
     assert itemY.itemParent == C.hNovelRoot
 
     # If the tree is empty, a new root folder is created
@@ -842,7 +842,7 @@ def testProjectTree_DuplicateHandleGuards(mockGUI, mockItems):
     beforeNodes = len(tree._nodes)
 
     # add() should reject duplicate handles
-    dupAdd = NWItem(project, C.hNovelRoot)
+    dupAdd = ProjectItem(project, C.hNovelRoot)
     dupAdd.setType(nwItemType.ROOT)
     dupAdd.setClass(nwItemClass.NOVEL)
     assert tree.add(dupAdd) is False
@@ -850,7 +850,7 @@ def testProjectTree_DuplicateHandleGuards(mockGUI, mockItems):
     assert len(tree._nodes) == beforeNodes
 
     # _addItems() should also skip duplicate handles
-    dupUnpack = NWItem(project, C.hNovelRoot)
+    dupUnpack = ProjectItem(project, C.hNovelRoot)
     dupUnpack.setType(nwItemType.ROOT)
     dupUnpack.setClass(nwItemClass.NOVEL)
     assert tree._addItems({C.hNovelRoot: dupUnpack}) == {}
@@ -868,7 +868,7 @@ def testProjectTree_RootParentIsNormalisedToTopLevel(mockGUI, mockItems):
     tree.unpack(mockItems)
     assertTreeModelConsistency(tree)
 
-    badRootOne = NWItem(project, tree._makeHandle())
+    badRootOne = ProjectItem(project, tree._makeHandle())
     badRootOne.setName("Bad Root One")
     badRootOne.setType(nwItemType.ROOT)
     badRootOne.setClass(nwItemClass.NOVEL)
@@ -879,7 +879,7 @@ def testProjectTree_RootParentIsNormalisedToTopLevel(mockGUI, mockItems):
     assert badRootOne.itemRoot == badRootOne.itemHandle
     assert tree.nodes[badRootOne.itemHandle].parent() is tree.model.root
 
-    badRootTwo = NWItem(project, tree._makeHandle())
+    badRootTwo = ProjectItem(project, tree._makeHandle())
     badRootTwo.setName("Bad Root Two")
     badRootTwo.setType(nwItemType.ROOT)
     badRootTwo.setClass(nwItemClass.PLOT)

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -933,7 +933,7 @@ def testProjectTree_ToCFile(monkeypatch, fncPath, mockGUI, mockItems):
 
     # Block extraction of the path
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.contentPath", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.contentPath", lambda *a: None)
         assert tree.writeToCFile() is False
 
     # Block opening the file

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -1,6 +1,6 @@
 """
-novelWriter – NWTree Class Tester
-=================================
+novelWriter – Project Tree Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -31,14 +31,14 @@ import pytest
 from novelwriter.constants import nwFiles
 from novelwriter.core.item import NWItem
 from novelwriter.core.project import NWProject
-from novelwriter.core.tree import NWTree
+from novelwriter.core.tree import ProjectTree
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType
 
 from tests.helpers import C, buildTestProject
 from tests.mocked import causeOSError
 
 
-def assertTreeModelConsistency(tree: NWTree) -> None:
+def assertTreeModelConsistency(tree: ProjectTree) -> None:
     """Assert map and model consistency for the loaded tree."""
     modelNodes = tree.model.root.allChildren()
     modelHandles = {node.item.itemHandle for node in modelNodes}
@@ -75,10 +75,10 @@ def mockItems(mockGUI, mockRnd, fncPath):
 
 
 @pytest.mark.core
-def testNWTree_Populate(monkeypatch, mockGUI, mockItems):
+def testProjectTree_Populate(monkeypatch, mockGUI, mockItems):
     """Test populating the project tree."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
 
     # Check that tree is empty
     assert bool(tree) is False
@@ -227,10 +227,10 @@ def testNWTree_Populate(monkeypatch, mockGUI, mockItems):
 
 
 @pytest.mark.core
-def testNWTree_ManipulateTree(monkeypatch, mockGUI, mockItems):
+def testProjectTree_ManipulateTree(monkeypatch, mockGUI, mockItems):
     """Check create, add, remove and duplicate items."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
     tree.unpack(mockItems)
     assertTreeModelConsistency(tree)
     assert len(tree) == 9
@@ -430,10 +430,10 @@ def testNWTree_ManipulateTree(monkeypatch, mockGUI, mockItems):
 
 
 @pytest.mark.core
-def testNWTree_PickParent(mockGUI, mockItems):
+def testProjectTree_PickParent(mockGUI, mockItems):
     """Check the parent item picker."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
     assert len(tree) == 0
 
     # Case 1: Root and Folder
@@ -569,10 +569,10 @@ def testNWTree_PickParent(mockGUI, mockItems):
 
 
 @pytest.mark.core
-def testNWTree_ItemMethods(monkeypatch, mockGUI, mockItems):
+def testProjectTree_ItemMethods(monkeypatch, mockGUI, mockItems):
     """Check the item methods of the tree."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
     tree.unpack(mockItems)
     assert len(tree) == 9
     assert [n.item.itemName for n in tree.model.root.allChildren()] == [
@@ -659,7 +659,7 @@ def testNWTree_ItemMethods(monkeypatch, mockGUI, mockItems):
 
 
 @pytest.mark.core
-def testNWTree_OtherMethods(qtbot, monkeypatch, mockGUI, fncPath, mockRnd):
+def testProjectTree_OtherMethods(qtbot, monkeypatch, mockGUI, fncPath, mockRnd):
     """Check other methods in the tree."""
     project = NWProject()
     buildTestProject(project, fncPath)
@@ -714,14 +714,14 @@ def testNWTree_OtherMethods(qtbot, monkeypatch, mockGUI, fncPath, mockRnd):
     assert tree._trash is None
 
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.tree.NWTree.create", lambda *a, **k: None)
+        mp.setattr("novelwriter.core.tree.ProjectTree.create", lambda *a, **k: None)
         tree._trash = trash
         assert tree.trash is None
         assert tree._getTrashNode() is None
 
 
 @pytest.mark.core
-def testNWTree_CheckConsistency(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
+def testProjectTree_CheckConsistency(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
     """Check the project tree's consistency."""
     project = NWProject()
     buildTestProject(project, fncPath)
@@ -798,16 +798,16 @@ def testNWTree_CheckConsistency(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
     project.tree.remove(yHandle)
     (contentPath / f"{yHandle}.nwd").write_text("### Stuff", encoding="utf-8")
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.tree.NWTree.add", lambda *a: False)
+        mp.setattr("novelwriter.core.tree.ProjectTree.add", lambda *a: False)
         assert project.tree.checkConsistency("Recovered") == (1, 0)
 
 
 @pytest.mark.core
-def testNWTree_MakeHandles(mockGUI):
+def testProjectTree_MakeHandles(mockGUI):
     """Test generating item handles."""
     random.seed(42)
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
 
     handles = ["1c803a3b1799d", "bdd6406671ad1", "3eb1346685257", "23b8c392456de"]
 
@@ -830,10 +830,10 @@ def testNWTree_MakeHandles(mockGUI):
 
 
 @pytest.mark.core
-def testNWTree_DuplicateHandleGuards(mockGUI, mockItems):
+def testProjectTree_DuplicateHandleGuards(mockGUI, mockItems):
     """Test duplicate handle guards in add and _addItems."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
     tree.unpack(mockItems)
     assertTreeModelConsistency(tree)
 
@@ -861,10 +861,10 @@ def testNWTree_DuplicateHandleGuards(mockGUI, mockItems):
 
 
 @pytest.mark.core
-def testNWTree_RootParentIsNormalisedToTopLevel(mockGUI, mockItems):
+def testProjectTree_RootParentIsNormalisedToTopLevel(mockGUI, mockItems):
     """Check malformed root parent references are normalised."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
     tree.unpack(mockItems)
     assertTreeModelConsistency(tree)
 
@@ -893,10 +893,10 @@ def testNWTree_RootParentIsNormalisedToTopLevel(mockGUI, mockItems):
 
 
 @pytest.mark.core
-def testNWTree_UnresolvedItemsKeepLoadedTreeConsistent(monkeypatch, mockGUI, mockItems):
+def testProjectTree_UnresolvedItemsKeepLoadedTreeConsistent(monkeypatch, mockGUI, mockItems):
     """Check unresolved unpack entries do not break loaded tree consistency."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
 
     with monkeypatch.context() as mp:
         mp.setattr("novelwriter.core.tree.MAX_DEPTH", 1)
@@ -913,10 +913,10 @@ def testNWTree_UnresolvedItemsKeepLoadedTreeConsistent(monkeypatch, mockGUI, moc
 
 
 @pytest.mark.core
-def testNWTree_ToCFile(monkeypatch, fncPath, mockGUI, mockItems):
+def testProjectTree_ToCFile(monkeypatch, fncPath, mockGUI, mockItems):
     """Test writing the ToC.txt file."""
     project = NWProject()
-    tree = NWTree(project)
+    tree = ProjectTree(project)
     tree.unpack(mockItems)
 
     def mockIsFile(fileName):

--- a/tests/dialogs/test_about.py
+++ b/tests/dialogs/test_about.py
@@ -1,6 +1,6 @@
 """
-novelWriter – About Dialog Class Tester
-=======================================
+novelWriter – About Dialog Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/dialogs/test_docmerge.py
+++ b/tests/dialogs/test_docmerge.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Merge Dialog Class Tester
-=======================================
+novelWriter – Merge Dialog Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/dialogs/test_docsplit.py
+++ b/tests/dialogs/test_docsplit.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Split Dialog Class Tester
-=======================================
+novelWriter – Split Dialog Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/dialogs/test_editlabel.py
+++ b/tests/dialogs/test_editlabel.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Edit Label Dialog Class Tester
-============================================
+novelWriter – Edit Label Dialog Tests
+=====================================
 
 This file is a part of novelWriter
 Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/dialogs/test_preferences.py
+++ b/tests/dialogs/test_preferences.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Preferences Dialog Class Tester
-=============================================
+novelWriter – Preferences Dialog Test
+=====================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/dialogs/test_preferences.py
+++ b/tests/dialogs/test_preferences.py
@@ -30,7 +30,7 @@ from PyQt6.QtWidgets import QFileDialog
 from novelwriter import CONFIG, SHARED
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_TREECOL
 from novelwriter.constants import nwUnicode
-from novelwriter.core.spellcheck import NWSpellEnchant
+from novelwriter.core.spellcheck import SpellEnchant
 from novelwriter.dialogs.preferences import GuiNeedsUpdate, GuiPreferences
 from novelwriter.dialogs.quotes import GuiQuoteSelect
 from novelwriter.extensions.modified import NFontDialog
@@ -45,7 +45,7 @@ KEY_DELAY = 1
 @pytest.mark.gui
 def testGuiPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
     """Test the preferences dialog loading."""
-    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
+    monkeypatch.setattr(SpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
     monkeypatch.setattr(GuiPreferences, "exec", lambda *a: None)
 
     # Load GUI with standard values
@@ -92,7 +92,7 @@ def testGuiPreferences_Main(qtbot, monkeypatch, nwGUI, tstPaths):
 @pytest.mark.gui
 def testGuiPreferences_Actions(qtbot, monkeypatch, nwGUI):
     """Test the preferences dialog actions."""
-    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
+    monkeypatch.setattr(SpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
     prefs = GuiPreferences(nwGUI)
     with qtbot.waitExposed(prefs):
         prefs.show()
@@ -151,7 +151,7 @@ def testGuiPreferences_Actions(qtbot, monkeypatch, nwGUI):
 def testGuiPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
     """Test the preferences dialog settings."""
     spelling = [("en", "English [en]"), ("de", "Deutch [de]")]
-    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: spelling)
+    monkeypatch.setattr(SpellEnchant, "listDictionaries", lambda *a: spelling)
 
     (fncPath / "nw_en_US.qm").touch()
     (fncPath / "project_en_US.json").touch()
@@ -497,5 +497,5 @@ def testGuiPreferences_Settings(qtbot, monkeypatch, nwGUI, fncPath, tstPaths):
 @pytest.mark.gui
 def testGuiPreferences_MemoryLeakRegression(qtbot, monkeypatch, nwGUI):
     """Test that the dialog is freed when it is closed."""
-    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
+    monkeypatch.setattr(SpellEnchant, "listDictionaries", lambda *a: [("en", "English [en]")])
     checkDialogFreedOnClose(qtbot, lambda: GuiPreferences(nwGUI))

--- a/tests/dialogs/test_projectsettings.py
+++ b/tests/dialogs/test_projectsettings.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Project Settings Dialog Class Tester
-==================================================
+novelWriter – Project Settings Dialog Tests
+===========================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/dialogs/test_projectsettings.py
+++ b/tests/dialogs/test_projectsettings.py
@@ -27,7 +27,7 @@ from PyQt6.QtGui import QAction, QColor
 from PyQt6.QtWidgets import QColorDialog, QFileDialog, QToolButton
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.core.spellcheck import NWSpellEnchant
+from novelwriter.core.spellcheck import SpellEnchant
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
 from novelwriter.enum import nwItemType, nwStatusShape
@@ -95,7 +95,7 @@ def testGuiProjectSettings_Dialog(qtbot, monkeypatch, nwGUI):
 def testGuiProjectSettings_SettingsPage(qtbot, monkeypatch, nwGUI, fncPath, projPath, mockRnd):
     """Test the settings page of the dialog."""
     languages = [("en", "English"), ("de", "German")]
-    monkeypatch.setattr(NWSpellEnchant, "listDictionaries", lambda *a: languages)
+    monkeypatch.setattr(SpellEnchant, "listDictionaries", lambda *a: languages)
 
     (fncPath / "nw_en.qm").touch()
     (fncPath / "nw_de.qm").touch()

--- a/tests/dialogs/test_quotes.py
+++ b/tests/dialogs/test_quotes.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Quotes Dialog Class Tester
-========================================
+novelWriter – Quotes Dialog Tests
+=================================
 
 This file is a part of novelWriter
 Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/dialogs/test_wordlist.py
+++ b/tests/dialogs/test_wordlist.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Other Dialog Classes Tester
-=========================================
+novelWriter – Word List Tests
+=============================
 
 This file is a part of novelWriter
 Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -49,7 +49,7 @@ from PyQt6.QtWidgets import QApplication, QMenu, QTextEdit
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import decodeMimeHandles, utf16CharMap
 from novelwriter.constants import nwKeyWords, nwUnicode
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.spellcheck import SpellEnchant
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.editor.autoreplace import TextAutoReplace
@@ -2483,7 +2483,7 @@ def testGuiDocEditor_MoveTextToNewDocument(qtbot, monkeypatch, nwGUI, projPath, 
     docEditor.setCursorLine(6)
     docEditor.docAction(nwDocAction.MOVE_TEXT)
     item = SHARED.project.tree[nHandle]
-    assert isinstance(item, NWItem)
+    assert isinstance(item, ProjectItem)
     assert item.itemName == "New Scene (1)"
     assert nwGUI.openDocument(nHandle) is True
     assert docEditor.getText() == "### New Scene (1)\n\n{0}\n".format("\n\n".join(ipsumText[2:]))
@@ -2505,7 +2505,7 @@ def testGuiDocEditor_MoveTextToNewDocument(qtbot, monkeypatch, nwGUI, projPath, 
     # Move to new document
     docEditor.docAction(nwDocAction.MOVE_TEXT)
     item = SHARED.project.tree[nHandle]
-    assert isinstance(item, NWItem)
+    assert isinstance(item, ProjectItem)
     assert item.itemName == "Another Scene"
     assert nwGUI.openDocument(nHandle) is True
     assert docEditor.getText() == f"### Another Scene\n\n{ipsumText[3]}\n"

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Document Editor Class Tester
-==========================================
+novelWriter – Document Editor Tests
+===================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -50,7 +50,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import decodeMimeHandles, utf16CharMap
 from novelwriter.constants import nwKeyWords, nwUnicode
 from novelwriter.core.item import NWItem
-from novelwriter.core.spellcheck import NWSpellEnchant
+from novelwriter.core.spellcheck import SpellEnchant
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.editor.autoreplace import TextAutoReplace
 from novelwriter.editor.completer import CommandCompleter
@@ -621,7 +621,7 @@ def testGuiDocEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     # The test must not depend on which dictionaries are available on
     # the host system, so all words are accepted from the start, and
     # the spell check worker must run synchronously
-    monkeypatch.setattr(NWSpellEnchant, "checkWord", lambda *a: True)
+    monkeypatch.setattr(SpellEnchant, "checkWord", lambda *a: True)
     monkeypatch.setattr(SHARED, "runInThreadPool", lambda r: r.run())
 
     assert nwGUI.openDocument(C.hSceneDoc) is True
@@ -674,7 +674,7 @@ def testGuiDocEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
     blockPos = cursor.block().position()
     data._spellErrors = [(0, 5, "Lorem"), (6, 11, "ipsum")]
     with monkeypatch.context() as mp:
-        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
+        mp.setattr(SpellEnchant, "suggestWords", lambda *a: [])
         assert docEditor._qDocument.spellErrorAtPos(blockPos + 8) == ("ipsum", 6, 11, [])
 
     # No entry matches the given position
@@ -706,7 +706,7 @@ def testGuiDocEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # With Suggestion
     with monkeypatch.context() as mp:
-        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [LORAX])
+        mp.setattr(SpellEnchant, "suggestWords", lambda *a: [LORAX])
         suggestion = f"{nwUnicode.U_ENDASH} {LORAX}"
 
         ctxMenu = getMenuForPos(docEditor, 16)
@@ -725,7 +725,7 @@ def testGuiDocEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Without Suggestion
     with monkeypatch.context() as mp:
-        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
+        mp.setattr(SpellEnchant, "suggestWords", lambda *a: [])
 
         ctxMenu = getMenuForPos(docEditor, 16)
         assert ctxMenu is not None
@@ -737,7 +737,7 @@ def testGuiDocEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # Add to Dictionary
     with monkeypatch.context() as mp:
-        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
+        mp.setattr(SpellEnchant, "suggestWords", lambda *a: [])
 
         ctxMenu = getMenuForPos(docEditor, 16)
         assert ctxMenu is not None
@@ -755,7 +755,7 @@ def testGuiDocEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
 
     # No spelling error at the clicked position: no spelling actions
     with monkeypatch.context() as mp:
-        mp.setattr(NWSpellEnchant, "suggestWords", lambda *a: [])
+        mp.setattr(SpellEnchant, "suggestWords", lambda *a: [])
 
         ctxMenu = getMenuForPos(docEditor, blockPos + 20)
         assert ctxMenu is not None

--- a/tests/editor/test_highlighter.py
+++ b/tests/editor/test_highlighter.py
@@ -27,7 +27,7 @@ from PyQt6.QtGui import QTextCharFormat, QTextCursor, QTextDocument
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.core.item import NWItem
-from novelwriter.core.spellcheck import NWSpellEnchant
+from novelwriter.core.spellcheck import SpellEnchant
 from novelwriter.editor.highlighter import BLOCK_META, BLOCK_TITLE, GuiDocHighlighter
 from novelwriter.editor.textblock import TextBlockData
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwTheme
@@ -517,7 +517,7 @@ def testGuiDocHighlighter_Text(monkeypatch, syntax):
     # Settings
     syntax._tHandle = T_HANDLE
     syntax._isNovel = True
-    monkeypatch.setattr(NWSpellEnchant, "checkWord", lambda *a: False)
+    monkeypatch.setattr(SpellEnchant, "checkWord", lambda *a: False)
 
     colHidden = theme.syntaxTheme.hidden.getRgb()
     colEmph = theme.syntaxTheme.emph.getRgb()

--- a/tests/editor/test_highlighter.py
+++ b/tests/editor/test_highlighter.py
@@ -26,7 +26,7 @@ import pytest
 from PyQt6.QtGui import QTextCharFormat, QTextCursor, QTextDocument
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.core.spellcheck import SpellEnchant
 from novelwriter.editor.highlighter import BLOCK_META, BLOCK_TITLE, GuiDocHighlighter
 from novelwriter.editor.textblock import TextBlockData
@@ -60,11 +60,11 @@ def syntax(nwGUI):
     syntax = GuiDocHighlighter(doc)
 
     # Add a Mock Item
-    tRoot = NWItem(SHARED.project, R_HANDLE)
+    tRoot = ProjectItem(SHARED.project, R_HANDLE)
     tRoot.setClass(nwItemClass.NOVEL)
     tRoot.setType(nwItemType.ROOT)
 
-    tItem = NWItem(SHARED.project, T_HANDLE)
+    tItem = ProjectItem(SHARED.project, T_HANDLE)
     tItem.setParent(R_HANDLE)
     tItem.setLayout(nwItemLayout.NOTE)
     tItem.setClass(nwItemClass.NOVEL)

--- a/tests/editor/test_highlighter.py
+++ b/tests/editor/test_highlighter.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Syntax Highlighter Class Tester
-=============================================
+novelWriter – Syntax Highlighter Tests
+======================================
 
 This file is a part of novelWriter
 Copyright (C) 2025 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/extensions/test_configlayout.py
+++ b/tests/extensions/test_configlayout.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ConfigLayout Extension Tester
-===========================================
+novelWriter – ConfigLayout Extension Tests
+==========================================
 
 This file is a part of novelWriter
 Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/extensions/test_eventfilters.py
+++ b/tests/extensions/test_eventfilters.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Wheel Event Filter Tester
-=======================================
+novelWriter – Wheel Event Filter Tests
+======================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/extensions/test_modified.py
+++ b/tests/extensions/test_modified.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Modified Widgets Tester
-=====================================
+novelWriter – Modified Widgets Tests
+====================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/extensions/test_progressbars.py
+++ b/tests/extensions/test_progressbars.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Progress Bar Tester
-=================================
+novelWriter – Progress Bar Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/extensions/test_switch.py
+++ b/tests/extensions/test_switch.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Switch Tester
-===========================
+novelWriter – Switch Tests
+==========================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/extensions/test_versioninfo.py
+++ b/tests/extensions/test_versioninfo.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Version Info Widget Tester
-========================================
+novelWriter – Version Info Widget Tests
+=======================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/formats/test_todocx.py
+++ b/tests/formats/test_todocx.py
@@ -33,7 +33,6 @@ from novelwriter.enum import nwBuildFmt, nwComment
 from novelwriter.formats.shared import BlockFmt, BlockTyp
 from novelwriter.formats.todocx import OOXML_SCM, DocXParagraph, ToDocX, _mkTag, _wTag
 from novelwriter.manuscript.buildsettings import BuildSettings
-from novelwriter.manuscript.docbuild import NWBuildDocument
 
 from tests.helpers import DOCX_IGNORE, cmpFiles, xmlToText
 
@@ -776,7 +775,7 @@ def testToDocX_SaveDocument(mockGUI, prjLipsum, fncPath, tstPaths):
     build.setValue("format.justifyOnBreak", False)
     build.setValue("doc.pageHeader", pageHeader)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     docPath = fncPath / "document.docx"

--- a/tests/formats/test_todocx.py
+++ b/tests/formats/test_todocx.py
@@ -33,6 +33,7 @@ from novelwriter.enum import nwBuildFmt, nwComment
 from novelwriter.formats.shared import BlockFmt, BlockTyp
 from novelwriter.formats.todocx import OOXML_SCM, DocXParagraph, ToDocX, _mkTag, _wTag
 from novelwriter.manuscript.buildsettings import BuildSettings
+from novelwriter.manuscript.docbuild import DocumentBuilder
 
 from tests.helpers import DOCX_IGNORE, cmpFiles, xmlToText
 

--- a/tests/formats/test_todocx.py
+++ b/tests/formats/test_todocx.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ToDocX Class Tester
-=================================
+novelWriter – DocX Format Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/formats/test_toepub.py
+++ b/tests/formats/test_toepub.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ToEPub Class Tester
-=================================
+novelWriter – EPub Format Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/formats/test_tohtml.py
+++ b/tests/formats/test_tohtml.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ToHtml Class Tester
-=================================
+novelWriter – HTML Format Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/formats/test_tokenizer.py
+++ b/tests/formats/test_tokenizer.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Tokenizer Class Tester
-====================================
+novelWriter – Text Tokenizer Tests
+==================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/formats/test_tomarkdown.py
+++ b/tests/formats/test_tomarkdown.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ToMd Class Tester
-===============================
+novelWriter – Markdown Format Tests
+===================================
 
 This file is a part of novelWriter
 Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/formats/test_toodt.py
+++ b/tests/formats/test_toodt.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ToOdt Class Tester
-================================
+novelWriter – Open Document Format Tests
+========================================
 
 This file is a part of novelWriter
 Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/formats/test_toqdoc.py
+++ b/tests/formats/test_toqdoc.py
@@ -1,6 +1,6 @@
 """
-novelWriter – ToQTextDocument Class Tester
-==========================================
+novelWriter – QTextDocument Format Tests
+========================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_mainmenu.py
+++ b/tests/gui/test_mainmenu.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI Main Menu Class Tester
-========================================
+novelWriter – GUI Main Menu Tests
+=================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_noveltree.py
+++ b/tests/gui/test_noveltree.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI Novel View Class Tester
-=========================================
+novelWriter – GUI Novel View Tests
+==================================
 
 This file is a part of novelWriter
 Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_outline.py
+++ b/tests/gui/test_outline.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI Outline Class Tester
-======================================
+novelWriter – GUI Outline Tests
+===============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_projtree.py
+++ b/tests/gui/test_projtree.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Main GUI Project Tree Class Tester
-================================================
+novelWriter – GUI Project Tree Tests
+====================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_search.py
+++ b/tests/gui/test_search.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Main GUI Project Search Tester
-============================================
+novelWriter – GUI Project Search Tests
+======================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_sidebar.py
+++ b/tests/gui/test_sidebar.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Side Bar Class Tester
-===================================
+novelWriter – GUI Side Bar Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2025 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_statusbar.py
+++ b/tests/gui/test_statusbar.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Main Status Bar Class Tester
-==========================================
+novelWriter – GUI Status Bar Tests
+==================================
 
 This file is a part of novelWriter
 Copyright (C) 2021 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/gui/test_theme.py
+++ b/tests/gui/test_theme.py
@@ -1,6 +1,6 @@
 """
-novelWriter – GUI Theme and Icons Classes Tester
-================================================
+novelWriter – GUI Theme and Icons Tests
+=======================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/manuscript/test_buildsettings.py
+++ b/tests/manuscript/test_buildsettings.py
@@ -470,7 +470,7 @@ def testBuildSettings_Collection(monkeypatch, mockGUI, fncPath: Path, mockRnd):
 
     # Check errors: No valid path
     with monkeypatch.context() as mp:
-        mp.setattr("novelwriter.core.storage.NWStorage.getMetaFile", lambda *a: None)
+        mp.setattr("novelwriter.core.storage.ProjectStorage.getMetaFile", lambda *a: None)
         assert builds._loadCollection() is False
         assert builds._saveCollection() is False
 

--- a/tests/manuscript/test_buildsettings.py
+++ b/tests/manuscript/test_buildsettings.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Manuscript Build Settings Tester
-==============================================
+novelWriter – Manuscript Build Settings Tests
+=============================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/manuscript/test_docbuild.py
+++ b/tests/manuscript/test_docbuild.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Manuscript Builder Class Tests
-============================================
+novelWriter – Manuscript Builder Tests
+======================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/manuscript/test_docbuild.py
+++ b/tests/manuscript/test_docbuild.py
@@ -37,6 +37,7 @@ from novelwriter.formats.toodt import ToOdt
 from novelwriter.formats.toqdoc import ToQTextDocument
 from novelwriter.formats.toraw import ToRaw
 from novelwriter.manuscript.buildsettings import BuildSettings
+from novelwriter.manuscript.docbuild import DocumentBuilder
 
 from tests.helpers import ODT_IGNORE, C, buildTestProject, cmpFiles
 from tests.mocked import causeException, causeOSError

--- a/tests/manuscript/test_docbuild.py
+++ b/tests/manuscript/test_docbuild.py
@@ -37,7 +37,6 @@ from novelwriter.formats.toodt import ToOdt
 from novelwriter.formats.toqdoc import ToQTextDocument
 from novelwriter.formats.toraw import ToRaw
 from novelwriter.manuscript.buildsettings import BuildSettings
-from novelwriter.manuscript.docbuild import NWBuildDocument
 
 from tests.helpers import ODT_IGNORE, C, buildTestProject, cmpFiles
 from tests.mocked import causeException, causeOSError
@@ -80,7 +79,7 @@ BUILD_CONF = {
 
 
 @pytest.mark.core
-def testNWBuildDocument_OpenDocument(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths):
+def testDocumentBuilder_OpenDocument(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths):
     """Test building an open document manuscript."""
     project = NWProject()
     project.openProject(prjLipsum)
@@ -88,7 +87,7 @@ def testNWBuildDocument_OpenDocument(monkeypatch, mockGUI, prjLipsum, fncPath, t
     build = BuildSettings()
     build.unpack(BUILD_CONF)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild._outline = True
     docBuild.queueAll()
 
@@ -186,7 +185,7 @@ def testNWBuildDocument_OpenDocument(monkeypatch, mockGUI, prjLipsum, fncPath, t
 
 
 @pytest.mark.core
-def testNWBuildDocument_HTML(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths):
+def testDocumentBuilder_HTML(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths):
     """Test building an HTML manuscript."""
     project = NWProject()
     project.openProject(prjLipsum)
@@ -194,7 +193,7 @@ def testNWBuildDocument_HTML(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths)
     build = BuildSettings()
     build.unpack(BUILD_CONF)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     assert len(docBuild) == 19
@@ -262,7 +261,7 @@ def testNWBuildDocument_HTML(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths)
 
 
 @pytest.mark.core
-def testNWBuildDocument_Markdown(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths):
+def testDocumentBuilder_Markdown(monkeypatch, mockGUI, prjLipsum, fncPath, tstPaths):
     """Test building an Markdown manuscript."""
     project = NWProject()
     project.openProject(prjLipsum)
@@ -270,7 +269,7 @@ def testNWBuildDocument_Markdown(monkeypatch, mockGUI, prjLipsum, fncPath, tstPa
     build = BuildSettings()
     build.unpack(BUILD_CONF)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     assert len(docBuild) == 19
@@ -330,7 +329,7 @@ def testNWBuildDocument_Markdown(monkeypatch, mockGUI, prjLipsum, fncPath, tstPa
 
 
 @pytest.mark.core
-def testNWBuildDocument_DocX(mockGUI, prjLipsum, fncPath):
+def testDocumentBuilder_DocX(mockGUI, prjLipsum, fncPath):
     """Test building a Word manuscript."""
     project = NWProject()
     project.openProject(prjLipsum)
@@ -338,7 +337,7 @@ def testNWBuildDocument_DocX(mockGUI, prjLipsum, fncPath):
     build = BuildSettings()
     build.unpack(BUILD_CONF)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     assert len(docBuild) == 19
@@ -363,7 +362,7 @@ def testNWBuildDocument_DocX(mockGUI, prjLipsum, fncPath):
 
 
 @pytest.mark.core
-def testNWBuildDocument_PDF(mockGUI, prjLipsum, fncPath):
+def testDocumentBuilder_PDF(mockGUI, prjLipsum, fncPath):
     """Test building a PDF manuscript."""
     project = NWProject()
     project.openProject(prjLipsum)
@@ -371,7 +370,7 @@ def testNWBuildDocument_PDF(mockGUI, prjLipsum, fncPath):
     build = BuildSettings()
     build.unpack(BUILD_CONF)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     assert len(docBuild) == 19
@@ -395,7 +394,7 @@ def testNWBuildDocument_PDF(mockGUI, prjLipsum, fncPath):
 
 
 @pytest.mark.core
-def testNWBuildDocument_NWD(mockGUI, prjLipsum, fncPath, tstPaths):
+def testDocumentBuilder_NWD(mockGUI, prjLipsum, fncPath, tstPaths):
     """Test building a NWD manuscript."""
     project = NWProject()
     project.openProject(prjLipsum)
@@ -403,7 +402,7 @@ def testNWBuildDocument_NWD(mockGUI, prjLipsum, fncPath, tstPaths):
     build = BuildSettings()
     build.unpack(BUILD_CONF)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
 
     assert len(docBuild) == 19
@@ -450,7 +449,7 @@ def testNWBuildDocument_NWD(mockGUI, prjLipsum, fncPath, tstPaths):
 
 
 @pytest.mark.core
-def testNWBuildDocument_Custom(mockGUI, fncPath: Path, mockRnd):
+def testDocumentBuilder_Custom(mockGUI, fncPath: Path, mockRnd):
     """Test custom builds and some error handling."""
     project = NWProject()
     buildTestProject(project, fncPath)
@@ -458,7 +457,7 @@ def testNWBuildDocument_Custom(mockGUI, fncPath: Path, mockRnd):
     build = BuildSettings()
     build.unpack(BUILD_CONF)
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
     assert len(docBuild) == 4
 
@@ -529,7 +528,7 @@ def testNWBuildDocument_Custom(mockGUI, fncPath: Path, mockRnd):
 
 
 @pytest.mark.core
-def testNWBuildDocument_IterBuild(mockGUI, fncPath: Path, mockRnd):
+def testDocumentBuilder_IterBuild(mockGUI, fncPath: Path, mockRnd):
     """Test iter build wrapper."""
     project = NWProject()
     buildTestProject(project, fncPath)
@@ -542,7 +541,7 @@ def testNWBuildDocument_IterBuild(mockGUI, fncPath: Path, mockRnd):
     project.storage.getDocument(hPlotDoc).writeDocument("# Main Plot\n**Text**")
     project.storage.getDocument(hCharDoc).writeDocument("# Jane Doe\n~~Text~~")
 
-    docBuild = NWBuildDocument(project, build)
+    docBuild = DocumentBuilder(project, build)
     docBuild.queueAll()
     assert len(docBuild) == 8
 

--- a/tests/manuscript/test_manusbuild.py
+++ b/tests/manuscript/test_manusbuild.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Manuscript Build Dialog Tester
-============================================
+novelWriter – Manuscript Build Dialog Tests
+===========================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/manuscript/test_manuscript.py
+++ b/tests/manuscript/test_manuscript.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Manuscript Tool Tester
-====================================
+novelWriter – Manuscript Tool Tests
+===================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/manuscript/test_manussettings.py
+++ b/tests/manuscript/test_manussettings.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Manuscript Build Settings Dialog Tester
-=====================================================
+novelWriter – Manuscript Build Settings Dialog Tests
+====================================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Common Functions Tester
-=====================================
+novelWriter – Common Functions Tests
+====================================
 
 This file is a part of novelWriter
 Copyright (C) 2019 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,7 +33,7 @@ from PyQt6.QtCore import QMimeData, QUrl
 from PyQt6.QtGui import QDesktopServices, QFont, QFontDatabase, QFontInfo
 
 from novelwriter.common import (
-    NWConfigParser,
+    NConfigParser,
     appendIfSet,
     checkBool,
     checkFloat,
@@ -960,8 +960,8 @@ def testCommon_qtWeakLambda():
 
 
 @pytest.mark.base
-def testCommon_NWConfigParser(fncPath):
-    """Test the NWConfigParser subclass."""
+def testCommon_NConfigParser(fncPath):
+    """Test the NConfigParser subclass."""
     conf = fncPath / "test.cfg"
     writeFile(
         conf,
@@ -982,7 +982,7 @@ def testCommon_NWConfigParser(fncPath):
         ),
     )
 
-    parser = NWConfigParser()
+    parser = NConfigParser()
     parser.read(conf)
 
     # Readers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Config Class Tester
-=================================
+novelWriter – Config Tests
+==========================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Error Handler Tester
-==================================
+novelWriter – Error Handler Tests
+=================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -25,7 +25,7 @@ import sys
 
 import pytest
 
-from novelwriter.error import NWErrorMessage, exceptionHandler, logException
+from novelwriter.error import ErrorMessage, exceptionHandler, logException
 
 from tests.mocked import causeException
 
@@ -43,7 +43,7 @@ def testError_LogException(caplog):
 @pytest.mark.base
 def testError_Dialog(qtbot, monkeypatch, nwGUI):
     """Test the error dialog."""
-    nwErr = NWErrorMessage(nwGUI)
+    nwErr = ErrorMessage(nwGUI)
     qtbot.addWidget(nwErr)
     nwErr.show()
 
@@ -90,27 +90,27 @@ def testError_Handler(qtbot, monkeypatch, nwGUI):
     """
     # Normal shutdown
     with monkeypatch.context() as mp:
-        mp.setattr(NWErrorMessage, "exec", lambda *a: None)
+        mp.setattr(ErrorMessage, "exec", lambda *a: None)
         mp.setattr("PyQt6.QtWidgets.QApplication.exit", lambda *a: None)
         exceptionHandler(Exception, "Error Message", None)  # type: ignore
 
     # Should not crash when no GUI is found
     with monkeypatch.context() as mp:
-        mp.setattr(NWErrorMessage, "exec", lambda *a: None)
+        mp.setattr(ErrorMessage, "exec", lambda *a: None)
         mp.setattr("PyQt6.QtWidgets.QApplication.exit", lambda *a: None)
         mp.setattr("PyQt6.QtWidgets.QApplication.topLevelWidgets", list)
         exceptionHandler(Exception, "Error Message", None)  # type: ignore
 
     # Should handle QApplication failing
     with monkeypatch.context() as mp:
-        mp.setattr(NWErrorMessage, "exec", lambda *a: None)
+        mp.setattr(ErrorMessage, "exec", lambda *a: None)
         mp.setattr("PyQt6.QtWidgets.QApplication.exit", lambda *a: None)
         mp.setattr("PyQt6.QtWidgets.QApplication.topLevelWidgets", causeException)
         exceptionHandler(Exception, "Error Message", None)  # type: ignore
 
     # Should handle failing to close main GUI
     with monkeypatch.context() as mp:
-        mp.setattr(NWErrorMessage, "exec", lambda *a: None)
+        mp.setattr(ErrorMessage, "exec", lambda *a: None)
         mp.setattr("PyQt6.QtWidgets.QApplication.exit", lambda *a: None)
         mp.setattr("novelwriter.guimain.GuiMain.closeMain", causeException)
         exceptionHandler(Exception, "Error Message", None)  # type: ignore

--- a/tests/test_guimain.py
+++ b/tests/test_guimain.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Main GUI Editor Class Tester
-==========================================
+novelWriter – Main GUI Windows Tests
+====================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Main GUI i18n Tests
-=================================
+novelWriter – GUI i18n Tests
+============================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Main Init Tester
-==============================
+novelWriter – App Init Tests
+============================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,5 +1,5 @@
 """
-novelWriter – SharedData Class Tester
+novelWriter – Shared Data Class Tests
 =====================================
 
 This file is a part of novelWriter

--- a/tests/text/test_counting.py
+++ b/tests/text/test_counting.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Counter Module Tester
-===================================
+novelWriter – Text Counter Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/text/test_formats.py
+++ b/tests/text/test_formats.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Text Comment Tester
-=================================
+novelWriter – Text Formats Tests
+================================
 
 This file is a part of novelWriter
 Copyright (C) 2025 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/text/test_patterns.py
+++ b/tests/text/test_patterns.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Patterns Module Tester
-====================================
+novelWriter – Text Patterns Tests
+=================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/tools/test_dictionaries.py
+++ b/tests/tools/test_dictionaries.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Dictionary Downloader Tester
-==========================================
+novelWriter – Dictionary Downloader Tests
+=========================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/tools/test_lipsum.py
+++ b/tests/tools/test_lipsum.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Lorem Ipsum Tool Tester
-=====================================
+novelWriter – Lorem Ipsum Tool Tests
+====================================
 
 This file is a part of novelWriter
 Copyright (C) 2022 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/tools/test_noveldetails.py
+++ b/tests/tools/test_noveldetails.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Novel Details Tool Tester
-=======================================
+novelWriter – Novel Details Tool Tests
+======================================
 
 This file is a part of novelWriter
 Copyright (C) 2024 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/tools/test_welcome.py
+++ b/tests/tools/test_welcome.py
@@ -34,7 +34,7 @@ from PyQt6.QtWidgets import QFileDialog, QMenu
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwFiles
 from novelwriter.core.coretools import ProjectBuilder
-from novelwriter.core.projectdata import NWProjectData
+from novelwriter.core.projectdata import ProjectData
 from novelwriter.enum import nwItemClass
 from novelwriter.shared import _GuiAlert
 from novelwriter.tools.welcome import SAMPLE_KEY, SAMPLE_NAME, GuiWelcome, _ProjectListEntry
@@ -142,8 +142,8 @@ def testGuiWelcome_Open(qtbot, monkeypatch, nwGUI):
     monkeypatch.setattr(QMenu, "exec", lambda *a: None)
     monkeypatch.setattr(QMenu, "setParent", lambda *a: None)
 
-    data1 = NWProjectData(SHARED.project)
-    data2 = NWProjectData(SHARED.project)
+    data1 = ProjectData(SHARED.project)
+    data2 = ProjectData(SHARED.project)
 
     data1.setUuid(None)
     data2.setUuid(None)

--- a/tests/tools/test_welcome.py
+++ b/tests/tools/test_welcome.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Welcome Window Tester
-===================================
+novelWriter – Welcome Dialog Tests
+==================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/tools/test_writingstats.py
+++ b/tests/tools/test_writingstats.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Writing Stats Dialog Class Tester
-===============================================
+novelWriter – Writing Stats Dialog Tests
+========================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/viewer/test_viewer.py
+++ b/tests/viewer/test_viewer.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Document Viewer Class Tester
-==========================================
+novelWriter – Document Viewer Tests
+===================================
 
 This file is a part of novelWriter
 Copyright (C) 2020 Veronica Berglyd Olsen and novelWriter contributors

--- a/tests/viewer/test_viewerpanel.py
+++ b/tests/viewer/test_viewerpanel.py
@@ -27,7 +27,7 @@ from PyQt6.QtGui import QIcon
 
 from novelwriter import SHARED
 from novelwriter.constants import nwLists
-from novelwriter.core.item import NWItem
+from novelwriter.core.item import ProjectItem
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.enum import nwChange
 
@@ -264,7 +264,7 @@ def testGuiDocViewerPanel_Tags(qtbot, monkeypatch, caplog, nwGUI, projPath, mock
     assert charTab.topLevelItemCount() == 2
 
     nwJohn = SHARED.project.tree[hJohn]
-    assert isinstance(nwJohn, NWItem)
+    assert isinstance(nwJohn, ProjectItem)
     nwJohn.setActive(False)
     nwJohn.notifyToRefresh()
     assert charTab.topLevelItemCount() == 1

--- a/tests/viewer/test_viewerpanel.py
+++ b/tests/viewer/test_viewerpanel.py
@@ -1,6 +1,6 @@
 """
-novelWriter – Main GUI Viewer Panel Class Tester
-================================================
+novelWriter – Document Viewer Panel Tests
+=========================================
 
 This file is a part of novelWriter
 Copyright (C) 2023 Veronica Berglyd Olsen and novelWriter contributors


### PR DESCRIPTION
**Summary:**

This PR:
* Cleans up a lot of module docstrings.
* Removes the `NW` prefix from all classes except for `NWProject`.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
