### PR TITLE
Add manuscript dialogue statistics

### DIFF
--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -233,6 +233,14 @@ def formatInt(value: int) -> str:
     return str(value)
 
 
+def formatPercent(value: float | int, *, divisor: float | int | None = None, prec: int = 1) -> str:
+    """Format a number and optionally a divisor as a percentage."""
+    if isinstance(divisor, (float, int)) and divisor != 0:
+        value = value / divisor
+    fmt = f"{{0:.{prec}f}}\u202f%"
+    return fmt.format(value * 100.0) if isinstance(value, (float, int)) else "ERR"
+
+
 def formatTimeStamp(value: float, fileSafe: bool = False, fmt: str | None = None) -> str:
     """Take a number (on the format returned by time.time()) and convert
     it to a timestamp string.

--- a/novelwriter/common.py
+++ b/novelwriter/common.py
@@ -235,10 +235,12 @@ def formatInt(value: int) -> str:
 
 def formatPercent(value: float | int, *, divisor: float | int | None = None, prec: int = 1) -> str:
     """Format a number and optionally a divisor as a percentage."""
+    if not isinstance(value, (float, int)):
+        return "ERR"
     if isinstance(divisor, (float, int)) and divisor != 0:
         value = value / divisor
     fmt = f"{{0:.{prec}f}}\u202f%"
-    return fmt.format(value * 100.0) if isinstance(value, (float, int)) else "ERR"
+    return fmt.format(value * 100.0)
 
 
 def formatTimeStamp(value: float, fileSafe: bool = False, fmt: str | None = None) -> str:

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -257,6 +257,7 @@ class nwStats:
     CHARS = "allChars"
     CHARS_TEXT = "textChars"
     CHARS_TITLE = "titleChars"
+    CHARS_DIALOG = "dialogChars"
     PARAGRAPHS = "paragraphCount"
     TITLES = "titleCount"
     WCHARS_ALL = "allWordChars"
@@ -387,6 +388,7 @@ class nwLabels:
         nwStats.CHARS: QT_TRANSLATE_NOOP("Stats", "Characters"),
         nwStats.CHARS_TEXT: QT_TRANSLATE_NOOP("Stats", "Characters in text"),
         nwStats.CHARS_TITLE: QT_TRANSLATE_NOOP("Stats", "Characters in headings"),
+        nwStats.CHARS_DIALOG: QT_TRANSLATE_NOOP("Stats", "Characters in dialogue"),
         nwStats.PARAGRAPHS: QT_TRANSLATE_NOOP("Stats", "Paragraphs"),
         nwStats.TITLES: QT_TRANSLATE_NOOP("Stats", "Headings"),
         nwStats.WCHARS_ALL: QT_TRANSLATE_NOOP("Stats", "Characters, no spaces"),

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -403,7 +403,6 @@ class nwLabels:
     STATS_DISPLAY: Final[dict[str, str]] = {
         nwStats.CHARS: QT_TRANSLATE_NOOP("Stats", "Characters: {0} ({1})"),
         nwStats.WORDS: QT_TRANSLATE_NOOP("Stats", "Words: {0} ({1})"),
-        nwStats.DIALOG_RATIO: QT_TRANSLATE_NOOP("Stats", "Dialogue: {0}%"),
     }
     BUILD_FMT: Final[dict[nwBuildFmt, str]] = {
         nwBuildFmt.ODT: QT_TRANSLATE_NOOP("Constant", "Open Document (.odt)"),

--- a/novelwriter/constants.py
+++ b/novelwriter/constants.py
@@ -266,6 +266,7 @@ class nwStats:
     WORDS = "allWords"
     WORDS_TEXT = "textWords"
     WORDS_TITLE = "titleWords"
+    DIALOG_RATIO = "dialogRatio"
 
     # Note: The order here affects the order of menu entries
     ALL_FIELDS: Final[list[str]] = [
@@ -397,10 +398,12 @@ class nwLabels:
         nwStats.WORDS: QT_TRANSLATE_NOOP("Stats", "Words"),
         nwStats.WORDS_TEXT: QT_TRANSLATE_NOOP("Stats", "Words in text"),
         nwStats.WORDS_TITLE: QT_TRANSLATE_NOOP("Stats", "Words in headings"),
+        nwStats.DIALOG_RATIO: QT_TRANSLATE_NOOP("Stats", "Dialogue"),
     }
     STATS_DISPLAY: Final[dict[str, str]] = {
         nwStats.CHARS: QT_TRANSLATE_NOOP("Stats", "Characters: {0} ({1})"),
         nwStats.WORDS: QT_TRANSLATE_NOOP("Stats", "Words: {0} ({1})"),
+        nwStats.DIALOG_RATIO: QT_TRANSLATE_NOOP("Stats", "Dialogue: {0}%"),
     }
     BUILD_FMT: Final[dict[nwBuildFmt, str]] = {
         nwBuildFmt.ODT: QT_TRANSLATE_NOOP("Constant", "Open Document (.odt)"),

--- a/novelwriter/core/options.py
+++ b/novelwriter/core/options.py
@@ -85,6 +85,7 @@ VALID_MAP: dict[str, set[str]] = {
         "detailsHeight",
         "detailsWidth",
         "detailsExpanded",
+        "statsExpanded",
         "showNewPage",
     },
     "GuiManuscriptBuild": {
@@ -214,6 +215,14 @@ class OptionState:
         """
         if group in self._state:
             return self._state[group].get(name, default)
+        return default
+
+    def getList(self, group: str, name: str, default: list[Any]) -> list[Any]:
+        """Return the value as a list, if it exists. Otherwise, return
+        the default value.
+        """
+        if group in self._state and isinstance(value := self._state[group].get(name, default), list):
+            return value
         return default
 
     def getString(self, group: str, name: str, default: str) -> str:

--- a/novelwriter/editor/editfooter.py
+++ b/novelwriter/editor/editfooter.py
@@ -212,7 +212,7 @@ class GuiDocEditFooter(QWidget):
             cPos = cursor.position() + 1
             cLine = cursor.blockNumber() + 1
             cCount = max(document.characterCount(), 1)
-            self.linesText.setText(self._trLineCount.format(f"{cLine:n}", f"{100 * cPos // cCount:d} %"))
+            self.linesText.setText(self._trLineCount.format(f"{cLine:n}", f"{100 * cPos // cCount:d}\u202f%"))
 
     def updateMainCount(self, count: int, selection: bool) -> None:
         """Update main counter information."""

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -321,7 +321,7 @@ class NIconToolButton(QToolButton):
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         self.setIconSize(iconSize)
         self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        if icon and color:
+        if icon and color:  # pragma: no branch
             self.setThemeIcon(icon, color)
 
     def setCheckable(self, checkable: bool) -> None:
@@ -363,7 +363,7 @@ class NIconToggleButton(QToolButton):
         self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         self.setCheckable(True)
         self.setStyleSheet("border: none; background: transparent;")
-        if icon and color:
+        if icon and color:  # pragma: no branch
             self.setThemeIcon(icon, color)
 
     def setThemeIcon(self, icon: str, color: str) -> None:

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -1080,13 +1080,28 @@ class Tokenizer(ABC):
 
                 dCount = 0
                 if countDialog and tFmt:
-                    start = None
+                    intervals = []
+                    dStart = None
+                    aStart = None
                     for pos, _, meta in tFmt:
-                        if meta in ("dialog", "altdialog") and start is None:
-                            start = pos
-                        elif meta in ("enddialog", "endaltdialog") and start is not None:
-                            dCount += pos - start
-                            start = None
+                        if meta == "dialog" and dStart is None:
+                            dStart = pos
+                        elif meta == "enddialog" and dStart is not None:
+                            intervals.append((dStart, pos))
+                            dStart = None
+                        elif meta == "altdialog" and aStart is None:
+                            aStart = pos
+                        elif meta == "endaltdialog" and aStart is not None:
+                            intervals.append((aStart, pos))
+                            aStart = None
+
+                    # Dialogue and alt-dialogue markers may overlap, so the
+                    # intervals are merged to avoid double-counting
+                    prevEnd = -1
+                    for iStart, iEnd in sorted(intervals):
+                        if iEnd > prevEnd:
+                            dCount += iEnd - max(iStart, prevEnd)
+                            prevEnd = iEnd
 
                 paragraphCount += 1
                 allWords += nPWords

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -1055,12 +1055,15 @@ class Tokenizer(ABC):
         allChars = self._counts.get(nwStats.CHARS, 0)
         textChars = self._counts.get(nwStats.CHARS_TEXT, 0)
         titleChars = self._counts.get(nwStats.CHARS_TITLE, 0)
