### PR TITLE
Menus cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 - Avoid adding test-specific code to the main code base
 - `CONFIG` is fully reset before every test by the autouse `functionFixture` fixture in `tests/conftest.py`; never save/restore `CONFIG.*` values in a test, just set them directly
 - Both line and branch test coverage should be complete and at 100%
+- Use the `coverage` tool directly when checking test coverage, not via `pytest-cov`
 
 ## Documentation
 

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -37,7 +37,7 @@ from urllib.parse import urljoin
 from urllib.request import pathname2url
 
 from PyQt6.QtCore import QCoreApplication, QLocale, QMimeData, QUrl
-from PyQt6.QtGui import QAction, QDesktopServices, QFont, QFontDatabase, QFontInfo
+from PyQt6.QtGui import QAction, QDesktopServices, QFont, QFontDatabase, QFontInfo, QIcon
 from PyQt6.QtWidgets import QMenu, QMenuBar, QWidget
 
 from novelwriter.constants import nwConst, nwLabels, nwQuotes, nwUnicode, trConst
@@ -565,17 +565,19 @@ def qtWeakLambda(method: MethodType, *args: Any, **kwargs: Any) -> Callable:
     return wrapper
 
 
-def qtAddAction(parent: QWidget, label: str, data: Any | None = None) -> QAction:
-    """Helper to add action to widget and always return the action."""  # noqa: D401
+def qtAddAction(parent: QWidget, label: str, *, icon: QIcon | None = None, data: Any | None = None) -> QAction:
+    """Add action to a widget and always return the action."""
     action = QAction(label, parent)
-    parent.addAction(action)
+    if icon is not None:
+        action.setIcon(icon)
     if data is not None:
         action.setData(data)
+    parent.addAction(action)
     return action
 
 
 def qtAddMenu(parent: QMenuBar | QMenu, label: str) -> QMenu:
-    """Helper to add menu to menu and always return the menu."""  # noqa: D401
+    """Add a menu to a menu and always return the menu."""
     menu = QMenu(label, parent)
     parent.addMenu(menu)
     return menu

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -565,10 +565,12 @@ def qtWeakLambda(method: MethodType, *args: Any, **kwargs: Any) -> Callable:
     return wrapper
 
 
-def qtAddAction(parent: QWidget, label: str) -> QAction:
+def qtAddAction(parent: QWidget, label: str, data: Any | None = None) -> QAction:
     """Helper to add action to widget and always return the action."""  # noqa: D401
     action = QAction(label, parent)
     parent.addAction(action)
+    if data is not None:
+        action.setData(data)
     return action
 
 

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -750,7 +750,7 @@ class GuiPreferences(NDialog):
         self.mnLineSymbols = QMenu(self)
         for symbol in nwQuotes.ALLOWED:
             label = trConst(nwQuotes.SYMBOLS.get(symbol, nwQuotes.DASHES.get(symbol, "None")))
-            qtAddAction(self.mnLineSymbols, f"[ {symbol} ] {label}", symbol)
+            qtAddAction(self.mnLineSymbols, f"[ {symbol} ] {label}", data=symbol)
 
         self.mnLineSymbols.triggered.connect(self._insertDialogLineSymbol)
 

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -40,7 +40,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import compact, describeFont, processDialogSymbols, uniqueCompact
+from novelwriter.common import compact, describeFont, processDialogSymbols, qtAddAction, uniqueCompact
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS, DEF_TREECOL
 from novelwriter.constants import nwLabels, nwQuotes, nwUnicode, trConst
 from novelwriter.dialogs.quotes import GuiQuoteSelect
@@ -750,8 +750,7 @@ class GuiPreferences(NDialog):
         self.mnLineSymbols = QMenu(self)
         for symbol in nwQuotes.ALLOWED:
             label = trConst(nwQuotes.SYMBOLS.get(symbol, nwQuotes.DASHES.get(symbol, "None")))
