### PR TITLE
Fix weekly backup name format

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -237,12 +237,11 @@ def formatTimeStamp(value: float, fileSafe: bool = False, fmt: str | None = None
     """Take a number (on the format returned by time.time()) and convert
     it to a timestamp string.
     """
-    if fmt is not None:
-        return datetime.fromtimestamp(value).strftime(fmt)
-    if fileSafe:
-        return datetime.fromtimestamp(value).strftime(nwConst.FMT_FSTAMP)
-    else:
-        return datetime.fromtimestamp(value).strftime(nwConst.FMT_TSTAMP)
+    try:
+        result = datetime.fromtimestamp(value).strftime(nwConst.FMT_TSTAMP if fmt is None else fmt)
+        return result.replace(":", ".") if fileSafe else result
+    except Exception:
+        return "ERROR"
 
 
 def formatTime(t: int) -> str:

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -43,7 +43,6 @@ class nwConst:
 
     # Date and Time Formats
     FMT_TSTAMP = "%Y-%m-%d %H:%M:%S"  # Default format
-    FMT_FSTAMP = "%Y-%m-%d %H.%M.%S"  # FileName safe format
     FMT_DSTAMP = "%Y-%m-%d"  # Date only format
 
     # URLs

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -507,10 +507,10 @@ class NWProject:
             case "day":
                 timeStamp = formatTimeStamp(time(), fileSafe=True, fmt="%Y-%m-%d")
             case "week":
-                timeStamp = formatTimeStamp(time(), fileSafe=True, fmt="%Y-%V")
+                timeStamp = formatTimeStamp(time(), fileSafe=True, fmt="%G-W%V")
             case "month":
                 timeStamp = formatTimeStamp(time(), fileSafe=True, fmt="%Y-%m")
-            case _:  # session interval setting falls through here
+            case _:  # Option "session" falls through here
                 timeStamp = formatTimeStamp(time(), fileSafe=True)
 
         archName = baseDir / f"{cleanName} {timeStamp}.zip"

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -548,7 +548,7 @@ def testNWProject_Backup(monkeypatch, mockGUI, fncPath, tstPaths):
 
         CONFIG.backupInterval = "week"
         assert project.backupProject(doNotify=False) is True
-        stamp = fixedLocal.strftime("%Y-%V")
+        stamp = fixedLocal.strftime("%G-W%V")
         assert (tstPaths.tmpDir / "Test Minimal" / f"Test Minimal {stamp}.zip").exists()
 
         CONFIG.backupInterval = "month"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -356,9 +356,10 @@ def testCommon_firstFloat():
 def testCommon_formatTimeStamp():
     """Test the formatTimeStamp function."""
     tTime = time.mktime(time.gmtime(0))
-    assert formatTimeStamp(tTime, True, "%Y") == "1970"
+    assert formatTimeStamp(tTime, False, "%Y") == "1970"
     assert formatTimeStamp(tTime, False) == "1970-01-01 00:00:00"
     assert formatTimeStamp(tTime, True) == "1970-01-01 00.00.00"
+    assert formatTimeStamp(tTime, False, 123) == "ERROR"  # type: ignore
 
 
 @pytest.mark.base


### PR DESCRIPTION
**Summary:**

The format used for weekly backup files in #2834 is ambiguous and overlaps with the monthly format. This changes it to the correct ISO8601 format instead.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