+        dialogChars = self._counts.get(nwStats.CHARS_DIALOG, 0)
 
         allWordChars = self._counts.get(nwStats.WCHARS_ALL, 0)
         textWordChars = self._counts.get(nwStats.WCHARS_TEXT, 0)
         titleWordChars = self._counts.get(nwStats.WCHARS_TITLE, 0)
 
-        for tType, _, tText, _, _ in self._blocks:
+        countDialog = self._hlightDialog
+
+        for tType, _, tText, tFmt, _ in self._blocks:
             tText = tText.replace(nwUnicode.U_ENDASH, " ")
             tText = tText.replace(nwUnicode.U_EMDASH, " ")
 
@@ -1075,11 +1078,22 @@ class Tokenizer(ABC):
                 nPChars = len(tText)
                 nPWChars = len("".join(tPWords))
 
+                dCount = 0
+                if countDialog and tFmt:
+                    start = None
+                    for pos, _, meta in tFmt:
+                        if meta == "dialog" and start is None:
+                            start = pos
+                        elif meta == "enddialog" and start is not None:
+                            dCount += pos - start
+                            start = None
+
                 paragraphCount += 1
                 allWords += nPWords
                 textWords += nPWords
                 allChars += nPChars
                 textChars += nPChars
+                dialogChars += dCount
                 allWordChars += nPWChars
                 textWordChars += nPWChars
 
@@ -1113,6 +1127,7 @@ class Tokenizer(ABC):
         self._counts[nwStats.CHARS] = allChars
         self._counts[nwStats.CHARS_TEXT] = textChars
         self._counts[nwStats.CHARS_TITLE] = titleChars
+        self._counts[nwStats.CHARS_DIALOG] = dialogChars
 
         self._counts[nwStats.WCHARS_ALL] = allWordChars
         self._counts[nwStats.WCHARS_TEXT] = textWordChars
@@ -1237,11 +1252,11 @@ class Tokenizer(ABC):
             if self._dialogParser.enabled:
                 for pos, end in self._dialogParser(text):
                     temp.append((pos, 0, TextFmt.COL_B, "dialog"))
-                    temp.append((end, 0, TextFmt.COL_E, ""))
+                    temp.append((end, 0, TextFmt.COL_E, "enddialog"))
             if self._rxAltDialog:
                 for res in self._rxAltDialog.finditer(text):
                     temp.append((res.start(0), 0, TextFmt.COL_B, "altdialog"))
-                    temp.append((res.end(0), 0, TextFmt.COL_E, ""))
+                    temp.append((res.end(0), 0, TextFmt.COL_E, "endaltdialog"))
 
         # Post-process text and format
         result = text

--- a/novelwriter/formats/tokenizer.py
+++ b/novelwriter/formats/tokenizer.py
@@ -1082,9 +1082,9 @@ class Tokenizer(ABC):
                 if countDialog and tFmt:
                     start = None
                     for pos, _, meta in tFmt:
-                        if meta == "dialog" and start is None:
+                        if meta in ("dialog", "altdialog") and start is None:
                             start = pos
-                        elif meta == "enddialog" and start is not None:
+                        elif meta in ("enddialog", "endaltdialog") and start is not None:
                             dCount += pos - start
                             start = None
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1063,9 +1063,9 @@ class GuiMain(QMainWindow):
 
         if updateFlags.theme:
             self.refreshThemeColors(syntax=updateFlags.syntax, force=True)
-        if updateFlags.editor or updateFlags.theme:
+        if updateFlags.editor or updateFlags.syntax or updateFlags.theme:
             self.docEditor.initEditor()
-        if updateFlags.viewer or updateFlags.theme:
+        if updateFlags.viewer or updateFlags.syntax or updateFlags.theme:
             self.docViewer.initViewer()
 
         self.projView.initSettings()

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -1001,6 +1001,10 @@ class _StatsWidget(QWidget):
         self.maxTotalChars.setText(f"{data.get(nwStats.CHARS, 0):n}")
         self.maxHeaderChars.setText(f"{data.get(nwStats.CHARS_TITLE, 0):n}")
         self.maxTextChars.setText(f"{data.get(nwStats.CHARS_TEXT, 0):n}")
+        if (dialog := data.get(nwStats.CHARS_DIALOG, 0)) > 0:
+            self.maxDialogChars.setText(f"{dialog:n}")
+        else:
+            self.maxDialogChars.setText("N/A")
 
         self.maxTotalWordChars.setText(f"{data.get(nwStats.WCHARS_ALL, 0):n}")
         self.maxHeadWordChars.setText(f"{data.get(nwStats.WCHARS_TITLE, 0):n}")
@@ -1040,6 +1044,7 @@ class _StatsWidget(QWidget):
         trAllChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS])
         trTextChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_TEXT])
         trTitleChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_TITLE])
+        trDialogChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_DIALOG])
         trParagraphCount = trStats(nwLabels.STATS_NAME[nwStats.PARAGRAPHS])
         trTitleCount = trStats(nwLabels.STATS_NAME[nwStats.TITLES])
         trAllWordChars = trStats(nwLabels.STATS_NAME[nwStats.WCHARS_ALL])
@@ -1080,6 +1085,7 @@ class _StatsWidget(QWidget):
         self.maxTotalChars = QLabel(self)
         self.maxHeaderChars = QLabel(self)
         self.maxTextChars = QLabel(self)
+        self.maxDialogChars = QLabel(self)
         self.maxTotalWordChars = QLabel(self)
         self.maxHeadWordChars = QLabel(self)
         self.maxTextWordChars = QLabel(self)
@@ -1087,6 +1093,7 @@ class _StatsWidget(QWidget):
         self.maxTotalChars.setAlignment(QtAlignRight)
         self.maxHeaderChars.setAlignment(QtAlignRight)
         self.maxTextChars.setAlignment(QtAlignRight)
+        self.maxDialogChars.setAlignment(QtAlignRight)
         self.maxTotalWordChars.setAlignment(QtAlignRight)
         self.maxHeadWordChars.setAlignment(QtAlignRight)
         self.maxTextWordChars.setAlignment(QtAlignRight)
@@ -1095,6 +1102,7 @@ class _StatsWidget(QWidget):
         self.rightForm.addRow(trAllChars, self.maxTotalChars)
         self.rightForm.addRow(trAllWordChars, self.maxTotalWordChars)
         self.rightForm.addRow(trTextChars, self.maxTextChars)
+        self.rightForm.addRow(trDialogChars, self.maxDialogChars)
         self.rightForm.addRow(trTextWordChars, self.maxTextWordChars)
         self.rightForm.addRow(trTitleChars, self.maxHeaderChars)
         self.rightForm.addRow(trTitleWordChars, self.maxHeadWordChars)

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -42,14 +42,12 @@ from PyQt6.QtPrintSupport import QPrinter, QPrintPreviewDialog
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QApplication,
-    QFormLayout,
     QGridLayout,
     QHBoxLayout,
     QLabel,
     QListWidget,
     QListWidgetItem,
     QSplitter,
-    QStackedWidget,
     QTabWidget,
     QTextBrowser,
     QTreeWidget,
@@ -59,10 +57,10 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import fuzzyTime
+from novelwriter.common import formatInt, formatPercent, fuzzyTime
 from novelwriter.constants import nwHeadFmt, nwLabels, nwStats, nwUnicode, trStats
 from novelwriter.enum import nwStandardButton
-from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton, NToolDialog
+from novelwriter.extensions.modified import NIconToolButton, NToolDialog
 from novelwriter.extensions.progressbars import NProgressCircle
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.formats.tokenizer import HeadingFormatter
@@ -78,8 +76,6 @@ from novelwriter.types import (
     QtAlignTop,
     QtHeaderStretch,
     QtHeaderToContents,
-    QtSizeExpanding,
-    QtSizeIgnored,
     QtUserRole,
 )
 