-            if action := self.mnLineSymbols.addAction(f"[ {symbol} ] {label}"):  # pragma: no branch
-                action.setData(symbol)
+            qtAddAction(self.mnLineSymbols, f"[ {symbol} ] {label}", symbol)
 
         self.mnLineSymbols.triggered.connect(self._insertDialogLineSymbol)
 

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -429,7 +429,7 @@ class _StatusPage(NFixedPage):
         buildMenu(self.shapeMenu.addMenu(self.tr("Circles ...")), nwLabels.SHAPES_CIRCLE)
         buildMenu(self.shapeMenu.addMenu(self.tr("Bars ...")), nwLabels.SHAPES_BARS)
         buildMenu(self.shapeMenu.addMenu(self.tr("Blocks ...")), nwLabels.SHAPES_BLOCKS)
-        self.shapeMenu.triggered.connect(self._selectShape)
+        self.shapeMenu.triggered.connect(self._shapeSelected)
 
         self.shapeButton = NIconToolButton(self, iSz)
         self.shapeButton.setMenu(self.shapeMenu)
@@ -625,8 +625,8 @@ class _StatusPage(NFixedPage):
                 SHARED.error("Could not write file.", exc=exc)
 
     @pyqtSlot(QAction)
-    def _selectShape(self, action: QAction) -> None:
-        """Set the current shape."""
+    def _shapeSelected(self, action: QAction) -> None:
+        """Update the status icon shape."""
         if isinstance(shape := action.data(), nwStatusShape):
             self._shape = shape
             self._setButtonIcons()

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -27,7 +27,7 @@ import logging
 from pathlib import Path
 
 from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QCloseEvent, QColor
+from PyQt6.QtGui import QAction, QCloseEvent, QColor
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QApplication,
@@ -421,10 +421,7 @@ class _StatusPage(NFixedPage):
             if menu is not None:  # pragma: no branch
                 for shape, label in items.items():
                     icon = ItemStatus.createIcon(self._iPx, iColor, shape)
-                    action = qtAddAction(menu, trConst(label))
-                    action.setIcon(icon)
-                    action.triggered.connect(qtLambda(self._selectShape, shape))
-                    menu.addAction(action)
+                    qtAddAction(menu, trConst(label), icon=icon, data=shape)
                     self._icons[shape] = icon
 
         self.shapeMenu = QMenu(self)
@@ -432,6 +429,7 @@ class _StatusPage(NFixedPage):
         buildMenu(self.shapeMenu.addMenu(self.tr("Circles ...")), nwLabels.SHAPES_CIRCLE)
         buildMenu(self.shapeMenu.addMenu(self.tr("Bars ...")), nwLabels.SHAPES_BARS)
         buildMenu(self.shapeMenu.addMenu(self.tr("Blocks ...")), nwLabels.SHAPES_BLOCKS)
+        self.shapeMenu.triggered.connect(self._selectShape)
 
         self.shapeButton = NIconToolButton(self, iSz)
         self.shapeButton.setMenu(self.shapeMenu)
@@ -626,15 +624,17 @@ class _StatusPage(NFixedPage):
             except Exception as exc:
                 SHARED.error("Could not write file.", exc=exc)
 
+    @pyqtSlot(QAction)
+    def _selectShape(self, action: QAction) -> None:
+        """Set the current shape."""
+        if isinstance(shape := action.data(), nwStatusShape):
+            self._shape = shape
+            self._setButtonIcons()
+            self._updateIcon()
+
     ##
     #  Internal Functions
     ##
-
-    def _selectShape(self, shape: nwStatusShape) -> None:
-        """Set the current shape."""
-        self._shape = shape
-        self._setButtonIcons()
-        self._updateIcon()
 
     def _updateIcon(self) -> None:
         """Apply changes made to a status icon."""

--- a/novelwriter/editor/completer.py
+++ b/novelwriter/editor/completer.py
@@ -90,9 +90,7 @@ class CommandCompleter(QMenu):
             return False
 
         for value in options:
-            rep = value + suffix
-            action = qtAddAction(self, value)
-            action.setData(CompleterAction(pos=offset, length=length, value=rep))
+            qtAddAction(self, value, data=CompleterAction(pos=offset, length=length, value=value + suffix))
 
         return True
 
@@ -140,8 +138,11 @@ class CommandCompleter(QMenu):
             if options:
                 for value in options:
                     rep = value + suffix
