### PR TITLE
Manuscript print kerning fix

### DIFF
--- a/novelwriter/assets/i18n/project_en_GB.json
+++ b/novelwriter/assets/i18n/project_en_GB.json
@@ -17,7 +17,6 @@
   "Entities": "Entities",
   "Custom": "Custom",
   "Mentions": "Mentions",
-  "New Page": "New Page",
   "0": "Zero",
   "1": "One",
   "2": "Two",

--- a/novelwriter/formats/toqdoc.py
+++ b/novelwriter/formats/toqdoc.py
@@ -38,6 +38,8 @@ from PyQt6.QtGui import (
     QTextDocument,
     QTextFrameFormat,
     QTextLength,
+    QTextTableCellFormat,
+    QTextTableFormat,
 )
 from PyQt6.QtPrintSupport import QPrinter
 
@@ -490,36 +492,24 @@ class ToQTextDocument(Tokenizer):
         cursor.insertText(stripEscape(temp[start:]), cFmt)
 
     def _insertNewPageMarker(self, cursor: QTextCursor) -> None:
-        """Insert a new page marker."""
+        """Insert a new page marker as a dashed line."""
         if self._newPage:
-            bgCol = QColor(self._theme.text)
-            bgCol.setAlphaF(0.1)
-            fgCol = QColor(self._theme.text)
-            fgCol.setAlphaF(0.8)
+            tFmt = QTextTableFormat()
+            tFmt.setBorder(0.0)
+            tFmt.setBorderStyle(QTextFrameFormat.BorderStyle.BorderStyle_None)
+            tFmt.setCellPadding(0.0)
+            tFmt.setCellSpacing(0.0)
+            tFmt.setTopMargin(self._mSep[0])
+            tFmt.setBottomMargin(self._mSep[1])
+            tFmt.setWidth(QTextLength(QTextLength.Type.PercentageLength, 100.0))
 
-            fFmt = QTextFrameFormat()
-            fFmt.setBorderStyle(QTextFrameFormat.BorderStyle.BorderStyle_None)
-            fFmt.setBackground(bgCol)
-            fFmt.setTopMargin(self._mSep[0])
-            fFmt.setBottomMargin(self._mSep[1])
+            cFmt = QTextTableCellFormat()
+            cFmt.setBottomBorder(1.0)
+            cFmt.setBottomBorderStyle(QTextFrameFormat.BorderStyle.BorderStyle_Dashed)
+            cFmt.setBottomBorderBrush(QBrush(self._theme.text))
 
-            bFmt = QTextBlockFormat(self._blockFmt)
-            bFmt.setAlignment(QtAlignCenter)
-            bFmt.setTopMargin(0.0)
-            bFmt.setBottomMargin(0.0)
-            bFmt.setLineHeight(100.0, QtPropLineHeight)
-
-            cFmt = QTextCharFormat(self._charFmt)
-            cFmt.setFontItalic(False)
-            cFmt.setFontUnderline(False)
-            cFmt.setFontStrikeOut(False)
-            cFmt.setFontWeight(QtFontNormal)
-            cFmt.setFontPointSize(0.75 * self._textFont.pointSizeF())
-            cFmt.setForeground(fgCol)
-
-            cursor.insertFrame(fFmt)
-            cursor.setBlockFormat(bFmt)
-            cursor.insertText(self._project.localLookup("New Page"), cFmt)
+            if table := cursor.insertTable(1, 1, tFmt):  # pragma: no branch
+                table.cellAt(0, 0).setFormat(cFmt)
             if root := self._document.rootFrame():  # pragma: no branch
                 cursor.swap(root.lastCursorPosition())
 

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -882,8 +882,17 @@ class _PreviewWidget(QTextBrowser):
         """Connect the print preview painter to the document viewer."""
         if document := self.document():  # pragma: no branch
             QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
+
+            # Disable font hinting for the print job, see issues #2637 and #2640
+            origFont = document.defaultFont()
+            noHint = QFont(origFont)
+            noHint.setHintingPreference(QFont.HintingPreference.PreferNoHinting)
+            document.setDefaultFont(noHint)
+
             printer.setPageOrientation(QPageLayout.Orientation.Portrait)
             document.print(printer)
+            document.setDefaultFont(origFont)
+
             QApplication.restoreOverrideCursor()
 
     @pyqtSlot(str)

--- a/tests/manuscript/test_manuscript.py
+++ b/tests/manuscript/test_manuscript.py
@@ -48,7 +48,7 @@ def testGuiManuscript_Init(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
     buildTestProject(nwGUI, projPath)
     nwGUI.openProject(projPath)
     SHARED.project.storage.getDocument(C.hChapterDoc).writeDocument("## A Chapter\n\n\t\tHi")
-    allText = "New Novel\nBy Jane Doe\nNew Page\n\nA Chapter\n\t\tHi"
+    allText = "New Novel\nBy Jane Doe\n\n\nA Chapter\n\t\tHi"
 
     nwGUI.mainMenu.aBuildManuscript.activate(QAction.ActionEvent.Trigger)
     qtbot.waitUntil(lambda: SHARED.findTopLevelWidget(GuiManuscript) is not None, timeout=1000)


### PR DESCRIPTION
**Summary:**

This should fix the kerning issue when printing the manuscript preview on Windows. Since the print also includes the new page marker, I made it a dashed line instead of the text block.

**Related Issue(s):**

Closes #2640

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