@@ -210,6 +206,8 @@ class GuiManuscript(NToolDialog):
         # Preview Options
         # ===============
 
+        self.countsLabel = QLabel(self)
+
         self.swtNewPage = NSwitch(self, height=iPx)
         self.swtNewPage.setChecked(options.getBool("GuiManuscript", "showNewPage", True))
         self.swtNewPage.clicked.connect(self._generatePreview)
@@ -221,10 +219,9 @@ class GuiManuscript(NToolDialog):
         # ============
 
         self.docPreview = _PreviewWidget(self)
-        self.docStats = _StatsWidget(self)
 
         self.docBar = QHBoxLayout()
-        self.docBar.addWidget(self.docStats, 1, QtAlignTop)
+        self.docBar.addWidget(self.countsLabel, 1, QtAlignTop)
         self.docBar.addWidget(self.lblNewPage, 0, QtAlignTop)
         self.docBar.addWidget(self.swtNewPage, 0, QtAlignTop)
         self.docBar.setContentsMargins(0, 0, 0, 0)
@@ -418,14 +415,15 @@ class GuiManuscript(NToolDialog):
 
         font = QFont()
         font.fromString(build.getStr("format.textFont"))
+        withDialog = build.getBool("format.showDialogue")
 
         self.docPreview.setTextFont(font)
         self.docPreview.setContent(buildObj.document)
         self.docPreview.setBuildName(build.name)
 
-        self.docStats.updateStats(buildObj.textStats)
         self.buildOutline.updateOutline(buildObj.textOutline)
-        self.buildStats.updateStats(buildObj.textStats)
+        self.buildStats.updateStats(buildObj.textStats, withDialog)
+        self._updateCountsLabel(buildObj.textStats, withDialog)
 
         logger.debug("Build completed in %.3f ms", 1000 * (time() - start))
 
@@ -535,6 +533,22 @@ class GuiManuscript(NToolDialog):
             if isinstance(obj, GuiBuildSettings) and obj.buildID == buildID:
                 return obj
         return None
+
+    def _updateCountsLabel(self, data: dict[str, int], withDialog: bool) -> None:
+        """Update the counts label with the given stats."""
+        words = data.get(nwStats.WORDS, 0)
+        chars = data.get(nwStats.CHARS, 0)
+        text = [
+            f"{trStats(nwLabels.STATS_NAME[nwStats.WORDS])}: {formatInt(words)}",
+            f"{trStats(nwLabels.STATS_NAME[nwStats.CHARS])}: {formatInt(chars)}",
+        ]
+        if withDialog:
+            textChars = data.get(nwStats.CHARS_TEXT, 0)
+            dialogChars = data.get(nwStats.CHARS_DIALOG, 0)
+            dialogRatio = formatPercent(dialogChars, divisor=textChars)
+            text.append(f"{trStats(nwLabels.STATS_NAME[nwStats.DIALOG_RATIO])}: {dialogRatio}")
+
+        self.countsLabel.setText("\u2003".join(text))
 
 
 class _DetailsWidget(QWidget):
@@ -837,7 +851,7 @@ class _StatisticsWidget(QWidget):
     #  Methods
     ##
 
-    def updateStats(self, data: dict[str, int]) -> None:
+    def updateStats(self, data: dict[str, int], withDialog: bool) -> None:
         """Update the stats values from a Tokenizer stats dict."""
         titles = data.get(nwStats.TITLES, 0)
         paragraphs = data.get(nwStats.PARAGRAPHS, 0)
@@ -854,11 +868,9 @@ class _StatisticsWidget(QWidget):
         titleChars = data.get(nwStats.CHARS_TITLE, 0)
         titleWChars = data.get(nwStats.WCHARS_TITLE, 0)
 
-        dialogRatio = f"{(dialogChars / textChars * 100.0):.1f}%" if chars > 0 else "N/A"
-
         self.cTitles.setText(1, f"{titles:n}")
         self.cParagraphs.setText(1, f"{paragraphs:n}")
-        self.cDialog.setText(1, dialogRatio)
+        self.cDialog.setText(1, formatPercent(dialogChars, divisor=textChars) if withDialog else "\u2014")
         self.cWords.setText(1, f"{words:n}")
         self.cChars.setText(1, f"{chars:n}")
 
@@ -868,7 +880,7 @@ class _StatisticsWidget(QWidget):
         self.cWChars.setText(1, f"{wChars:n}")
         self.cTextWChars.setText(1, f"{textWChars:n}")
         self.cTextChars.setText(1, f"{textChars:n}")
-        self.cDialogChars.setText(1, f"{dialogChars:n}" if dialogChars > 0 else "N/A")
+        self.cDialogChars.setText(1, f"{dialogChars:n}" if withDialog else "\u2014")
         self.cTitlesChars.setText(1, f"{titleChars:n}")
         self.cTitleWChars.setText(1, f"{titleWChars:n}")
 
@@ -879,6 +891,8 @@ class _StatisticsWidget(QWidget):
 
 
 class _PreviewWidget(QTextBrowser):