-                    action = qtAddAction(self, rep.rstrip(":. "))
-                    action.setData(CompleterAction(pos=offset, length=length, value=rep))
+                    qtAddAction(
+                        self,
+                        rep.rstrip(":. "),
+                        data=CompleterAction(pos=offset, length=length, value=rep),
+                    )
                 return True
 
         return False

--- a/novelwriter/editor/editheader.py
+++ b/novelwriter/editor/editheader.py
@@ -27,7 +27,7 @@ from time import time
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QTimer, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QPalette
+from PyQt6.QtGui import QAction, QPalette
 from PyQt6.QtWidgets import QHBoxLayout, QMenu, QWidget
 
 from novelwriter import CONFIG, SHARED
@@ -83,6 +83,7 @@ class GuiDocEditHeader(QWidget):
 
         # Other Widgets
         self.outlineMenu = QMenu(self)
+        self.outlineMenu.triggered.connect(self._gotoBlock)
 
         # Buttons
         self.tbButton = NIconToolButton(self, iSz)
@@ -162,8 +163,7 @@ class GuiDocEditHeader(QWidget):
             tStart = time()
             self.outlineMenu.clear()
             for number, text in data.items():
-                action = qtAddAction(self.outlineMenu, text)
-                action.triggered.connect(qtLambda(self._gotoBlock, number))
+                qtAddAction(self.outlineMenu, text, data=number)
             self._docOutline = data
             logger.debug("Document outline updated in %.3f ms", 1000 * (time() - tStart))
 
@@ -243,10 +243,11 @@ class GuiDocEditHeader(QWidget):
         self.clearHeader()
         self.closeDocumentRequest.emit()
 
-    @pyqtSlot(int)
-    def _gotoBlock(self, blockNumber: int) -> None:
+    @pyqtSlot(QAction)
+    def _gotoBlock(self, action: QAction) -> None:
         """Move cursor to a specific heading."""
-        self.docEditor.setCursorLine(blockNumber + 1)
+        if isinstance(blockNumber := action.data(), int):
+            self.docEditor.setCursorLine(blockNumber + 1)
 
     @pyqtSlot(bool)
     def _focusModeChanged(self, focusMode: bool) -> None:

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -378,9 +378,12 @@ class GuiProjectToolBar(QWidget):
         logger.debug("Rebuilding quick links menu")
         self.mQuick.clear()
         for tHandle, nwItem in SHARED.project.tree.iterRoots(None):
-            action = qtAddAction(self.mQuick, nwItem.itemName)
-            action.setData(tHandle)
-            action.setIcon(SHARED.theme.getIcon(nwLabels.CLASS_ICON[nwItem.itemClass], "root"))
+            action = qtAddAction(
+                self.mQuick,
+                nwItem.itemName,
+                icon=SHARED.theme.getIcon(nwLabels.CLASS_ICON[nwItem.itemClass], "root"),
+                data=tHandle,
+            )
             action.triggered.connect(qtLambda(self.projView.setSelectedHandle, tHandle, doScroll=True))
 
     def buildTemplatesMenu(self) -> None:
@@ -422,10 +425,12 @@ class GuiProjectToolBar(QWidget):
         """Build the rood folder menu."""
 
         def addClass(itemClass: nwItemClass) -> None:
-            aNew = qtAddAction(self.mAddRoot, trConst(nwLabels.CLASS_NAME[itemClass]))
-            aNew.setIcon(SHARED.theme.getIcon(nwLabels.CLASS_ICON[itemClass], "root"))
-            aNew.triggered.connect(qtLambda(self.projTree.newTreeItem, nwItemType.ROOT, itemClass))
-            self.mAddRoot.addAction(aNew)
+            action = qtAddAction(
+                self.mAddRoot,
+                trConst(nwLabels.CLASS_NAME[itemClass]),
+                icon=SHARED.theme.getIcon(nwLabels.CLASS_ICON[itemClass], "root"),
+            )
+            action.triggered.connect(qtLambda(self.projTree.newTreeItem, nwItemType.ROOT, itemClass))
 
         self.mAddRoot.clear()
         addClass(nwItemClass.NOVEL)
