### PR TITLE
Editor document cache

### DIFF
--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -143,7 +143,7 @@ class ProjectTree:
         self._nodes.clear()
         self._ready = False
         self._trash = None
-        oldModel.deleteLater()
+        oldModel.setParent(None)
         del oldModel
 
     def add(self, item: ProjectItem, pos: int = -1) -> bool:

--- a/novelwriter/editor/documentcache.py
+++ b/novelwriter/editor/documentcache.py
@@ -80,20 +80,22 @@ class DocumentCache:
         self._entries[tHandle] = CacheEntry(nwDocument, qDocument)
         self._entries.move_to_end(tHandle)
         while len(self._entries) > self._maxSize:
-            _, evicted = self._entries.popitem(last=False)
-            logger.debug("Evicting document '%s' from cache", evicted.nwDocument.fileLocation)
+            eHandle, evicted = self._entries.popitem(last=False)
+            logger.debug("Evicted document '%s' from cache", eHandle)
             evicted.qDocument.deleteLater()
 
     def remove(self, tHandle: str) -> None:
         """Remove and discard a cached entry, if present."""
         if entry := self._entries.pop(tHandle, None):
             entry.qDocument.deleteLater()
+            logger.debug("Removed document '%s' from cache", tHandle)
 
     def clear(self) -> None:
         """Discard all cached entries."""
         for entry in self._entries.values():
             entry.qDocument.deleteLater()
         self._entries.clear()
+        logger.debug("Cleared document cache")
 
     def documents(self) -> list[GuiTextDocument]:
         """Return the text documents of all cached entries."""