+    """The manuscript preview widget."""
+
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
@@ -1094,179 +1108,3 @@ class _PreviewWidget(QTextBrowser):
         self.ageLabel.setGeometry(tB, tB, vW, tH)
         self.setViewportMargins(0, tH, 0, 0)
         self.buildProgress.move((vW - pS) // 2, (vH - pS) // 2)
-
-
-class _StatsWidget(QWidget):
-    def __init__(self, parent: QWidget) -> None:
-        super().__init__(parent=parent)
-
-        font = self.font()
-        font.setPointSizeF(0.9 * SHARED.theme.fontPointSize)
-        self.setFont(font)
-
-        self.minWidget = QWidget(self)
-        self.maxWidget = QWidget(self)
-
-        self.toggleButton = NIconToggleButton(self, SHARED.theme.baseIconSize)
-        self.toggleButton.toggled.connect(self._toggleView)
-
-        self._buildBottomPanel()
-
-        self.mainStack = QStackedWidget(self)
-        self.mainStack.addWidget(self.minWidget)
-        self.mainStack.addWidget(self.maxWidget)
-
-        self.outerBox = QHBoxLayout()
-        self.outerBox.addWidget(self.toggleButton, 0, QtAlignTop)
-        self.outerBox.addWidget(self.mainStack, 1, QtAlignTop)
-        self.outerBox.setContentsMargins(0, 0, 0, 0)
-
-        self.setLayout(self.outerBox)
-        self.updateTheme()
-
-        self._toggleView(False)
-
-    def updateStats(self, data: dict[str, int]) -> None:
-        """Update the stats values from a Tokenizer stats dict."""
-        # Minimal
-        self.minWordCount.setText(f"{data.get(nwStats.WORDS, 0):n}")
-        self.minCharCount.setText(f"{data.get(nwStats.CHARS, 0):n}")
-
-        # Maximal
-        self.maxTotalWords.setText(f"{data.get(nwStats.WORDS, 0):n}")
-        self.maxHeadWords.setText(f"{data.get(nwStats.WORDS_TITLE, 0):n}")
-        self.maxTextWords.setText(f"{data.get(nwStats.WORDS_TEXT, 0):n}")
-        self.maxTitleCount.setText(f"{data.get(nwStats.TITLES, 0):n}")
-        self.maxParCount.setText(f"{data.get(nwStats.PARAGRAPHS, 0):n}")
-
-        self.maxTotalChars.setText(f"{data.get(nwStats.CHARS, 0):n}")
-        self.maxHeaderChars.setText(f"{data.get(nwStats.CHARS_TITLE, 0):n}")
-        self.maxTextChars.setText(f"{data.get(nwStats.CHARS_TEXT, 0):n}")
-        if (dialog := data.get(nwStats.CHARS_DIALOG, 0)) > 0:
-            self.maxDialogChars.setText(f"{dialog:n}")
-        else:
-            self.maxDialogChars.setText("N/A")
-
-        self.maxTotalWordChars.setText(f"{data.get(nwStats.WCHARS_ALL, 0):n}")
-        self.maxHeadWordChars.setText(f"{data.get(nwStats.WCHARS_TITLE, 0):n}")
-        self.maxTextWordChars.setText(f"{data.get(nwStats.WCHARS_TEXT, 0):n}")
-
-    def updateTheme(self) -> None:
-        """Update theme elements."""
-        logger.debug("Theme Update: _StatsWidget")
-        self.toggleButton.setThemeIcon("unfold", "default")
-
-    ##
-    #  Private Slots
-    ##
-
-    @pyqtSlot(bool)
-    def _toggleView(self, state: bool) -> None:
-        """Toggle minimal or maximal view."""
-        if state:
-            self.mainStack.setCurrentWidget(self.maxWidget)
-            self.maxWidget.setSizePolicy(QtSizeExpanding, QtSizeExpanding)
-            self.minWidget.setSizePolicy(QtSizeIgnored, QtSizeIgnored)
-        else:
-            self.mainStack.setCurrentWidget(self.minWidget)
-            self.maxWidget.setSizePolicy(QtSizeIgnored, QtSizeIgnored)
-            self.minWidget.setSizePolicy(QtSizeExpanding, QtSizeExpanding)
-        self.maxWidget.adjustSize()
-        self.minWidget.adjustSize()
-        self.mainStack.adjustSize()
-        self.adjustSize()
-
-    ##
-    #  Internal Functions
-    ##
-
-    def _buildBottomPanel(self) -> None:
-        """Build the bottom page."""
-        trAllChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS])
-        trTextChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_TEXT])
-        trTitleChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_TITLE])
-        trDialogChars = trStats(nwLabels.STATS_NAME[nwStats.CHARS_DIALOG])
-        trParagraphCount = trStats(nwLabels.STATS_NAME[nwStats.PARAGRAPHS])
-        trTitleCount = trStats(nwLabels.STATS_NAME[nwStats.TITLES])
-        trAllWordChars = trStats(nwLabels.STATS_NAME[nwStats.WCHARS_ALL])
-        trTextWordChars = trStats(nwLabels.STATS_NAME[nwStats.WCHARS_TEXT])
-        trTitleWordChars = trStats(nwLabels.STATS_NAME[nwStats.WCHARS_TITLE])
-        trAllWords = trStats(nwLabels.STATS_NAME[nwStats.WORDS])
-        trTextWords = trStats(nwLabels.STATS_NAME[nwStats.WORDS_TEXT])
-        trTitleWords = trStats(nwLabels.STATS_NAME[nwStats.WORDS_TITLE])
-
-        # Minimal Form
-        self.minWordCount = QLabel(self)
-        self.minCharCount = QLabel(self)
-
-        # Maximal Form, Left Column
-        self.maxTotalWords = QLabel(self)
-        self.maxHeadWords = QLabel(self)
-        self.maxTextWords = QLabel(self)
-        self.maxTitleCount = QLabel(self)
-        self.maxParCount = QLabel(self)
-
-        self.maxTotalWords.setAlignment(QtAlignRight)
-        self.maxHeadWords.setAlignment(QtAlignRight)
-        self.maxTextWords.setAlignment(QtAlignRight)
-        self.maxTitleCount.setAlignment(QtAlignRight)
-        self.maxParCount.setAlignment(QtAlignRight)
-
-        self.leftForm = QFormLayout()
-        self.leftForm.addRow(trAllWords, self.maxTotalWords)
-        self.leftForm.addRow(trTextWords, self.maxTextWords)
-        self.leftForm.addRow(trTitleWords, self.maxHeadWords)
-        self.leftForm.addRow("", QLabel(self))
-        self.leftForm.addRow(trTitleCount, self.maxTitleCount)
-        self.leftForm.addRow(trParagraphCount, self.maxParCount)
-        self.leftForm.setHorizontalSpacing(12)
-        self.leftForm.setVerticalSpacing(4)
-
-        # Maximal Form, Right Column
-        self.maxTotalChars = QLabel(self)
-        self.maxHeaderChars = QLabel(self)
-        self.maxTextChars = QLabel(self)
-        self.maxDialogChars = QLabel(self)
-        self.maxTotalWordChars = QLabel(self)
-        self.maxHeadWordChars = QLabel(self)
-        self.maxTextWordChars = QLabel(self)
-
-        self.maxTotalChars.setAlignment(QtAlignRight)
-        self.maxHeaderChars.setAlignment(QtAlignRight)
-        self.maxTextChars.setAlignment(QtAlignRight)
-        self.maxDialogChars.setAlignment(QtAlignRight)
-        self.maxTotalWordChars.setAlignment(QtAlignRight)
-        self.maxHeadWordChars.setAlignment(QtAlignRight)
-        self.maxTextWordChars.setAlignment(QtAlignRight)
-
-        self.rightForm = QFormLayout()
-        self.rightForm.addRow(trAllChars, self.maxTotalChars)
-        self.rightForm.addRow(trAllWordChars, self.maxTotalWordChars)
-        self.rightForm.addRow(trTextChars, self.maxTextChars)
-        self.rightForm.addRow(trDialogChars, self.maxDialogChars)
-        self.rightForm.addRow(trTextWordChars, self.maxTextWordChars)
-        self.rightForm.addRow(trTitleChars, self.maxHeaderChars)
-        self.rightForm.addRow(trTitleWordChars, self.maxHeadWordChars)
-        self.rightForm.setHorizontalSpacing(12)
-        self.rightForm.setVerticalSpacing(4)
-
-        # Assemble
-        self.minLayout = QHBoxLayout()
-        self.minLayout.addWidget(QLabel(trAllWords, self))
-        self.minLayout.addWidget(self.minWordCount)
-        self.minLayout.addSpacing(8)
-        self.minLayout.addWidget(QLabel(trAllChars, self))
-        self.minLayout.addWidget(self.minCharCount)
-        self.minLayout.addStretch(1)
-        self.minLayout.setSpacing(8)
-        self.minLayout.setContentsMargins(0, 0, 0, 0)
-
-        self.maxLayout = QHBoxLayout()
-        self.maxLayout.addLayout(self.leftForm)
-        self.maxLayout.addLayout(self.rightForm)
-        self.maxLayout.addStretch(1)
-        self.maxLayout.setSpacing(32)
-        self.maxLayout.setContentsMargins(0, 0, 0, 0)
-
-        self.minWidget.setLayout(self.minLayout)
-        self.maxWidget.setLayout(self.maxLayout)

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -72,7 +72,16 @@ from novelwriter.manuscript.buildsettings import BuildCollection, BuildSettings
 from novelwriter.manuscript.docbuild import DocumentBuilder
 from novelwriter.manuscript.manusbuild import GuiManuscriptBuild
 from novelwriter.manuscript.manussettings import GuiBuildSettings
-from novelwriter.types import QtAlignCenter, QtAlignRight, QtAlignTop, QtSizeExpanding, QtSizeIgnored, QtUserRole
+from novelwriter.types import (
+    QtAlignCenter,
+    QtAlignRight,
+    QtAlignTop,
+    QtHeaderStretch,
+    QtHeaderToContents,
+    QtSizeExpanding,
+    QtSizeIgnored,
+    QtUserRole,
+)
 
 if TYPE_CHECKING:
     from novelwriter.guimain import GuiMain
@@ -161,9 +170,13 @@ class GuiManuscript(NToolDialog):
 
         self.buildOutline = _OutlineWidget(self)
 
+        self.buildStats = _StatisticsWidget(self)
+        self.buildStats.setExpandedState(SHARED.project.options.getList("GuiManuscript", "statsExpanded", []))
+
         self.detailsTabs = QTabWidget(self)
         self.detailsTabs.addTab(self.buildDetails, self.tr("Details"))
         self.detailsTabs.addTab(self.buildOutline, self.tr("Outline"))
+        self.detailsTabs.addTab(self.buildStats, self.tr("Statistics"))
 
         self.buildSplit = QSplitter(Qt.Orientation.Vertical, self)
         self.buildSplit.addWidget(self.buildList)
@@ -412,6 +425,7 @@ class GuiManuscript(NToolDialog):
 
         self.docStats.updateStats(buildObj.textStats)
         self.buildOutline.updateOutline(buildObj.textOutline)
+        self.buildStats.updateStats(buildObj.textStats)
 
         logger.debug("Build completed in %.3f ms", 1000 * (time() - start))
 
@@ -464,6 +478,7 @@ class GuiManuscript(NToolDialog):
         buildSplit = self.buildSplit.sizes()
         detailsWidth = self.buildDetails.getColumnWidth()
         detailsExpanded = self.buildDetails.getExpandedState()