@@ -1170,22 +1175,18 @@ class _TreeContextMenu(QMenu):
         """Add Active/Inactive actions."""
         if len(self._indices) > 1:
             mSub = qtAddMenu(self, self.tr("Set Active to ..."))
-            aOne = qtAddAction(mSub, self._tree.trActive)
-            aOne.setIcon(SHARED.theme.getIcon("checked", "accept"))
+            aOne = qtAddAction(mSub, self._tree.trActive, icon=SHARED.theme.getIcon("checked", "accept"))
             aOne.triggered.connect(qtWeakLambda(self._iterItemActive, True))
-            aTwo = qtAddAction(mSub, self._tree.trInactive)
-            aTwo.setIcon(SHARED.theme.getIcon("unchecked", "reject"))
+            aTwo = qtAddAction(mSub, self._tree.trInactive, icon=SHARED.theme.getIcon("unchecked", "reject"))
             aTwo.triggered.connect(qtWeakLambda(self._iterItemActive, False))
         else:
             action = qtAddAction(self, self.tr("Toggle Active"))
             action.triggered.connect(self._toggleItemActive)
             if self._children > 0:
                 mSub = qtAddMenu(self, self.tr("Set Children to ..."))
-                aOne = qtAddAction(mSub, self._tree.trActive)
-                aOne.setIcon(SHARED.theme.getIcon("checked", "accept"))
+                aOne = qtAddAction(mSub, self._tree.trActive, icon=SHARED.theme.getIcon("checked", "accept"))
                 aOne.triggered.connect(qtWeakLambda(self._recurseItemActive, True))
-                aTwo = qtAddAction(mSub, self._tree.trInactive)
-                aTwo.setIcon(SHARED.theme.getIcon("unchecked", "reject"))
+                aTwo = qtAddAction(mSub, self._tree.trInactive, icon=SHARED.theme.getIcon("unchecked", "reject"))
                 aTwo.triggered.connect(qtWeakLambda(self._recurseItemActive, False))
 
     def _itemStatusImport(self, multi: bool) -> None:
@@ -1197,8 +1198,7 @@ class _TreeContextMenu(QMenu):
                 name = entry.name
                 if not multi and current == key:
                     name += f" ({nwUnicode.U_CHECK})"
-                action = qtAddAction(menu, name)
-                action.setIcon(entry.icon)
+                action = qtAddAction(menu, name, icon=entry.icon)
                 if multi:
                     action.triggered.connect(qtWeakLambda(self._iterSetItemStatus, key))
                 else:
@@ -1213,8 +1213,7 @@ class _TreeContextMenu(QMenu):
                 name = entry.name
                 if not multi and current == key:
                     name += f" ({nwUnicode.U_CHECK})"
-                action = qtAddAction(menu, name)
-                action.setIcon(entry.icon)
+                action = qtAddAction(menu, name, icon=entry.icon)
                 if multi:
                     action.triggered.connect(qtWeakLambda(self._iterSetItemImport, key))
                 else:

--- a/novelwriter/manuscript/manussettings.py
+++ b/novelwriter/manuscript/manussettings.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QEvent, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QFont, QIcon, QSyntaxHighlighter, QTextCharFormat, QTextDocument
+from PyQt6.QtGui import QAction, QFont, QIcon, QSyntaxHighlighter, QTextCharFormat, QTextDocument
 from PyQt6.QtWidgets import (
     QAbstractButton,
     QAbstractItemView,
@@ -1070,11 +1070,9 @@ class _FormattingTab(NScrollableForm):
         self.ignoredKeywords = QLineEdit(self)
 
         self.mnKeywords = QMenu(self)
+        self.mnKeywords.triggered.connect(self._ignoredKeywordSelected)
         for keyword in nwKeyWords.VALID_KEYS:
-            self.mnKeywords.addAction(
-                trConst(nwLabels.KEY_NAME[keyword]),
-                lambda keyword=keyword: self._updateIgnoredKeywords(keyword),
-            )
+            qtAddAction(self.mnKeywords, trConst(nwLabels.KEY_NAME[keyword]), data=keyword)
 
         self.ignoredKeywordsButton = NIconToolButton(self, iSz, "add", "add")
         self.ignoredKeywordsButton.setToolTip(self.tr("Select Keyword"))
@@ -1890,6 +1888,12 @@ class _FormattingTab(NScrollableForm):
         self.textMarginB.setEnabled(enabled)
         self.sepMarginT.setEnabled(enabled)
         self.sepMarginB.setEnabled(enabled)
+
+    @pyqtSlot(QAction)
+    def _ignoredKeywordSelected(self, action: QAction) -> None:
+        """Process the user selecting an ignored keyword from the menu."""
+        if isinstance(keyword := action.data(), str):
+            self._updateIgnoredKeywords(keyword)
 
     ##
     #  Internal Functions

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -644,16 +644,25 @@ class _NewProjectForm(QWidget):
 
         self.fillMenu = QMenu(self.browseFill)
 
-        self.fillBlank = qtAddAction(self.fillMenu, self.tr("Create a fresh project"))
-        self.fillBlank.setIcon(SHARED.theme.getIcon("document", "file"))
+        self.fillBlank = qtAddAction(
+            self.fillMenu,
+            self.tr("Create a fresh project"),
+            icon=SHARED.theme.getIcon("document", "file"),
+        )
         self.fillBlank.triggered.connect(self._setFillBlank)
 
-        self.fillSample = qtAddAction(self.fillMenu, self.tr("Create an example project"))
-        self.fillSample.setIcon(SHARED.theme.getIcon("document_add", "add"))
+        self.fillSample = qtAddAction(
+            self.fillMenu,
+            self.tr("Create an example project"),
+            icon=SHARED.theme.getIcon("document_add", "add"),
+        )
         self.fillSample.triggered.connect(self._setFillSample)
 
-        self.fillCopy = qtAddAction(self.fillMenu, self.tr("Copy an existing project"))
-        self.fillCopy.setIcon(SHARED.theme.getIcon("project_copy", "action"))
+        self.fillCopy = qtAddAction(
+            self.fillMenu,
+            self.tr("Copy an existing project"),
+            icon=SHARED.theme.getIcon("project_copy", "action"),
+        )
         self.fillCopy.triggered.connect(self._setFillCopy)
 
         self.browseFill.setMenu(self.fillMenu)

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -44,7 +44,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import checkInt, checkIntTuple, formatTime, minmax
+from novelwriter.common import checkInt, checkIntTuple, formatTime, minmax, qtAddAction
 from novelwriter.constants import nwConst
 from novelwriter.enum import nwStandardButton
 from novelwriter.error import formatException
@@ -277,16 +277,10 @@ class GuiWritingStats(NToolDialog):
         self.btnClose.clicked.connect(self.closeDialog)
         self.btnClose.setAutoDefault(False)
 
-        self.saveJSON = QAction(self.tr("JSON Data File (.json)"), self)
-        self.saveJSON.setData(self.FMT_JSON)
-
-        self.saveCSV = QAction(self.tr("CSV Data File (.csv)"), self)
-        self.saveCSV.setData(self.FMT_CSV)
-
         self.saveMenu = QMenu(self)
-        self.saveMenu.addAction(self.saveJSON)
-        self.saveMenu.addAction(self.saveCSV)
         self.saveMenu.triggered.connect(self._saveMenuTriggered)
+        qtAddAction(self.saveMenu, self.tr("JSON Data File (.json)"), data=self.FMT_JSON)
+        qtAddAction(self.saveMenu, self.tr("CSV Data File (.csv)"), data=self.FMT_CSV)
 
         self.btnSave = NPushButton(self, self.tr("Save As"), bSz, "btn_save", "action")
         self.btnSave.setAutoDefault(False)

--- a/novelwriter/viewer/viewheader.py
+++ b/novelwriter/viewer/viewheader.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import pyqtSlot
-from PyQt6.QtGui import QPalette
+from PyQt6.QtGui import QAction, QPalette
 from PyQt6.QtWidgets import QHBoxLayout, QMenu, QWidget
 
 from novelwriter import CONFIG, SHARED
@@ -78,6 +78,7 @@ class GuiDocViewHeader(QWidget):
 
         # Other Widgets
         self.outlineMenu = QMenu(self)
+        self.outlineMenu.triggered.connect(self._gotoHeader)
 
         # Buttons
         self.outlineButton = NIconToolButton(self, iSz)
@@ -167,8 +168,7 @@ class GuiDocViewHeader(QWidget):
                     minLevel = min(minLevel, level)
             for title, text, level in entries[:30]:
                 indent = "    " * (level - minLevel)
-                action = qtAddAction(self.outlineMenu, f"{indent}{text}")
-                action.triggered.connect(lambda _, title=title: self.docViewer.navigateTo(f"#{tHandle}:{title}"))
+                qtAddAction(self.outlineMenu, f"{indent}{text}", data=f"#{tHandle}:{title}")
             self._docOutline = data
 
     def updateFont(self) -> None:
@@ -264,3 +264,9 @@ class GuiDocViewHeader(QWidget):
         """Process an activated link in the label."""
         if link.startswith("#"):
             self.docViewer.requestProjectItemSelected.emit(link.lstrip("#"), True)
+
+    @pyqtSlot(QAction)
+    def _gotoHeader(self, action: QAction) -> None:
+        """Move cursor to a specific heading."""
+        if isinstance(data := action.data(), str):
+            self.docViewer.navigateTo(data)

--- a/tests/dialogs/test_projectsettings.py
+++ b/tests/dialogs/test_projectsettings.py
@@ -235,13 +235,13 @@ def testGuiProjectSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, moc
         status.colorButton.click()
         shapeAction = QAction(status)
         shapeAction.setData(nwStatusShape.CIRCLE)
-        status._selectShape(shapeAction)
+        status._shapeSelected(shapeAction)
         assert status.listBox.topLevelItemCount() == 4
 
         # Non-shape data is ignored
         otherAction = QAction(status)
         otherAction.setData("not-a-shape")
-        status._selectShape(otherAction)
+        status._shapeSelected(otherAction)
 
     assert status.changed is True
     update = status.getNewList()
@@ -309,7 +309,7 @@ def testGuiProjectSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, moc
         importance.colorButton.click()
         shapeAction = QAction(importance)
         shapeAction.setData(nwStatusShape.TRIANGLE)
-        importance._selectShape(shapeAction)
+        importance._shapeSelected(shapeAction)
         assert importance.listBox.topLevelItemCount() == 4
 
     assert importance.changed is True

--- a/tests/dialogs/test_projectsettings.py
+++ b/tests/dialogs/test_projectsettings.py
@@ -233,8 +233,15 @@ def testGuiProjectSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, moc
         status.listBox.setCurrentItem(status.listBox.topLevelItem(3))
         status._onNameEdit("Final")
         status.colorButton.click()
-        status._selectShape(nwStatusShape.CIRCLE)
+        shapeAction = QAction(status)
+        shapeAction.setData(nwStatusShape.CIRCLE)
+        status._selectShape(shapeAction)
         assert status.listBox.topLevelItemCount() == 4
+
+        # Non-shape data is ignored
+        otherAction = QAction(status)
+        otherAction.setData("not-a-shape")
+        status._selectShape(otherAction)
 
     assert status.changed is True
     update = status.getNewList()
@@ -300,7 +307,9 @@ def testGuiProjectSettings_StatusImport(qtbot, monkeypatch, nwGUI, projPath, moc
         importance.listBox.setCurrentItem(importance.listBox.topLevelItem(3))
         importance._onNameEdit("Final")
         importance.colorButton.click()
-        importance._selectShape(nwStatusShape.TRIANGLE)
+        shapeAction = QAction(importance)
+        shapeAction.setData(nwStatusShape.TRIANGLE)
+        importance._selectShape(shapeAction)
         assert importance.listBox.topLevelItemCount() == 4
 
     assert importance.changed is True

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -165,6 +165,12 @@ def testGuiDocEditor_Init(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     docEditor.docHeader.outlineMenu.actions()[0].trigger()
     assert docEditor.getCursorPosition() == 0
 
+    # Non-integer data is ignored
+    otherAction = QAction(docEditor.docHeader)
+    otherAction.setData("not-an-int")
+    docEditor.docHeader._gotoBlock(otherAction)
+    assert docEditor.getCursorPosition() == 0
+
     # Select item from header
     with qtbot.waitSignal(docEditor.requestProjectItemSelected, timeout=1000) as signal:
         docEditor.docHeader._processLabelLink(f"#{docEditor.docHeader._docHandle}")

--- a/tests/manuscript/test_manussettings.py
+++ b/tests/manuscript/test_manussettings.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import pytest
 
 from PyQt6.QtCore import pyqtSlot
-from PyQt6.QtGui import QFont
+from PyQt6.QtGui import QAction, QFont
 
 from novelwriter import SHARED
 from novelwriter.common import describeFont
@@ -590,6 +590,17 @@ def testGuiBuildSettings_FormatTextContent(qtbot, nwGUI):
     fmtTab.ignoredKeywords.setText("@stuff, @pizza, @object")  # First two are invalid
     fmtTab._updateIgnoredKeywords("@custom")  # Adding a new should trigger cleanup
     assert fmtTab.ignoredKeywords.text() in ("@custom, @object", "@object, @custom")
+
+    # Selecting a keyword from the menu should also trigger cleanup
+    fmtTab.mnKeywords.actions()[0].trigger()
+    assert fmtTab.ignoredKeywords.text() != ""
+    fmtTab.ignoredKeywords.setText("@custom, @object")
+
+    # Non-string data is ignored
+    otherAction = QAction(fmtTab)
+    otherAction.setData(1)
+    fmtTab._ignoredKeywordSelected(otherAction)
+    assert fmtTab.ignoredKeywords.text() == "@custom, @object"
 
     # Save values
     fmtTab.saveContent()

--- a/tests/tools/test_writingstats.py
+++ b/tests/tools/test_writingstats.py
@@ -135,8 +135,9 @@ def testGuiWritingStats_Export(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
         assert not sessLog._saveData(sessLog.FMT_CSV)
         assert not sessLog._saveData(sessLog.FMT_JSON)
         assert not sessLog._saveData(None)  # type: ignore
-        sessLog.saveJSON.trigger()
-        sessLog.saveCSV.trigger()
+        saveJSON, saveCSV = sessLog.saveMenu.actions()
+        saveJSON.trigger()
+        saveCSV.trigger()
 
     # Sort by time
     sessLog.listBox.sortByColumn(sessLog.C_TIME, Qt.SortOrder.AscendingOrder)

--- a/tests/viewer/test_viewer.py
+++ b/tests/viewer/test_viewer.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from PyQt6.QtCore import QMimeData, QPointF, Qt, QUrl
-from PyQt6.QtGui import QDesktopServices, QDragEnterEvent, QDragMoveEvent, QDropEvent
+from PyQt6.QtGui import QAction, QDesktopServices, QDragEnterEvent, QDragMoveEvent, QDropEvent
 from PyQt6.QtWidgets import QApplication, QMenu, QTextBrowser
 
 from novelwriter import CONFIG, SHARED
@@ -397,6 +397,14 @@ def testGuiDocViewer_HeaderTitle(qtbot, nwGUI, projPath, mockRnd):
     docViewer.docHeader._docOutline = {}
     docViewer.docHeader.setOutline({"T0000": ("Title", 1), "T0001": ("Chapter One", 1)})
     assert [a.text() for a in docViewer.docHeader.outlineMenu.actions()] == ["Chapter One"]
+
+    # Selecting an entry from the outline menu navigates to it
+    docViewer.docHeader.outlineMenu.actions()[0].trigger()
+
+    # Non-string data is ignored
+    otherAction = QAction(docViewer.docHeader)
+    otherAction.setData(1)
+    docViewer.docHeader._gotoHeader(otherAction)
 
 
 @pytest.mark.gui


### PR DESCRIPTION
**Summary:**

This PR extends the qtAddAction helper to add data and icon as parameters, and updates the helper usage in the code. Some redundant code was also removed.

**Related Issue(s):**

Closes #2828

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