--- a/novelwriter/editor/documentcache.py
+++ b/novelwriter/editor/documentcache.py
@@ -75,25 +75,25 @@ class DocumentCache:
         evicting the least recently used entry if the cache is full.
         """
         if (old := self._entries.get(tHandle)) and old.qDocument is not qDocument:
-            old.qDocument.deleteLater()
+            old.qDocument.softDelete()
 
         self._entries[tHandle] = CacheEntry(nwDocument, qDocument)
         self._entries.move_to_end(tHandle)
         while len(self._entries) > self._maxSize:
             eHandle, evicted = self._entries.popitem(last=False)
             logger.debug("Evicted document '%s' from cache", eHandle)
-            evicted.qDocument.deleteLater()
+            evicted.qDocument.softDelete()
 
     def remove(self, tHandle: str) -> None:
         """Remove and discard a cached entry, if present."""
         if entry := self._entries.pop(tHandle, None):
-            entry.qDocument.deleteLater()
+            entry.qDocument.softDelete()
             logger.debug("Removed document '%s' from cache", tHandle)
 
     def clear(self) -> None:
         """Discard all cached entries."""
         for entry in self._entries.values():
-            entry.qDocument.deleteLater()
+            entry.qDocument.softDelete()
         self._entries.clear()
         logger.debug("Cleared document cache")
 

--- a/novelwriter/editor/documentcache.py
+++ b/novelwriter/editor/documentcache.py
@@ -1,0 +1,100 @@
+"""
+novelWriter – Document Cache
+=============================
+
+This file is a part of novelWriter
+Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""  # noqa
+
+from __future__ import annotations
+
+import logging
+
+from collections import OrderedDict
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from novelwriter.core.document import ProjectDocument
+    from novelwriter.editor.editordocument import GuiTextDocument
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_SIZE = 5
+
+
+class CacheEntry(NamedTuple):
+    """Core: A single cached document entry."""
+
+    nwDocument: ProjectDocument
+    qDocument: GuiTextDocument
+
+
+class DocumentCache:
+    """Core: LRU Cache of Recently Opened Editor Documents.
+
+    Keeps a bounded number of ProjectDocument/GuiTextDocument pairs
+    alive in memory so that switching back to a recently opened
+    document restores its Qt-native undo/redo history and syntax
+    highlighting, instead of reloading the document from scratch.
+    """
+
+    def __init__(self, maxSize: int = DEFAULT_CACHE_SIZE) -> None:
+        self._maxSize = max(1, maxSize)
+        self._entries: OrderedDict[str, CacheEntry] = OrderedDict()
+
+    def __len__(self) -> int:
+        """Return the number of cached entries."""
+        return len(self._entries)
+
+    def __contains__(self, tHandle: str) -> bool:
+        """Check if a document handle is cached."""
+        return tHandle in self._entries
+
+    def get(self, tHandle: str) -> CacheEntry | None:
+        """Return a cached entry, and mark it as most recently used."""
+        if entry := self._entries.get(tHandle):
+            self._entries.move_to_end(tHandle)
+            return entry
+        return None
+
+    def store(self, tHandle: str, nwDocument: ProjectDocument, qDocument: GuiTextDocument) -> None:
+        """Add or replace a cache entry as the most recently used one,
+        evicting the least recently used entry if the cache is full.
+        """
+        if (old := self._entries.get(tHandle)) and old.qDocument is not qDocument:
+            old.qDocument.deleteLater()
+
+        self._entries[tHandle] = CacheEntry(nwDocument, qDocument)
+        self._entries.move_to_end(tHandle)
+        while len(self._entries) > self._maxSize:
+            _, evicted = self._entries.popitem(last=False)
+            logger.debug("Evicting document '%s' from cache", evicted.nwDocument.fileLocation)
+            evicted.qDocument.deleteLater()
+
+    def remove(self, tHandle: str) -> None:
+        """Remove and discard a cached entry, if present."""
+        if entry := self._entries.pop(tHandle, None):
+            entry.qDocument.deleteLater()
+
+    def clear(self) -> None:
+        """Discard all cached entries."""
+        for entry in self._entries.values():
+            entry.qDocument.deleteLater()
+        self._entries.clear()
+
+    def documents(self) -> list[GuiTextDocument]:
+        """Return the text documents of all cached entries."""
+        return [entry.qDocument for entry in self._entries.values()]

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -45,6 +45,7 @@ from PyQt6.QtGui import (
     QDragEnterEvent,
     QDragMoveEvent,
     QDropEvent,
+    QFont,
     QInputMethodEvent,
     QKeyEvent,
     QKeySequence,
@@ -69,6 +70,7 @@ from novelwriter.core.document import ProjectDocument
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.editor.autoreplace import TextAutoReplace
 from novelwriter.editor.completer import CommandCompleter
+from novelwriter.editor.documentcache import DocumentCache
 from novelwriter.editor.editfooter import GuiDocEditFooter
 from novelwriter.editor.editheader import GuiDocEditHeader
 from novelwriter.editor.editordocument import GuiTextDocument
@@ -160,8 +162,10 @@ class GuiDocEditor(QTextEdit):
         "_completer",
         "_dirtyBlocks",
         "_doReplace",
+        "_docCache",
         "_docChanged",
         "_docHandle",
+        "_emptyDocument",
         "_followTagEdit",
         "_followTagView",
         "_formatErrFormat",
@@ -304,7 +308,9 @@ class GuiDocEditor(QTextEdit):
         self._completer.insertText.connect(self._insertCompletion)
 
         # Create Custom Document
-        self._qDocument = GuiTextDocument(self)
+        self._docCache = DocumentCache()
+        self._emptyDocument = GuiTextDocument(self)
+        self._qDocument = self._emptyDocument
         self.setDocument(self._qDocument)
 
         # Connect Editor and Document Signals
@@ -437,8 +443,13 @@ class GuiDocEditor(QTextEdit):
         """Check if the current document is empty."""
         return self._qDocument.isEmpty()
 
+    @property
+    def docCache(self) -> DocumentCache:
+        """Return the document cache."""
+        return self._docCache
+
     ##
-    #  Methods
+    #  Core Methods
     ##
 
     def clearEditor(self) -> None:
@@ -447,7 +458,7 @@ class GuiDocEditor(QTextEdit):
         """
         self._nwDocument = None
         self.setReadOnly(True)
-        self.clear()
+        self._setActiveDocument(self._emptyDocument)
         self._timerDoc.stop()
         self._timerSel.stop()
 
@@ -535,18 +546,12 @@ class GuiDocEditor(QTextEdit):
         # Set the font. See issues #1862 and #1875.
         font = fontMatcher(CONFIG.textFont)
         self.setFont(font)
-        self._qDocument.setDefaultFont(font)
         self.docHeader.updateFont()
         self.docFooter.updateFont()
         self.docSearch.updateFont()
 
-        # Update highlighter settings
-        self._qDocument.syntaxHighlighter.initHighlighter()
-
-        # Set default text margins
         # Due to cursor visibility, a part of the margin must be
         # allocated to the document itself. See issue #1112.
-        self._qDocument.setDocumentMargin(4)
         self._vpMargin = max(CONFIG.textMargin - 4, 0)
         self.setViewportMargins(self._vpMargin, self._vpMargin, self._vpMargin, self._vpMargin)
 
@@ -558,7 +563,13 @@ class GuiDocEditor(QTextEdit):
             options.setFlags(options.flags() | QTextOption.Flag.ShowTabsAndSpaces)
         if CONFIG.showLineEndings:
             options.setFlags(options.flags() | QTextOption.Flag.ShowLineAndParagraphSeparators)
-        self._qDocument.setDefaultTextOption(options)
+
+        # Refresh settings on the active document, plus any cached
+        # documents that are not currently visible
+        self._refreshDocumentSettings(self._qDocument, font, options)
+        for qDocument in self._docCache.documents():
+            if qDocument is not self._qDocument:
+                self._refreshDocumentSettings(qDocument, font, options)
 
         # Scrolling
         if CONFIG.hideVScroll:
@@ -583,9 +594,6 @@ class GuiDocEditor(QTextEdit):
         # font changed, otherwise we just clear the editor entirely,
         # which makes it read only.
         if self._docHandle:
-            self._qDocument.setLineHeight(CONFIG.lineHeight)
-            self._qDocument.syntaxHighlighter.rehighlight()
-            self._qDocument.markContentsDirty(0, self._qDocument.characterCount())
             self._beginCheckPass()
             self.docHeader.setHandle(self._docHandle)
         else:
@@ -601,16 +609,26 @@ class GuiDocEditor(QTextEdit):
         happen if the file contains binary elements or an encoding that
         novelWriter does not support. If loading is successful, or the
         document is new (empty string), we set up the editor for editing
-        the file.
+        the file. If the document was recently open, it is instead
+        restored from the document cache, along with its undo history.
         """
-        self._nwDocument = SHARED.project.storage.getDocument(tHandle)
-        self._nwItem = self._nwDocument.nwItem
+        cached = self._docCache.get(tHandle)
+        if cached:
+            self._nwDocument = cached.nwDocument
+            self._nwItem = self._nwDocument.nwItem
+        else:
+            self._nwDocument = SHARED.project.storage.getDocument(tHandle)
+            self._nwItem = self._nwDocument.nwItem
+
         if not (self._nwItem and self._nwItem.itemType == nwItemType.FILE):
             logger.debug("Requested item '%s' is not a document", tHandle)
+            if cached:
+                self._docCache.remove(tHandle)
             self.clearEditor()
             return False
 
-        if (text := self._nwDocument.readDocument()) is None:
+        text = ""
+        if cached is None and (text := self._nwDocument.readDocument()) is None:
             # There was an I/O error
             self.clearEditor()
             return False
@@ -618,9 +636,14 @@ class GuiDocEditor(QTextEdit):
         QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
         self._docHandle = tHandle
 
-        self._allowAutoReplace(False)
-        self._qDocument.setTextContent(text, tHandle)
-        self._allowAutoReplace(True)
+        if cached:
+            self._setActiveDocument(cached.qDocument)
+        else:
+            self._setActiveDocument(GuiTextDocument(self))
+            self._allowAutoReplace(False)
+            self._qDocument.setTextContent(text, tHandle)
+            self._allowAutoReplace(True)
+
         self._beginCheckPass()
         QApplication.processEvents()
 
@@ -639,15 +662,21 @@ class GuiDocEditor(QTextEdit):
         self.docHeader.setHandle(tHandle)
         self.docFooter.setHandle(tHandle)
 
-        # This is a hack to fix invisible cursor on an empty document
-        if self._qDocument.characterCount() <= 1:
-            self.setPlainText("\n")
-            self.setPlainText("")
-            self.setCursorPosition(0)
+        if cached is None:
+            # This is a hack to fix invisible cursor on an empty document
+            if self._qDocument.characterCount() <= 1:
+                self.setPlainText("\n")
+                self.setPlainText("")
+                self.setCursorPosition(0)
 
-        QApplication.processEvents()
-        self.setDocumentChanged(False)
-        self._qDocument.clearUndoRedoStacks()
+            QApplication.processEvents()
+            self.setDocumentChanged(False)
+            self._qDocument.clearUndoRedoStacks()
+            self._docCache.store(tHandle, self._nwDocument, self._qDocument)
+        else:
+            QApplication.processEvents()
+            self.setDocumentChanged(False)
+
         self.docToolBar.setVisible(CONFIG.showEditToolBar)
 
         # Process State Changes
@@ -777,6 +806,34 @@ class GuiDocEditor(QTextEdit):
             if frameFormat.bottomMargin() != bottomMargin:
                 frameFormat.setBottomMargin(bottomMargin)
                 rootFrame.setFrameFormat(frameFormat)
+
+    ##
+    #  Internal Core Methods
+    ##
+
+    def _setActiveDocument(self, qDocument: GuiTextDocument) -> None:
+        """Attach a text document to the editor widget, moving the
+        contentsChange signal connection over to the new document.
+        """
+        if qDocument is not self._qDocument:
+            self._qDocument.contentsChange.disconnect(self._docChange)
+            self._qDocument = qDocument
+            self.setDocument(self._qDocument)
+            self._qDocument.contentsChange.connect(self._docChange)
+
+    def _refreshDocumentSettings(self, qDocument: GuiTextDocument, font: QFont, options: QTextOption) -> None:
+        """Apply the current user settings to a single text document.
+        Used to keep cached, currently invisible documents in sync
+        with editor settings, so they don't show stale formatting
+        when swapped back into view.
+        """
+        qDocument.setDefaultFont(font)
+        qDocument.syntaxHighlighter.initHighlighter()
+        qDocument.setDocumentMargin(4)
+        qDocument.setDefaultTextOption(options)
+        qDocument.setLineHeight(CONFIG.lineHeight)
+        qDocument.syntaxHighlighter.rehighlight()
+        qDocument.markContentsDirty(0, qDocument.characterCount())
 
     ##
     #  Getters

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -309,7 +309,7 @@ class GuiDocEditor(QTextEdit):
 
         # Create Custom Document
         self._docCache = DocumentCache()
-        self._emptyDocument = GuiTextDocument(self)
+        self._emptyDocument = self._newTextDocument()
         self._qDocument = self._emptyDocument
         self.setDocument(self._qDocument)
 
@@ -556,13 +556,7 @@ class GuiDocEditor(QTextEdit):
         self.setViewportMargins(self._vpMargin, self._vpMargin, self._vpMargin, self._vpMargin)
 
         # Also set the document text options for the document text flow
-        options = QTextOption()
-        if CONFIG.doJustify:
-            options.setAlignment(QtAlignJustify)
-        if CONFIG.showTabsNSpaces:
-            options.setFlags(options.flags() | QTextOption.Flag.ShowTabsAndSpaces)
-        if CONFIG.showLineEndings:
-            options.setFlags(options.flags() | QTextOption.Flag.ShowLineAndParagraphSeparators)
+        options = self._documentTextOptions()
 
         # Refresh settings on the active document, plus any cached
         # documents that are not currently visible
@@ -639,7 +633,7 @@ class GuiDocEditor(QTextEdit):
         if cached:
             self._setActiveDocument(cached.qDocument)
         else:
-            self._setActiveDocument(GuiTextDocument(self))
+            self._setActiveDocument(self._newTextDocument())
             self._allowAutoReplace(False)
             self._qDocument.setTextContent(text, tHandle)
             self._allowAutoReplace(True)
@@ -810,6 +804,27 @@ class GuiDocEditor(QTextEdit):
     ##
     #  Internal Core Methods
     ##
+
+    def _documentTextOptions(self) -> QTextOption:
+        """Build the document text options for the document text flow
+        from the current user settings.
+        """
+        options = QTextOption()
+        if CONFIG.doJustify:
+            options.setAlignment(QtAlignJustify)
+        if CONFIG.showTabsNSpaces:
+            options.setFlags(options.flags() | QTextOption.Flag.ShowTabsAndSpaces)
+        if CONFIG.showLineEndings:
+            options.setFlags(options.flags() | QTextOption.Flag.ShowLineAndParagraphSeparators)
+        return options
+
+    def _newTextDocument(self) -> GuiTextDocument:
+        """Create a new text document with the current user settings."""
+        qDocument = GuiTextDocument(self)
+        qDocument.setDefaultFont(fontMatcher(CONFIG.textFont))
+        qDocument.setDocumentMargin(4)
+        qDocument.setDefaultTextOption(self._documentTextOptions())
+        return qDocument
 
     def _setActiveDocument(self, qDocument: GuiTextDocument) -> None:
         """Attach a text document to the editor widget, moving the

--- a/novelwriter/editor/editordocument.py
+++ b/novelwriter/editor/editordocument.py
@@ -74,6 +74,14 @@ class GuiTextDocument(QTextDocument):
     #  Methods
     ##
 
+    def softDelete(self) -> None:
+        """Since calling deleteLater is sometimes not safe from Python,
+        as the C++ object can be deleted before the Python process is
+        done with the object, we instead set the document's parent to
+        None so that it gets garbage collected when it runs out of scope.
+        """
+        self.setParent(None)  # type: ignore
+
     def setTextContent(self, text: str, tHandle: str) -> None:
         """Set the text content of the document."""
         self._syntax.setHandle(tHandle)

--- a/novelwriter/editor/editordocument.py
+++ b/novelwriter/editor/editordocument.py
@@ -80,7 +80,7 @@ class GuiTextDocument(QTextDocument):
         done with the object, we instead set the document's parent to
         None so that it gets garbage collected when it runs out of scope.
         """
-        self.setParent(None)  # type: ignore
+        self.setParent(None)
 
     def setTextContent(self, text: str, tHandle: str) -> None:
         """Set the text content of the document."""

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -64,7 +64,7 @@ class NDialog(QDialog):
         done with the object, we instead set the dialog's parent to None
         so that it gets garbage collected when it runs out of scope.
         """
-        self.setParent(None)  # type: ignore
+        self.setParent(None)
 
     @pyqtSlot()
     def closeDialog(self) -> None:
@@ -153,7 +153,7 @@ class NFontDialog(QFontDialog):
 
         font = dialog.selectedFont()
         status = dialog.result() == 1
-        dialog.setParent(None)  # type: ignore
+        dialog.setParent(None)
 
         return font, status
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -101,6 +101,10 @@ class GuiMain(QMainWindow):
         # Core Classes
         # ============
 
+        # Internal Variables
+        self._lastTotalCount = 0
+        self._switchingDocument = False
+
         # Initialise UserData Instance
         SHARED.initSharedData(self)
 
@@ -303,9 +307,6 @@ class GuiMain(QMainWindow):
         self.keyEscape = QShortcut(self)
         self.keyEscape.setKey("Esc")
         self.keyEscape.activated.connect(self._keyPressEscape)
-
-        # Internal Variables
-        self._lastTotalCount = 0
 
         # Initialise Main GUI
         self.initMain()
@@ -532,6 +533,10 @@ class GuiMain(QMainWindow):
             logger.error("Nothing to open")
             return False
 
+        if self._switchingDocument:
+            logger.debug("Ignoring re-entrant request to open '%s'", tHandle)
+            return False
+
         if sTitle and tLine is None and (hItem := SHARED.project.index.getItemHeading(tHandle, sTitle)):
             tLine = hItem.line
 
@@ -539,11 +544,15 @@ class GuiMain(QMainWindow):
         if tHandle == self.docEditor.docHandle:
             self.docEditor.setCursorLine(tLine)
         else:
-            self.closeDocument()
-            if self.docEditor.loadText(tHandle, tLine):
-                self.projView.setSelectedHandle(tHandle, doScroll=doScroll)
-            else:
-                return False
+            self._switchingDocument = True
+            try:
+                self.closeDocument()
+                if self.docEditor.loadText(tHandle, tLine):
+                    self.projView.setSelectedHandle(tHandle, doScroll=doScroll)
+                else:
+                    return False
+            finally:
+                self._switchingDocument = False
 
         if changeFocus:
             self.docEditor.setFocus()

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -386,6 +386,7 @@ class GuiMain(QMainWindow):
 
         if saveOK:
             self.closeDocument()
+            self.docEditor.docCache.clear()
             self.docViewer.clearNavHistory()
             self.closeViewerPanel(byUser=False)
 

--- a/novelwriter/shared.py
+++ b/novelwriter/shared.py
@@ -198,6 +198,8 @@ class SharedData(QObject):
 
     def closeDocument(self, tHandle: str | None = None) -> None:
         """Close the document editor, optionally a specific document."""
+        if tHandle is not None:
+            self.mainGui.docEditor.docCache.remove(tHandle)
         if tHandle is None or tHandle == self.mainGui.docEditor.docHandle:
             self.mainGui.closeDocument()
         if tHandle is None or tHandle == self.mainGui.docViewer.docHandle:

--- a/tests/editor/test_documentcache.py
+++ b/tests/editor/test_documentcache.py
@@ -21,7 +21,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
 
+import gc
+import weakref
+
 from unittest.mock import MagicMock
+
+from PyQt6.QtCore import QObject
 
 from novelwriter.editor.documentcache import DocumentCache
 
@@ -32,6 +37,17 @@ def _entry() -> tuple[MagicMock, MagicMock]:
     nwDocument.fileLocation = "mock.nwd"
     qDocument = MagicMock()
     return nwDocument, qDocument
+
+
+class _StubDocument(QObject):
+    """Minimal real QObject with a genuine softDelete, so eviction can
+    be checked to actually free memory rather than just having its
+    mocked softDelete method called.
+    """
+
+    def softDelete(self) -> None:
+        """Detach from any Qt parent, matching GuiTextDocument.softDelete."""
+        self.setParent(None)  # type: ignore
 
 
 def testEditorDocCache_GetStoreRemove():
@@ -55,7 +71,7 @@ def testEditorDocCache_GetStoreRemove():
     assert len(cache) == 0
     assert "aaa" not in cache
     assert cache.get("aaa") is None
-    qDoc.deleteLater.assert_called_once()
+    qDoc.softDelete.assert_called_once()
 
     # Removing a handle that isn't cached should be a no-op
     cache.remove("aaa")
@@ -72,7 +88,7 @@ def testEditorDocCache_StoreReplacesExistingEntry():
     nwDocA, qDocA = _entry()
     cache.store("aaa", nwDocA, qDocA)
     assert cache.get("aaa") is not None
-    qDocA.deleteLater.assert_not_called()
+    qDocA.softDelete.assert_not_called()
 
     nwDocB, qDocB = _entry()
     cache.store("aaa", nwDocB, qDocB)
@@ -82,13 +98,13 @@ def testEditorDocCache_StoreReplacesExistingEntry():
     assert entry is not None
     assert entry.nwDocument is nwDocB
     assert entry.qDocument is qDocB
-    qDocA.deleteLater.assert_called_once()
-    qDocB.deleteLater.assert_not_called()
+    qDocA.softDelete.assert_called_once()
+    qDocB.softDelete.assert_not_called()
 
     # Re-storing the same document under its own handle should not
     # trigger a deletion of itself
     cache.store("aaa", nwDocB, qDocB)
-    qDocB.deleteLater.assert_not_called()
+    qDocB.softDelete.assert_not_called()
 
 
 def testEditorDocCache_Eviction():
@@ -112,9 +128,9 @@ def testEditorDocCache_Eviction():
     assert "a" not in cache
     assert "b" in cache
     assert "c" in cache
-    qDocA.deleteLater.assert_called_once()
-    qDocB.deleteLater.assert_not_called()
-    qDocC.deleteLater.assert_not_called()
+    qDocA.softDelete.assert_called_once()
+    qDocB.softDelete.assert_not_called()
+    qDocC.softDelete.assert_not_called()
 
 
 def testEditorDocCache_GetPromotesToMostRecentlyUsed():
@@ -137,8 +153,8 @@ def testEditorDocCache_GetPromotesToMostRecentlyUsed():
     assert "a" in cache
     assert "b" not in cache
     assert "c" in cache
-    qDocB.deleteLater.assert_called_once()
-    qDocA.deleteLater.assert_not_called()
+    qDocB.softDelete.assert_called_once()
+    qDocA.softDelete.assert_not_called()
 
 
 def testEditorDocCache_Clear():
@@ -154,8 +170,8 @@ def testEditorDocCache_Clear():
 
     assert len(cache) == 0
     assert cache.documents() == []
-    qDocA.deleteLater.assert_called_once()
-    qDocB.deleteLater.assert_called_once()
+    qDocA.softDelete.assert_called_once()
+    qDocB.softDelete.assert_called_once()
 
 
 def testEditorDocCache_Documents():
@@ -168,3 +184,26 @@ def testEditorDocCache_Documents():
     cache.store("b", MagicMock(), qDocB)
 
     assert set(cache.documents()) == {qDocA, qDocB}
+
+
+def testEditorDocCache_EvictionFreesDocument(qtbot):
+    """Test that an evicted document is freed by reference count alone
+    (with the cyclic GC disabled) once the cache and the test both
+    drop their references to it, i.e. that eviction doesn't leak.
+    Mirrors the checkWidgetFreedOnRelease pattern used elsewhere in
+    this codebase for the same class of QObject lifetime check.
+    """
+    cache = DocumentCache(maxSize=1)
+
+    qDocA = _StubDocument()
+    ref = weakref.ref(qDocA)
+    cache.store("a", MagicMock(), qDocA)  # type: ignore[arg-type]
+    del qDocA
+
+    gc.disable()
+    try:
+        # Storing a second entry evicts "a" and calls its softDelete
+        cache.store("b", MagicMock(), _StubDocument())  # type: ignore[arg-type]
+        assert ref() is None, "Evicted document was not freed by reference count alone"
+    finally:
+        gc.enable()

--- a/tests/editor/test_documentcache.py
+++ b/tests/editor/test_documentcache.py
@@ -1,0 +1,170 @@
+"""
+novelWriter – Document Cache Tests
+==================================
+
+This file is a part of novelWriter
+Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""  # noqa
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from novelwriter.editor.documentcache import DocumentCache
+
+
+def _entry() -> tuple[MagicMock, MagicMock]:
+    """Create a stand-in (nwDocument, qDocument) pair for cache tests."""
+    nwDocument = MagicMock()
+    nwDocument.fileLocation = "mock.nwd"
+    qDocument = MagicMock()
+    return nwDocument, qDocument
+
+
+def testEditorDocCache_GetStoreRemove():
+    """Test the basic get/store/remove operations of the cache."""
+    cache = DocumentCache(maxSize=5)
+    assert len(cache) == 0
+    assert "aaa" not in cache
+    assert cache.get("aaa") is None
+
+    nwDoc, qDoc = _entry()
+    cache.store("aaa", nwDoc, qDoc)
+    assert len(cache) == 1
+    assert "aaa" in cache
+
+    entry = cache.get("aaa")
+    assert entry is not None
+    assert entry.nwDocument is nwDoc
+    assert entry.qDocument is qDoc
+
+    cache.remove("aaa")
+    assert len(cache) == 0
+    assert "aaa" not in cache
+    assert cache.get("aaa") is None
+    qDoc.deleteLater.assert_called_once()
+
+    # Removing a handle that isn't cached should be a no-op
+    cache.remove("aaa")
+    cache.remove("bbb")
+    assert len(cache) == 0
+
+
+def testEditorDocCache_StoreReplacesExistingEntry():
+    """Test that storing a new document under an already cached handle
+    discards the previous document.
+    """
+    cache = DocumentCache(maxSize=5)
+
+    nwDocA, qDocA = _entry()
+    cache.store("aaa", nwDocA, qDocA)
+    assert cache.get("aaa") is not None
+    qDocA.deleteLater.assert_not_called()
+
+    nwDocB, qDocB = _entry()
+    cache.store("aaa", nwDocB, qDocB)
+    assert len(cache) == 1
+
+    entry = cache.get("aaa")
+    assert entry is not None
+    assert entry.nwDocument is nwDocB
+    assert entry.qDocument is qDocB
+    qDocA.deleteLater.assert_called_once()
+    qDocB.deleteLater.assert_not_called()
+
+    # Re-storing the same document under its own handle should not
+    # trigger a deletion of itself
+    cache.store("aaa", nwDocB, qDocB)
+    qDocB.deleteLater.assert_not_called()
+
+
+def testEditorDocCache_Eviction():
+    """Test that the least recently used entry is evicted once the
+    cache exceeds its maximum size, and that its document is deleted.
+    """
+    cache = DocumentCache(maxSize=2)
+
+    _, qDocA = _entry()
+    _, qDocB = _entry()
+    _, qDocC = _entry()
+
+    cache.store("a", MagicMock(), qDocA)
+    cache.store("b", MagicMock(), qDocB)
+    assert len(cache) == 2
+
+    # Adding a third entry should evict "a", the least recently used
+    cache.store("c", MagicMock(), qDocC)
+
+    assert len(cache) == 2
+    assert "a" not in cache
+    assert "b" in cache
+    assert "c" in cache
+    qDocA.deleteLater.assert_called_once()
+    qDocB.deleteLater.assert_not_called()
+    qDocC.deleteLater.assert_not_called()
+
+
+def testEditorDocCache_GetPromotesToMostRecentlyUsed():
+    """Test that fetching an entry marks it as most recently used, so
+    that it isn't the next one evicted.
+    """
+    cache = DocumentCache(maxSize=2)
+
+    _, qDocA = _entry()
+    _, qDocB = _entry()
+    _, qDocC = _entry()
+
+    cache.store("a", MagicMock(), qDocA)
+    cache.store("b", MagicMock(), qDocB)
+
+    # Touch "a" so that "b" becomes the least recently used
+    assert cache.get("a") is not None
+    cache.store("c", MagicMock(), qDocC)
+
+    assert "a" in cache
+    assert "b" not in cache
+    assert "c" in cache
+    qDocB.deleteLater.assert_called_once()
+    qDocA.deleteLater.assert_not_called()
+
+
+def testEditorDocCache_Clear():
+    """Test that clearing the cache deletes all cached documents."""
+    cache = DocumentCache(maxSize=5)
+
+    _, qDocA = _entry()
+    _, qDocB = _entry()
+    cache.store("a", MagicMock(), qDocA)
+    cache.store("b", MagicMock(), qDocB)
+
+    cache.clear()
+
+    assert len(cache) == 0
+    assert cache.documents() == []
+    qDocA.deleteLater.assert_called_once()
+    qDocB.deleteLater.assert_called_once()
+
+
+def testEditorDocCache_Documents():
+    """Test that the documents helper returns all cached documents."""
+    cache = DocumentCache(maxSize=5)
+
+    _, qDocA = _entry()
+    _, qDocB = _entry()
+    cache.store("a", MagicMock(), qDocA)
+    cache.store("b", MagicMock(), qDocB)
+
+    assert set(cache.documents()) == {qDocA, qDocB}

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -304,6 +304,28 @@ def testGuiDocEditor_LoadText_CachedInvalidItem(qtbot, monkeypatch, nwGUI, projP
 
 
 @pytest.mark.gui
+def testGuiDocEditor_LoadText_NewDocumentFont(qtbot, nwGUI, projPath, mockRnd):
+    """Test that a document that isn't already in the document cache
+    is created with the user's configured font applied, rather than
+    Qt's default font for a new QTextDocument.
+    """
+    buildTestProject(nwGUI, projPath)
+    docEditor = nwGUI.docEditor
+
+    font = QFont()
+    font.setPointSize(31)
+    CONFIG.textFont = font
+
+    # This document has not been opened yet this session, so it must
+    # go through the "not cached" branch of loadText
+    assert C.hSceneDoc not in docEditor.docCache
+    assert docEditor.loadText(C.hSceneDoc) is True
+    assert docEditor.document().defaultFont().pointSize() == 31
+
+    # qtbot.stop()
+
+
+@pytest.mark.gui
 def testGuiDocEditor_SaveText(qtbot, monkeypatch, caplog, nwGUI, projPath, ipsumText, mockRnd):
     """Test saving text from the editor."""
     buildTestProject(nwGUI, projPath)

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -58,7 +58,16 @@ from novelwriter.editor.autoreplace import TextAutoReplace
 from novelwriter.editor.completer import CommandCompleter
 from novelwriter.editor.editor import GuiDocEditor, _TagAction
 from novelwriter.editor.textblock import TextBlockData, formatCheckText
-from novelwriter.enum import nwComment, nwDocAction, nwDocInsert, nwItemClass, nwItemLayout, nwState, nwVimMode
+from novelwriter.enum import (
+    nwComment,
+    nwDocAction,
+    nwDocInsert,
+    nwItemClass,
+    nwItemLayout,
+    nwItemType,
+    nwState,
+    nwVimMode,
+)
 from novelwriter.shared import _GuiAlert
 from novelwriter.text.counting import standardCounter
 from novelwriter.types import (
@@ -230,6 +239,66 @@ def testGuiDocEditor_LoadText(qtbot, nwGUI, projPath, ipsumText, mockRnd):
     nwGUI.saveDocument()
     assert docEditor.loadText(C.hSceneDoc) is True
     assert docEditor.toPlainText() == ""
+
+    # qtbot.stop()
+
+
+@pytest.mark.gui
+def testGuiDocEditor_LoadText_UndoCache(qtbot, nwGUI, projPath, mockRnd):
+    """Test that switching away from and back to a document preserves
+    its undo history, via the document cache.
+    """
+    buildTestProject(nwGUI, projPath)
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    docEditor = nwGUI.docEditor
+
+    original = docEditor.getText()
+
+    docEditor.setCursorPosition(len(original))
+    qtbot.keyClicks(docEditor, "Some new text.")
+    edited = docEditor.getText()
+    assert edited != original
+    assert docEditor.document().isUndoAvailable() is True
+
+    # Switching to another document and back should not touch the
+    # cached text document, so the edit and its undo history survive
+    assert nwGUI.openDocument(C.hChapterDoc) is True
+    assert docEditor.docHandle == C.hChapterDoc
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    assert docEditor.docHandle == C.hSceneDoc
+
+    assert docEditor.getText() == edited
+    assert docEditor.document().isUndoAvailable() is True
+
+    docEditor.undo()
+    assert docEditor.getText() == original
+
+    # qtbot.stop()
+
+
+@pytest.mark.gui
+def testGuiDocEditor_LoadText_CachedInvalidItem(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
+    """Test that a cached document whose project item is no longer a
+    valid file (e.g. changed or removed out-of-band) is discarded
+    from the cache instead of being reopened.
+    """
+    buildTestProject(nwGUI, projPath)
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    docEditor = nwGUI.docEditor
+    assert C.hSceneDoc in docEditor.docCache
+
+    nwGUI.closeDocument()
+    assert C.hSceneDoc in docEditor.docCache
+
+    # Simulate the cached item becoming invalid while it isn't the
+    # active document
+    cached = docEditor.docCache.get(C.hSceneDoc)
+    assert cached is not None
+    monkeypatch.setattr(cached.nwDocument.nwItem, "_type", nwItemType.FOLDER)
+
+    assert docEditor.loadText(C.hSceneDoc) is False
+    assert docEditor.docHandle is None
+    assert C.hSceneDoc not in docEditor.docCache
 
     # qtbot.stop()
 
@@ -2848,10 +2917,9 @@ def testGuiDocEditor_LineHeight(qtbot, nwGUI, projPath, mockRnd):
     """
     buildTestProject(nwGUI, projPath)
     docEditor = nwGUI.docEditor
-    document = docEditor.document()
 
     def allBlocksHaveLineHeight(height: int) -> bool:
-        block = document.firstBlock()
+        block = docEditor.document().firstBlock()
         while block.isValid():
             if block.blockFormat().lineHeight() != height:
                 return False
@@ -2865,6 +2933,44 @@ def testGuiDocEditor_LineHeight(qtbot, nwGUI, projPath, mockRnd):
     CONFIG.lineHeight = 2.00
     docEditor.initEditor()
     assert allBlocksHaveLineHeight(200)
+
+
+@pytest.mark.gui
+def testGuiDocEditor_LineHeight_CachedDocument(qtbot, nwGUI, projPath, mockRnd):
+    """Test that initEditor refreshes the line height (and other
+    per-document settings) of cached documents that are not the one
+    currently visible, so they aren't stale when swapped back in.
+    """
+    buildTestProject(nwGUI, projPath)
+    docEditor = nwGUI.docEditor
+
+    def allBlocksHaveLineHeight(height: int) -> bool:
+        block = docEditor.document().firstBlock()
+        while block.isValid():
+            if block.blockFormat().lineHeight() != height:
+                return False
+            block = block.next()
+        return True
+
+    CONFIG.lineHeight = 1.50
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    assert allBlocksHaveLineHeight(150)
+
+    # Move to another document, leaving hSceneDoc cached but inactive
+    assert nwGUI.openDocument(C.hChapterDoc) is True
+    assert docEditor.docHandle == C.hChapterDoc
+    assert C.hSceneDoc in docEditor.docCache
+
+    CONFIG.lineHeight = 2.00
+    docEditor.initEditor()
+    assert allBlocksHaveLineHeight(200)  # The active document, hChapterDoc
+
+    # Switching back should show the refreshed line height, not a
+    # stale value from when hSceneDoc was cached
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    assert allBlocksHaveLineHeight(200)
+
+    # qtbot.stop()
 
 
 @pytest.mark.gui

--- a/tests/test_guimain.py
+++ b/tests/test_guimain.py
@@ -1128,6 +1128,38 @@ def testGuiMain_OpenClose(qtbot, monkeypatch, nwGUI: GuiMain, projPath, fncPath,
 
 
 @pytest.mark.gui
+def testGuiMain_OpenDocument_ReentrancyGuard(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
+    """Test that openDocument ignores a re-entrant call made while a
+    document switch is already in progress, instead of letting it
+    clobber the in-progress switch and the document cache.
+
+    This models what happens holding F3 with project-wide loop search
+    enabled: loadText calls QApplication.processEvents while a switch
+    is still in progress, and if that dispatches an already-queued
+    key-repeat event, it can re-trigger another document switch before
+    the first one has finished setting up the cache and editor state.
+    """
+    buildTestProject(nwGUI, projPath)
+
+    reentered = []
+    realProcessEvents = QApplication.processEvents
+
+    def reentrantProcessEvents(*args, **kwargs):
+        if not reentered:
+            reentered.append(True)
+            assert nwGUI.openDocument(C.hChapterDoc) is False
+        return realProcessEvents(*args, **kwargs)
+
+    monkeypatch.setattr(QApplication, "processEvents", staticmethod(reentrantProcessEvents))
+
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    assert reentered == [True]
+    assert nwGUI.docEditor.docHandle == C.hSceneDoc
+    assert C.hSceneDoc in nwGUI.docEditor.docCache
+    assert C.hChapterDoc not in nwGUI.docEditor.docCache
+
+
+@pytest.mark.gui
 def testGuiMain_FocusView(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test switching focus and view of the main window."""
     buildTestProject(nwGUI, projPath)

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -31,7 +31,7 @@ from PyQt6.QtCore import QThreadPool, QUrl
 from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtWidgets import QFileDialog, QWidget
 
-from novelwriter import CONFIG
+from novelwriter import CONFIG, SHARED
 from novelwriter.core.project import NWProject
 from novelwriter.shared import SharedData, _GuiAlert
 
@@ -84,6 +84,34 @@ def testSharedData_Functions(monkeypatch):
         shared.openWebsite("http://www.example.com")
         assert openUrl.called is True
         assert openUrl.call_args[0][0] == QUrl("http://www.example.com")
+
+
+@pytest.mark.base
+def testSharedData_CloseDocument(monkeypatch, mockGUI):
+    """Test that closeDocument only removes a specific handle from the
+    document cache when one is given, and always closes the editor
+    and viewer panels when no handle is given.
+    """
+    closeDoc = MagicMock()
+    closeViewer = MagicMock()
+    monkeypatch.setattr(mockGUI, "closeDocument", closeDoc, raising=False)
+    monkeypatch.setattr(mockGUI, "closeViewerPanel", closeViewer, raising=False)
+
+    mockGUI.docEditor.docHandle = "aaaaaaaaaaaaa"
+    mockGUI.docViewer.docHandle = "bbbbbbbbbbbbb"
+
+    # A specific handle is always removed from the cache, but the
+    # panels are only closed if the handle matches what's open
+    SHARED.closeDocument("ccccccccccccc")
+    mockGUI.docEditor.docCache.remove.assert_called_once_with("ccccccccccccc")
+    closeDoc.assert_not_called()
+    closeViewer.assert_not_called()
+
+    # No handle closes both panels, and does not touch the cache
+    SHARED.closeDocument()
+    mockGUI.docEditor.docCache.remove.assert_called_once()  # Unchanged
+    closeDoc.assert_called_once()
+    closeViewer.assert_called_once()
 
 
 @pytest.mark.base


### PR DESCRIPTION
**Summary:**

This PR adds a cache of recently open documents. The main benefit here is rapid switching back and forth between documents, but also that it preserves the undo cache.

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All linting checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