+        statsExpanded = self.buildStats.getExpandedState()
         showNewPage = self.swtNewPage.isChecked()
 
         logger.debug("Saving State: GuiManuscript")
@@ -476,6 +491,7 @@ class GuiManuscript(NToolDialog):
         pOptions.setValue("GuiManuscript", "detailsHeight", buildSplit[1])
         pOptions.setValue("GuiManuscript", "detailsWidth", detailsWidth)
         pOptions.setValue("GuiManuscript", "detailsExpanded", detailsExpanded)
+        pOptions.setValue("GuiManuscript", "statsExpanded", statsExpanded)
         pOptions.setValue("GuiManuscript", "showNewPage", showNewPage)
         pOptions.saveSettings()
 
@@ -522,6 +538,8 @@ class GuiManuscript(NToolDialog):
 
 
 class _DetailsWidget(QWidget):
+    """The details of the selected build settings."""
+
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
@@ -580,7 +598,7 @@ class _DetailsWidget(QWidget):
     def updateInfo(self, build: BuildSettings) -> None:
         """Load the build settings info into the table."""
         if self._initExpanded:
-            previous = SHARED.project.options.getValue("GuiManuscript", "detailsExpanded", [])
+            previous = SHARED.project.options.getList("GuiManuscript", "detailsExpanded", [])
             expanded = [bool(s) for s in previous]
             self._initExpanded = False
         else:
@@ -666,6 +684,8 @@ class _DetailsWidget(QWidget):
 
 
 class _OutlineWidget(QWidget):
+    """The outline of the manuscript."""
+
     D_LINE = QtUserRole
 
     outlineEntryClicked = pyqtSignal(str)
@@ -735,6 +755,127 @@ class _OutlineWidget(QWidget):
     def _onItemClick(self, item: QTreeWidgetItem) -> None:
         """Process tree item click."""
         self.outlineEntryClicked.emit(str(item.data(0, self.D_LINE)))
+
+
+class _StatisticsWidget(QWidget):
+    """The statistics of the manuscript."""
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent=parent)
+
+        self._initExpanded = True
+
+        # Tree Widget
+        self.listView = QTreeWidget(self)
+        self.listView.setHeaderLabels([self.tr("Count"), self.tr("Value")])
+        self.listView.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        self.listView.setIndentation(SHARED.theme.baseIconHeight)
+
+        # Entries
+        self.cTitles = QTreeWidgetItem(self.listView, [trStats(nwLabels.STATS_NAME[nwStats.TITLES]), ""])
+        self.cParagraphs = QTreeWidgetItem(self.listView, [trStats(nwLabels.STATS_NAME[nwStats.PARAGRAPHS]), ""])
+        self.cDialog = QTreeWidgetItem(self.listView, [trStats(nwLabels.STATS_NAME[nwStats.DIALOG_RATIO]), ""])
+        self.cWords = QTreeWidgetItem(self.listView, [trStats(nwLabels.STATS_NAME[nwStats.WORDS]), ""])
+        self.cChars = QTreeWidgetItem(self.listView, [trStats(nwLabels.STATS_NAME[nwStats.CHARS]), ""])
+
+        self.cTextWords = QTreeWidgetItem(self.cWords, [trStats(nwLabels.STATS_NAME[nwStats.WORDS_TEXT]), ""])
+        self.cTitlesWords = QTreeWidgetItem(self.cWords, [trStats(nwLabels.STATS_NAME[nwStats.WORDS_TITLE]), ""])
+
+        self.cWChars = QTreeWidgetItem(self.cChars, [trStats(nwLabels.STATS_NAME[nwStats.WCHARS_ALL]), ""])
+        self.cTextChars = QTreeWidgetItem(self.cChars, [trStats(nwLabels.STATS_NAME[nwStats.CHARS_TEXT]), ""])
+        self.cTextWChars = QTreeWidgetItem(self.cChars, [trStats(nwLabels.STATS_NAME[nwStats.WCHARS_TEXT]), ""])
+        self.cDialogChars = QTreeWidgetItem(self.cChars, [trStats(nwLabels.STATS_NAME[nwStats.CHARS_DIALOG]), ""])
+        self.cTitlesChars = QTreeWidgetItem(self.cChars, [trStats(nwLabels.STATS_NAME[nwStats.CHARS_TITLE]), ""])
+        self.cTitleWChars = QTreeWidgetItem(self.cChars, [trStats(nwLabels.STATS_NAME[nwStats.WCHARS_TITLE]), ""])
+
+        self.cTitles.setTextAlignment(1, QtAlignRight)
+        self.cParagraphs.setTextAlignment(1, QtAlignRight)
+        self.cDialog.setTextAlignment(1, QtAlignRight)
+        self.cWords.setTextAlignment(1, QtAlignRight)
+        self.cChars.setTextAlignment(1, QtAlignRight)
+        self.cTextWords.setTextAlignment(1, QtAlignRight)
+        self.cTitlesWords.setTextAlignment(1, QtAlignRight)
+        self.cTextChars.setTextAlignment(1, QtAlignRight)
+        self.cTitlesChars.setTextAlignment(1, QtAlignRight)
+        self.cDialogChars.setTextAlignment(1, QtAlignRight)
+        self.cWChars.setTextAlignment(1, QtAlignRight)
+        self.cTextWChars.setTextAlignment(1, QtAlignRight)
+        self.cTitleWChars.setTextAlignment(1, QtAlignRight)
+
+        # Assemble
+        self.outerBox = QVBoxLayout()
+        self.outerBox.addWidget(self.listView)
+        self.outerBox.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(self.outerBox)
+
+    ##
+    #  Getters
+    ##
+
+    def getExpandedState(self) -> list[bool]:
+        """Get the expanded state of each top level item."""
+        state = []
+        for i in range(self.listView.topLevelItemCount()):
+            item = self.listView.topLevelItem(i)
+            if isinstance(item, QTreeWidgetItem):  # pragma: no branch
+                state.append(item.isExpanded())
+        return state
+
+    ##
+    #  Setters
+    ##
+
+    def setExpandedState(self, state: list[bool]) -> None:
+        """Set the expanded state of each top level item."""
+        count = len(state)
+        for i in range(self.listView.topLevelItemCount()):
+            item = self.listView.topLevelItem(i)
+            if isinstance(item, QTreeWidgetItem):  # pragma: no branch
+                item.setExpanded((state[i] if i < count else True) and item.childCount() > 0)
+
+    ##
+    #  Methods
+    ##
+
+    def updateStats(self, data: dict[str, int]) -> None:
+        """Update the stats values from a Tokenizer stats dict."""
+        titles = data.get(nwStats.TITLES, 0)
+        paragraphs = data.get(nwStats.PARAGRAPHS, 0)
+        words = data.get(nwStats.WORDS, 0)
+        chars = data.get(nwStats.CHARS, 0)
+
+        textWords = data.get(nwStats.WORDS_TEXT, 0)
+        titleWords = data.get(nwStats.WORDS_TITLE, 0)
+
+        wChars = data.get(nwStats.WCHARS_ALL, 0)
+        textWChars = data.get(nwStats.WCHARS_TEXT, 0)
+        textChars = data.get(nwStats.CHARS_TEXT, 0)
+        dialogChars = data.get(nwStats.CHARS_DIALOG, 0)
+        titleChars = data.get(nwStats.CHARS_TITLE, 0)
+        titleWChars = data.get(nwStats.WCHARS_TITLE, 0)
+
+        dialogRatio = f"{(dialogChars / textChars * 100.0):.1f}%" if chars > 0 else "N/A"
+
+        self.cTitles.setText(1, f"{titles:n}")
+        self.cParagraphs.setText(1, f"{paragraphs:n}")
+        self.cDialog.setText(1, dialogRatio)
+        self.cWords.setText(1, f"{words:n}")
+        self.cChars.setText(1, f"{chars:n}")
+
+        self.cTextWords.setText(1, f"{textWords:n}")
+        self.cTitlesWords.setText(1, f"{titleWords:n}")
+
+        self.cWChars.setText(1, f"{wChars:n}")
+        self.cTextWChars.setText(1, f"{textWChars:n}")
+        self.cTextChars.setText(1, f"{textChars:n}")
+        self.cDialogChars.setText(1, f"{dialogChars:n}" if dialogChars > 0 else "N/A")
+        self.cTitlesChars.setText(1, f"{titleChars:n}")
+        self.cTitleWChars.setText(1, f"{titleWChars:n}")
+
+        if header := self.listView.header():  # pragma: no branch
+            header.setStretchLastSection(False)
+            header.setSectionResizeMode(0, QtHeaderStretch)
+            header.setSectionResizeMode(1, QtHeaderToContents)
 
 
 class _PreviewWidget(QTextBrowser):

--- a/novelwriter/tools/noveldetails.py
+++ b/novelwriter/tools/noveldetails.py
@@ -43,8 +43,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import SHARED
-from novelwriter.common import formatTime, numberToRoman
-from novelwriter.constants import nwUnicode
+from novelwriter.common import formatPercent, formatTime, numberToRoman
 from novelwriter.enum import nwStandardButton
 from novelwriter.extensions.configlayout import NColorLabel, NFixedPage, NScrollablePage
 from novelwriter.extensions.modified import NNonBlockingDialog
@@ -463,9 +462,8 @@ class _ContentsPage(NFixedPage):
                 progText = ""
             else:
                 cPage = tPages - fstPage
-                pgProg = 100.0 * (cPage - 1) / pMax if pMax > 0 else 0.0
                 progPage = f"{cPage:n}"
-                progText = f"{pgProg:.1f}{nwUnicode.U_THSP}%"
+                progText = formatPercent(cPage - 1, divisor=pMax, prec=1)
 
             hDec = SHARED.theme.getHeaderDecoration(tLevel)
             if tTitle.strip() == "":

--- a/novelwriter/tools/writingstats.py
+++ b/novelwriter/tools/writingstats.py
@@ -44,7 +44,7 @@ from PyQt6.QtWidgets import (
 )
 
 from novelwriter import CONFIG, SHARED
-from novelwriter.common import checkInt, checkIntTuple, formatTime, minmax, qtAddAction
+from novelwriter.common import checkInt, checkIntTuple, formatPercent, formatTime, minmax, qtAddAction
 from novelwriter.constants import nwConst
 from novelwriter.enum import nwStandardButton
 from novelwriter.error import formatException
@@ -566,8 +566,7 @@ class GuiWritingStats(NToolDialog):
             if showIdleTime:
                 idleEntry = formatTime(sIdle)
             else:
-                sRatio = sIdle / sDiff if sDiff > 0.0 else 0.0
-                idleEntry = f"{round(100.0 * sRatio)} %"
+                idleEntry = formatPercent(sIdle, divisor=sDiff, prec=0)
 
             newItem = QTreeWidgetItem()
             newItem.setText(self.C_TIME, sStart)

--- a/tests/_reference/fmtToDocX_SaveDocument_settings.xml
+++ b/tests/_reference/fmtToDocX_SaveDocument_settings.xml
@@ -16,6 +16,7 @@
     <w:docVar w:name="ManuscriptAllChars" w:val="27164" />
     <w:docVar w:name="ManuscriptTextChars" w:val="24964" />
     <w:docVar w:name="ManuscriptTitleChars" w:val="123" />
+    <w:docVar w:name="ManuscriptDialogChars" w:val="0" />
     <w:docVar w:name="ManuscriptAllWordChars" w:val="23208" />
     <w:docVar w:name="ManuscriptTextWordChars" w:val="21296" />
     <w:docVar w:name="ManuscriptTitleWordChars" w:val="113" />

--- a/tests/_reference/fmtToOdt_SaveFlatWithEmptyLines_document.fodt
+++ b/tests/_reference/fmtToOdt_SaveFlatWithEmptyLines_document.fodt
@@ -122,6 +122,7 @@
         <text:user-field-decl office:value-type="float" office:value="1471" text:name="ManuscriptAllChars" />
         <text:user-field-decl office:value-type="float" office:value="1441" text:name="ManuscriptTextChars" />
         <text:user-field-decl office:value-type="float" office:value="30" text:name="ManuscriptTitleChars" />
+        <text:user-field-decl office:value-type="float" office:value="0" text:name="ManuscriptDialogChars" />
         <text:user-field-decl office:value-type="float" office:value="1258" text:name="ManuscriptAllWordChars" />
         <text:user-field-decl office:value-type="float" office:value="1231" text:name="ManuscriptTextWordChars" />
         <text:user-field-decl office:value-type="float" office:value="27" text:name="ManuscriptTitleWordChars" />

--- a/tests/_reference/fmtToOdt_SaveFlat_document.fodt
+++ b/tests/_reference/fmtToOdt_SaveFlat_document.fodt
@@ -119,6 +119,7 @@
         <text:user-field-decl office:value-type="float" office:value="1471" text:name="ManuscriptAllChars" />
         <text:user-field-decl office:value-type="float" office:value="1441" text:name="ManuscriptTextChars" />
         <text:user-field-decl office:value-type="float" office:value="30" text:name="ManuscriptTitleChars" />
+        <text:user-field-decl office:value-type="float" office:value="0" text:name="ManuscriptDialogChars" />
         <text:user-field-decl office:value-type="float" office:value="1258" text:name="ManuscriptAllWordChars" />
         <text:user-field-decl office:value-type="float" office:value="1231" text:name="ManuscriptTextWordChars" />
         <text:user-field-decl office:value-type="float" office:value="27" text:name="ManuscriptTitleWordChars" />

--- a/tests/_reference/fmtToOdt_SaveFull_content.xml
+++ b/tests/_reference/fmtToOdt_SaveFull_content.xml
@@ -25,6 +25,7 @@
         <text:user-field-decl office:value-type="float" office:value="1471" text:name="ManuscriptAllChars" />
         <text:user-field-decl office:value-type="float" office:value="1441" text:name="ManuscriptTextChars" />
         <text:user-field-decl office:value-type="float" office:value="30" text:name="ManuscriptTitleChars" />
+        <text:user-field-decl office:value-type="float" office:value="0" text:name="ManuscriptDialogChars" />
         <text:user-field-decl office:value-type="float" office:value="1258" text:name="ManuscriptAllWordChars" />
         <text:user-field-decl office:value-type="float" office:value="1231" text:name="ManuscriptTextWordChars" />
         <text:user-field-decl office:value-type="float" office:value="27" text:name="ManuscriptTitleWordChars" />

--- a/tests/_reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
+++ b/tests/_reference/mBuildDocBuild_OpenDocument_Lorem_Ipsum.fodt
@@ -167,6 +167,7 @@
         <text:user-field-decl office:value-type="float" office:value="27998" text:name="ManuscriptAllChars" />
         <text:user-field-decl office:value-type="float" office:value="25578" text:name="ManuscriptTextChars" />
         <text:user-field-decl office:value-type="float" office:value="310" text:name="ManuscriptTitleChars" />
+        <text:user-field-decl office:value-type="float" office:value="0" text:name="ManuscriptDialogChars" />
         <text:user-field-decl office:value-type="float" office:value="23914" text:name="ManuscriptAllWordChars" />
         <text:user-field-decl office:value-type="float" office:value="21806" text:name="ManuscriptTextWordChars" />
         <text:user-field-decl office:value-type="float" office:value="275" text:name="ManuscriptTitleWordChars" />

--- a/tests/core/test_options.py
+++ b/tests/core/test_options.py
@@ -147,12 +147,20 @@ def testOptionState_SetGet(mockGUI):
     assert options.getBool("GuiNovelDetails", "mockItem", None) is None  # type: ignore
     assert options.getEnum("GuiNovelView", "lastCol", nwNovelExtra, nwColHidden) == nwColHidden
 
+    # Get list
+    assert options.setValue("GuiManuscript", "statsExpanded", [True, False]) is True
+    assert options.getList("GuiManuscript", "statsExpanded", []) == [True, False]
+    assert options.setValue("GuiManuscript", "detailsExpanded", "notAList") is True
+    assert options.getList("GuiManuscript", "detailsExpanded", []) == []
+    assert options.getList("GuiManuscript", "mockItem", []) == []
+
     # Get enum, invalid value
     assert options.setValue("GuiNovelView", "lastCol", "invalidValue") is True
     assert options.getEnum("GuiNovelView", "lastCol", nwNovelExtra, nwColHidden) == nwColHidden
 
     # Get from non-existent groups
     assert options.getValue("SomeGroup", "mockItem", None) is None
+    assert options.getList("SomeGroup", "mockItem", []) == []
     assert options.getString("SomeGroup", "mockItem", None) is None  # type: ignore
     assert options.getInt("SomeGroup", "mockItem", None) is None  # type: ignore
     assert options.getFloat("SomeGroup", "mockItem", None) is None  # type: ignore

--- a/tests/formats/test_tokenizer.py
+++ b/tests/formats/test_tokenizer.py
@@ -2421,6 +2421,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 15,
         "textChars": 0,
         "titleChars": 15,
+        "dialogChars": 0,
         "allWordChars": 13,
         "textWordChars": 0,
         "titleWordChars": 13,
@@ -2443,6 +2444,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 20,
         "textChars": 0,
         "titleChars": 20,
+        "dialogChars": 0,
         "allWordChars": 16,
         "textWordChars": 0,
         "titleWordChars": 16,
@@ -2463,6 +2465,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 47,
         "textChars": 47,
         "titleChars": 0,
+        "dialogChars": 0,
         "allWordChars": 40,
         "textWordChars": 40,
         "titleWordChars": 0,
@@ -2485,6 +2488,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 20,
         "textChars": 8,
         "titleChars": 7,
+        "dialogChars": 0,
         "allWordChars": 18,
         "textWordChars": 8,
         "titleWordChars": 7,
@@ -2509,6 +2513,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 26,
         "textChars": 4,
         "titleChars": 7,
+        "dialogChars": 0,
         "allWordChars": 25,
         "textWordChars": 4,
         "titleWordChars": 7,
@@ -2533,6 +2538,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 35,
         "textChars": 4,
         "titleChars": 7,
+        "dialogChars": 0,
         "allWordChars": 33,
         "textWordChars": 4,
         "titleWordChars": 7,
@@ -2557,6 +2563,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 25,
         "textChars": 4,
         "titleChars": 7,
+        "dialogChars": 0,
         "allWordChars": 24,
         "textWordChars": 4,
         "titleWordChars": 7,
@@ -2581,6 +2588,7 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 30,
         "textChars": 4,
         "titleChars": 7,
+        "dialogChars": 0,
         "allWordChars": 27,
         "textWordChars": 4,
         "titleWordChars": 7,
@@ -2639,10 +2647,70 @@ def testTokenizer_CountStats(mockGUI, ipsumText):
         "allChars": 3859,
         "textChars": 3513,
         "titleChars": 46,
+        "dialogChars": 0,
         "allWordChars": 3289,
         "textWordChars": 2990,
         "titleWordChars": 38,
     }
+
+
+@pytest.mark.core
+def testTokenizer_CountStats_Dialogue(mockGUI):
+    """Test the dialogue character counter of the Tokenizer class."""
+    CONFIG.fmtDQuoteOpen = "\u201c"
+    CONFIG.fmtDQuoteClose = "\u201d"
+    CONFIG.fmtSQuoteOpen = "\u2018"
+    CONFIG.fmtSQuoteClose = "\u2019"
+    CONFIG.dialogStyle = 3
+    CONFIG.altDialogOpen = "::"
+    CONFIG.altDialogClose = "::"
+
+    project = NWProject()
+    project.data.setLanguage("en")
+    project._loadProjectLocalisation()
+    tokens = BareTokenizer(project)
+    tokens._isNovel = True
+
+    # Highlighting disabled: no dialogue is counted, even if present
+    tokens._text = "Text with \u201cdialogue,\u201d and ::alt dialogue::, too.\n\n"
+    tokens._counts = {}
+    tokens.setDialogHighlight(False)
+    tokens.tokenizeText()
+    tokens.countStats()
+    assert tokens.textStats["dialogChars"] == 0
+
+    # Highlighting enabled: quoted dialogue is counted
+    tokens._text = "Text with \u201cdialogue one\u201d and \u201cdialogue two\u201d, too.\n\n"
+    tokens._counts = {}
+    tokens.setDialogHighlight(True)
+    tokens.tokenizeText()
+    tokens.countStats()
+    assert tokens.textStats["dialogChars"] == len("\u201cdialogue one\u201d") + len("\u201cdialogue two\u201d")
+
+    # Highlighting enabled: alt-dialogue syntax is also counted
+    tokens._text = "Text with ::alt dialogue one:: and ::alt dialogue two::, too.\n\n"
+    tokens._counts = {}
+    tokens.setDialogHighlight(True)
+    tokens.tokenizeText()
+    tokens.countStats()
+    assert tokens.textStats["dialogChars"] == len("::alt dialogue one::") + len("::alt dialogue two::")
+
+    # Highlighting enabled: both regular and alt dialogue are combined
+    tokens._text = "Text with \u201cdialogue\u201d and ::alt dialogue::, too.\n\n"
+    tokens._counts = {}
+    tokens.setDialogHighlight(True)
+    tokens.tokenizeText()
+    tokens.countStats()
+    assert tokens.textStats["dialogChars"] == len("\u201cdialogue\u201d") + len("::alt dialogue::")
+
+    # Highlighting enabled: unrelated formatting markers within the same
+    # paragraph should be skipped when scanning for dialogue markers
+    tokens._text = "Text with \u201c**bold** dialogue\u201d, too.\n\n"
+    tokens._counts = {}
+    tokens.setDialogHighlight(True)
+    tokens.tokenizeText()
+    tokens.countStats()
+    assert tokens.textStats["dialogChars"] == len("\u201cbold dialogue\u201d")
 
 
 @pytest.mark.core

--- a/tests/formats/test_tokenizer.py
+++ b/tests/formats/test_tokenizer.py
@@ -1721,9 +1721,9 @@ def testTokenizer_Dialogue(mockGUI):
             "Text with \u2018dialogue one,\u2019 and \u2018dialogue two.\u2019",
             [
                 (10, TextFmt.COL_B, "dialog"),
-                (25, TextFmt.COL_E, ""),
+                (25, TextFmt.COL_E, "enddialog"),
                 (30, TextFmt.COL_B, "dialog"),
-                (45, TextFmt.COL_E, ""),
+                (45, TextFmt.COL_E, "enddialog"),
             ],
             BlockFmt.NONE,
         )
@@ -1739,9 +1739,9 @@ def testTokenizer_Dialogue(mockGUI):
             "Text with \u201cdialogue one,\u201d and \u201cdialogue two.\u201d",
             [
                 (10, TextFmt.COL_B, "dialog"),
-                (25, TextFmt.COL_E, ""),
+                (25, TextFmt.COL_E, "enddialog"),
                 (30, TextFmt.COL_B, "dialog"),
-                (45, TextFmt.COL_E, ""),
+                (45, TextFmt.COL_E, "enddialog"),
             ],
             BlockFmt.NONE,
         )
@@ -1757,9 +1757,9 @@ def testTokenizer_Dialogue(mockGUI):
             "Text with ::dialogue one,:: and ::dialogue two.::",
             [
                 (10, TextFmt.COL_B, "altdialog"),
-                (27, TextFmt.COL_E, ""),
+                (27, TextFmt.COL_E, "endaltdialog"),
                 (32, TextFmt.COL_B, "altdialog"),
-                (49, TextFmt.COL_E, ""),
+                (49, TextFmt.COL_E, "endaltdialog"),
             ],
             BlockFmt.NONE,
         )
@@ -1780,7 +1780,7 @@ def testTokenizer_Dialogue(mockGUI):
             "\u2013 Dialogue line without narrator break.",
             [
                 (0, TextFmt.COL_B, "dialog"),
-                (39, TextFmt.COL_E, ""),
+                (39, TextFmt.COL_E, "enddialog"),
             ],
             BlockFmt.NONE,
         )
@@ -1801,9 +1801,9 @@ def testTokenizer_Dialogue(mockGUI):
             "\u2013 Dialogue with a narrator break, \u2013he said\u2013, see?",
             [
                 (0, TextFmt.COL_B, "dialog"),
-                (34, TextFmt.COL_E, ""),
+                (34, TextFmt.COL_E, "enddialog"),
                 (44, TextFmt.COL_B, "dialog"),
-                (49, TextFmt.COL_E, ""),
+                (49, TextFmt.COL_E, "enddialog"),
             ],
             BlockFmt.NONE,
         )
@@ -1823,7 +1823,7 @@ def testTokenizer_Dialogue(mockGUI):
             [
                 (0, TextFmt.I_B, ""),
                 (0, TextFmt.COL_B, "dialog"),
-                (16, TextFmt.COL_E, ""),
+                (16, TextFmt.COL_E, "enddialog"),
                 (16, TextFmt.I_E, ""),
             ],
             BlockFmt.NONE,

--- a/tests/formats/test_tokenizer.py
+++ b/tests/formats/test_tokenizer.py
@@ -2712,6 +2712,26 @@ def testTokenizer_CountStats_Dialogue(mockGUI):
     tokens.countStats()
     assert tokens.textStats["dialogChars"] == len("\u201cbold dialogue\u201d")
 
+    # Highlighting enabled: a nested alt-dialogue marker fully contained
+    # within a regular dialogue quote overlaps, and must not be double
+    # counted, nor cause the overlapping regions to be dropped
+    tokens._text = "Text with \u201c::dialogue::\u201d, too.\n\n"
+    tokens._counts = {}
+    tokens.setDialogHighlight(True)
+    tokens.tokenizeText()
+    tokens.countStats()
+    assert tokens.textStats["dialogChars"] == len("\u201c::dialogue::\u201d")
+
+    # Highlighting enabled: a dialogue quote and an alt-dialogue marker
+    # that cross each other, rather than nest, must still be merged into
+    # a single non-overlapping span
+    tokens._text = "Text with \u201cdialog and ::alt\u201d dialog:: in it.\n\n"
+    tokens._counts = {}
+    tokens.setDialogHighlight(True)
+    tokens.tokenizeText()
+    tokens.countStats()
+    assert tokens.textStats["dialogChars"] == len("\u201cdialog and ::alt\u201d dialog::")
+
 
 @pytest.mark.core
 def testTokenizer_SceneSeparators(mockGUI):

--- a/tests/formats/test_toodt.py
+++ b/tests/formats/test_toodt.py
@@ -270,7 +270,7 @@ def testToOdt_DialogueFormatting(mockGUI):
 
     # Regular dialogue
     text = "Text with 'dialogue in it.'"
-    fmt = [(10, TextFmt.COL_B, "dialog"), (27, TextFmt.COL_E, "")]
+    fmt = [(10, TextFmt.COL_B, "dialog"), (27, TextFmt.COL_E, "enddialog")]
     xTest = ET.Element(_mkTag("office", "text"))
     odt._addTextPar(xTest, "Standard", oStyle, text, tFmt=fmt)
     assert odt.errData == []
@@ -283,7 +283,7 @@ def testToOdt_DialogueFormatting(mockGUI):
 
     # Alternative dialogue
     text = "Text with ::dialogue in it.::"
-    fmt = [(10, TextFmt.COL_B, "altdialog"), (29, TextFmt.COL_E, "")]
+    fmt = [(10, TextFmt.COL_B, "altdialog"), (29, TextFmt.COL_E, "endaltdialog")]
     xTest = ET.Element(_mkTag("office", "text"))
     odt._addTextPar(xTest, "Standard", oStyle, text, tFmt=fmt)
     assert odt.errData == []

--- a/tests/manuscript/test_manuscript.py
+++ b/tests/manuscript/test_manuscript.py
@@ -33,7 +33,7 @@ from PyQt6.QtPrintSupport import QPrintPreviewDialog
 from PyQt6.QtWidgets import QListWidgetItem
 
 from novelwriter import SHARED
-from novelwriter.constants import nwHeadFmt
+from novelwriter.constants import nwHeadFmt, nwStats
 from novelwriter.manuscript.buildsettings import BuildSettings
 from novelwriter.manuscript.manusbuild import GuiManuscriptBuild
 from novelwriter.manuscript.manuscript import GuiManuscript
@@ -323,14 +323,23 @@ def testGuiManuscript_Features(monkeypatch, qtbot, nwGUI, projPath, mockRnd):
         assert openUrl.call_args[0][0] == QUrl("http://www.example.com")
 
     # Check Preview Stats
-    assert manus.docStats.mainStack.currentWidget() == manus.docStats.minWidget
-    assert manus.docStats.minWordCount.text() == "25"
-    assert manus.docStats.minCharCount.text() == "117"
+    assert manus.countsLabel.text() == "Words: 25\u2003Characters: 117"
+    assert manus.buildStats.cWords.text(1) == "25"
+    assert manus.buildStats.cChars.text(1) == "117"
+    assert manus.buildStats.cDialog.text(1) == "\u2014"
 
-    manus.docStats.toggleButton.toggle()
-    assert manus.docStats.mainStack.currentWidget() == manus.docStats.maxWidget
-    assert manus.docStats.maxTotalWords.text() == "25"
-    assert manus.docStats.maxTotalChars.text() == "117"
+    # Check Preview Stats w/Dialogue
+    dialogData = {
+        nwStats.WORDS: 25,
+        nwStats.CHARS: 117,
+        nwStats.CHARS_TEXT: 100,
+        nwStats.CHARS_DIALOG: 25,
+    }
+    manus._updateCountsLabel(dialogData, True)
+    assert manus.countsLabel.text() == "Words: 25\u2003Characters: 117\u2003Dialogue: 25.0\u202f%"
+    manus.buildStats.updateStats(dialogData, True)
+    assert manus.buildStats.cDialog.text(1) == "25.0\u202f%"
+    assert manus.buildStats.cDialogChars.text(1) == "25"
 
     # Tests are too fast to trigger this one, so we trigger it manually to ensure it isn't failing
     manus.docPreview._postUpdate()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -53,6 +53,7 @@ from novelwriter.common import (
     formatFileFilter,
     formatInt,
     formatLink,
+    formatPercent,
     formatTime,
     formatTimeStamp,
     formatVersion,
@@ -558,6 +559,31 @@ def testCommon_formatInt():
     assert formatInt(12.3) == "ERR"  # type: ignore
     assert formatInt(None) == "ERR"  # type: ignore
     assert formatInt("42") == "ERR"  # type: ignore
+
+
+@pytest.mark.base
+def testCommon_formatPercent():
+    """Test the formatPercent function."""
+    # Plain fraction, no divisor
+    assert formatPercent(0.5) == "50.0\u202f%"
+    assert formatPercent(1.0) == "100.0\u202f%"
+    assert formatPercent(0) == "0.0\u202f%"
+
+    # With a divisor
+    assert formatPercent(50, divisor=100) == "50.0\u202f%"
+    assert formatPercent(1, divisor=3) == "33.3\u202f%"
+
+    # Divisor of zero is ignored, value is used as-is
+    assert formatPercent(0, divisor=0) == "0.0\u202f%"
+
+    # Precision
+    assert formatPercent(1, divisor=3, prec=0) == "33\u202f%"
+    assert formatPercent(1, divisor=3, prec=3) == "33.333\u202f%"
+
+    # Exceptions
+    assert formatPercent(None) == "ERR"  # type: ignore
+    assert formatPercent("42") == "ERR"  # type: ignore
+    assert formatPercent("42", divisor=3) == "ERR"  # type: ignore
 
 
 @pytest.mark.base

--- a/tests/tools/test_writingstats.py
+++ b/tests/tools/test_writingstats.py
@@ -730,7 +730,7 @@ def testGuiWritingStats_Filters(qtbot, monkeypatch, nwGUI, projPath, tstPaths):
     # Toggle Idle Time
     item = sessLog.listBox.topLevelItem(7)
     assert item is not None
-    assert item.text(sessLog.C_IDLE) == "4 %"
+    assert item.text(sessLog.C_IDLE) == "4\u202f%"
 
     qtbot.mouseClick(sessLog.swtShowIdleTime, QtMouseLeft)
 


### PR DESCRIPTION
**Summary:**

This PR adds a new statistics value containing the number of characters inside dialogue in the body text of the manuscript. the statistics panel that used to fold/unfold under the manuscript preview has now been moved to the tabbed list views on the left, and the dialogue character count is shown under "characters". The ratio of dialog to text is also shown in the panel.

The old panel below the preview document still shows the word and character count, and also dialogue percentage when the value is available.

**Related Issue(s):**

Closes #2096

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
