### PR TITLE
Make it possible to hide the item details panel below the project tree

### DIFF
--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -189,6 +189,7 @@ class Config:
         "searchProjWord",
         "searchRegEx",
         "searchWord",
+        "showDetailsPanel",
         "showEditToolBar",
         "showFullPath",
         "showLineEndings",
@@ -382,6 +383,7 @@ class Config:
         self.spellLanguage = "en"
 
         # State
+        self.showDetailsPanel = True  # The panel for the item details is visible
         self.showViewerPanel = True  # The panel for the viewer is visible
         self.showEditToolBar = False  # The document editor toolbar visibility
         self.showSessionTime = True  # Show the session time in the status bar
@@ -856,6 +858,7 @@ class Config:
 
         # State
         sec = "State"
+        self.showDetailsPanel = conf.rdBool(sec, "showdetailspanel", self.showDetailsPanel)
         self.showViewerPanel = conf.rdBool(sec, "showviewerpanel", self.showViewerPanel)
         self.showEditToolBar = conf.rdBool(sec, "showedittoolbar", self.showEditToolBar)
         self.showSessionTime = conf.rdBool(sec, "showsessiontime", self.showSessionTime)
@@ -992,6 +995,7 @@ class Config:
         }
 
         conf["State"] = {
+            "showdetailspanel": str(self.showDetailsPanel),
             "showviewerpanel": str(self.showViewerPanel),
             "showedittoolbar": str(self.showEditToolBar),
             "showsessiontime": str(self.showSessionTime),

--- a/novelwriter/extensions/expandpanel.py
+++ b/novelwriter/extensions/expandpanel.py
@@ -1,0 +1,101 @@
+"""
+novelWriter – Custom Widget: Expandable Panel
+=============================================
+
+This file is a part of novelWriter
+Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""  # noqa
+
+from __future__ import annotations
+
+from PyQt6.QtCore import pyqtSlot
+from PyQt6.QtWidgets import QHBoxLayout, QLayout, QVBoxLayout, QWidget
+
+from novelwriter import SHARED
+from novelwriter.extensions.modified import NClickableLabel, NIconToggleButton
+
+
+class NExpandablePanel(QWidget):
+    """Custom Widget: Expandable Panel.
+
+    A panel that can be expanded or collapsed by clicking on its header.
+    The header contains a title and an optional icon, and the content
+    area can contain any widget.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._ep_expanded = True
+        self._ep_widget = QWidget(self)
+
+        self._ep_toggle = NIconToggleButton(self, SHARED.theme.baseIconSize, "unfold", "default")
+        self._ep_toggle.setChecked(self._ep_expanded)
+        self._ep_toggle.toggled.connect(self._toggleExpanded)
+
+        self._ep_label = NClickableLabel("Unnamed", self)
+        self._ep_label.setFont(SHARED.theme.guiFontB)
+        self._ep_label.mouseClicked.connect(self._ep_toggle.click)
+
+        self._ep_header = QHBoxLayout()
+        self._ep_header.setContentsMargins(0, 0, 0, 0)
+        self._ep_header.addWidget(self._ep_toggle)
+        self._ep_header.addWidget(self._ep_label)
+        self._ep_header.setSpacing(2)
+
+        self._ep_layout = QVBoxLayout()
+        self._ep_layout.setContentsMargins(0, 0, 0, 0)
+        self._ep_layout.addLayout(self._ep_header)
+        self._ep_layout.addWidget(self._ep_widget)
+
+        self.setLayout(self._ep_layout)
+
+    ##
+    #  Setters
+    ##
+
+    def setTitle(self, title: str) -> None:
+        """Set the title of the panel."""
+        self._ep_label.setText(title)
+
+    def setExpanded(self, expanded: bool) -> None:
+        """Set the expanded state of the panel."""
+        self._ep_toggle.setChecked(expanded)
+
+    def setContentLayout(self, layout: QLayout) -> None:
+        """Set the content layout of the panel."""
+        self._ep_widget.setLayout(layout)
+
+    ##
+    #  Methods
+    ##
+
+    def isExpanded(self) -> bool:
+        """Return the expanded state of the panel."""
+        return self._ep_expanded
+
+    def updateTheme(self) -> None:
+        """Update the theme of the panel."""
+        self._ep_toggle.refreshTheme()
+
+    ##
+    #  Private Slots
+    ##
+
+    @pyqtSlot(bool)
+    def _toggleExpanded(self, state: bool) -> None:
+        """Toggle the expanded state of the panel."""
+        self._ep_expanded = state
+        self._ep_widget.setVisible(state)

--- a/novelwriter/extensions/expandpanel.py
+++ b/novelwriter/extensions/expandpanel.py
@@ -21,7 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
 
-from PyQt6.QtCore import pyqtSlot
+from PyQt6.QtCore import pyqtSignal, pyqtSlot
 from PyQt6.QtWidgets import QHBoxLayout, QLayout, QVBoxLayout, QWidget
 
 from novelwriter import SHARED
@@ -35,6 +35,8 @@ class NExpandablePanel(QWidget):
     The header contains a title and an optional icon, and the content
     area can contain any widget.
     """
+
+    expandedStateChanged = pyqtSignal(bool)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -97,5 +99,7 @@ class NExpandablePanel(QWidget):
     @pyqtSlot(bool)
     def _toggleExpanded(self, state: bool) -> None:
         """Toggle the expanded state of the panel."""
-        self._ep_expanded = state
-        self._ep_widget.setVisible(state)
+        if self._ep_expanded != state:
+            self._ep_expanded = state
+            self._ep_widget.setVisible(state)
+            self.expandedStateChanged.emit(state)

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -28,22 +28,24 @@ from enum import Enum
 from PyQt6.QtCore import pyqtSlot
 from PyQt6.QtWidgets import QGridLayout, QLabel, QWidget
 
-from novelwriter import SHARED
+from novelwriter import CONFIG, SHARED
 from novelwriter.common import elide
 from novelwriter.constants import nwLabels, nwStats, trConst, trStats
 from novelwriter.enum import nwChange
+from novelwriter.extensions.expandpanel import NExpandablePanel
 from novelwriter.types import QtAlignLeft, QtAlignLeftBase, QtAlignRight, QtAlignRightBase, QtAlignRightMiddle
 
 logger = logging.getLogger(__name__)
 
 
-class GuiItemDetails(QWidget):
+class GuiItemDetails(NExpandablePanel):
     """GUI: Project Item Details Panel."""
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
         logger.debug("Create: GuiItemDetails")
+        self.setTitle(self.tr("Details"))
 
         # Internal Variables
         self._handle = None
@@ -168,7 +170,8 @@ class GuiItemDetails(QWidget):
         self.mainBox.setVerticalSpacing(1)
         self.mainBox.setContentsMargins(6, 6, 6, 6)
 
-        self.setLayout(self.mainBox)
+        self.setContentLayout(self.mainBox)
+        self.setExpanded(CONFIG.showDetailsPanel)
 
         self.updateTheme()
 
@@ -205,6 +208,7 @@ class GuiItemDetails(QWidget):
 
     def updateTheme(self) -> None:
         """Update theme elements."""
+        super().updateTheme()
         logger.debug("Theme Update: GuiItemDetails")
         self.updateViewBox(self._handle)
 

--- a/novelwriter/gui/itemdetails.py
+++ b/novelwriter/gui/itemdetails.py
@@ -49,6 +49,7 @@ class GuiItemDetails(NExpandablePanel):
 
         # Internal Variables
         self._handle = None
+        self._refresh = None
 
         # Predefined
         fntLabel = SHARED.theme.guiFontSmallB
@@ -172,8 +173,9 @@ class GuiItemDetails(NExpandablePanel):
 
         self.setContentLayout(self.mainBox)
         self.setExpanded(CONFIG.showDetailsPanel)
-
         self.updateTheme()
+
+        self.expandedStateChanged.connect(self._expandedStateChanged)
 
         # Make sure the columns for flags and counts don't resize too often
         flagWidth = SHARED.theme.getTextWidth("Mm", fntValue)
@@ -214,6 +216,10 @@ class GuiItemDetails(NExpandablePanel):
 
     def updateViewBox(self, tHandle: str | None) -> None:
         """Populate the details box from a given handle."""
+        if not self.isExpanded():
+            self._refresh = {"handle": tHandle}
+            return
+
         if not (tHandle and (nwItem := SHARED.project.tree[tHandle])):
             self.clearDetails()
             return
@@ -222,35 +228,25 @@ class GuiItemDetails(NExpandablePanel):
         iPx = round(0.9 * SHARED.theme.baseIconHeight)
 
         # Label
-        # =====
-
         _, icon = nwItem.getActiveStatus()
         self.labelIcon.setPixmap(icon.pixmap(iPx, iPx))
         self.labelData.setText(elide(nwItem.itemName, 100))
 
         # Status
-        # ======
-
         status, icon = nwItem.getImportStatus()
         self.statusIcon.setPixmap(icon.pixmap(iPx, iPx))
         self.statusData.setText(status)
 
         # Class
-        # =====
-
         classIcon = SHARED.theme.getIcon(nwLabels.CLASS_ICON[nwItem.itemClass], "root")
         self.classIcon.setPixmap(classIcon.pixmap(iPx, iPx))
         self.classData.setText(trConst(nwLabels.CLASS_NAME[nwItem.itemClass]))
 
         # Layout
-        # ======
-
         self.usageIcon.setPixmap(nwItem.getMainIcon().pixmap(iPx, iPx))
         self.usageData.setText(nwItem.describeMe())
 
         # Counts
-        # ======
-
         if nwItem.isFileType():
             self.cCountData.setText(f"{nwItem.charCount:n}")
             self.wCountData.setText(f"{nwItem.wordCount:n}")
@@ -259,6 +255,8 @@ class GuiItemDetails(NExpandablePanel):
             self.cCountData.setText("–")
             self.wCountData.setText("–")
             self.pCountData.setText("–")
+
+        self._refresh = None
 
         return
 
@@ -274,3 +272,13 @@ class GuiItemDetails(NExpandablePanel):
                 self.updateViewBox(tHandle)
             elif change == nwChange.DELETE:
                 self.updateViewBox(None)
+
+    ##
+    #  Private Slots
+    ##
+
+    @pyqtSlot(bool)
+    def _expandedStateChanged(self, state: bool) -> None:
+        """Process the expanded state change."""
+        if state and isinstance(self._refresh, dict):
+            self.updateViewBox(self._refresh.get("handle"))

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -849,6 +849,7 @@ class GuiMain(QMainWindow):
             if self.docViewerPanel.isVisible():
                 CONFIG.viewPanePos = self.splitView.sizes()
 
+        CONFIG.showDetailsPanel = self.itemDetails.isExpanded()
         CONFIG.showViewerPanel = self.docViewerPanel.isVisible()
         wFull = Qt.WindowState.WindowFullScreen
         if self.windowState() & wFull != wFull:

--- a/tests/_reference/baseConfig_novelwriter.conf
+++ b/tests/_reference/baseConfig_novelwriter.conf
@@ -1,5 +1,5 @@
 [Meta]
-timestamp = 2026-07-11 00:22:29
+timestamp = 2026-07-13 20:44:51
 
 [Main]
 font = 
@@ -86,6 +86,7 @@ stopwhenidle = True
 useridletime = 300
 
 [State]
+showdetailspanel = True
 showviewerpanel = True
 showedittoolbar = False
 showsessiontime = True

--- a/tests/extensions/test_expandpanel.py
+++ b/tests/extensions/test_expandpanel.py
@@ -40,6 +40,9 @@ def testNExpandablePanel_Main(qtbot, mockGUI):
     dialog.show()
     qtbot.addWidget(dialog)
 
+    changes = []
+    panel.expandedStateChanged.connect(changes.append)
+
     # Default state is expanded, with a default title
     assert panel.isExpanded() is True
     assert panel._ep_widget.isVisible() is True
@@ -61,28 +64,40 @@ def testNExpandablePanel_Main(qtbot, mockGUI):
     assert panel.isExpanded() is False
     assert panel._ep_widget.isVisible() is False
     assert panel._ep_toggle.isChecked() is False
+    assert changes == [False]
 
     # Click the title label to expand the panel again
     qtbot.mouseClick(panel._ep_label, QtMouseLeft)
     assert panel.isExpanded() is True
     assert panel._ep_widget.isVisible() is True
     assert panel._ep_toggle.isChecked() is True
+    assert changes == [False, True]
 
-    # Set the expanded state directly
+    # Set the expanded state directly, which must also update the toggle
+    # button so its icon stays in sync with the actual state
     panel.setExpanded(False)
     assert panel.isExpanded() is False
     assert panel._ep_widget.isVisible() is False
     assert panel._ep_toggle.isChecked() is False
+    assert changes == [False, True, False]
 
     panel.setExpanded(True)
     assert panel.isExpanded() is True
     assert panel._ep_widget.isVisible() is True
     assert panel._ep_toggle.isChecked() is True
+    assert changes == [False, True, False, True]
 
-    # Setting the same state again should not change anything
+    # Setting the same state again should not change anything, or emit
     panel.setExpanded(True)
     assert panel.isExpanded() is True
     assert panel._ep_widget.isVisible() is True
+    assert changes == [False, True, False, True]
+
+    # The internal slot itself also guards against a redundant state,
+    # regardless of how it is invoked
+    panel._toggleExpanded(True)
+    assert panel.isExpanded() is True
+    assert changes == [False, True, False, True]
 
     # Update the theme
     panel.updateTheme()

--- a/tests/extensions/test_expandpanel.py
+++ b/tests/extensions/test_expandpanel.py
@@ -1,0 +1,88 @@
+"""
+novelWriter – ExpandPanel Extension Tests
+=========================================
+
+This file is a part of novelWriter
+Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""  # noqa
+
+from __future__ import annotations
+
+import pytest
+
+from PyQt6.QtWidgets import QLabel, QVBoxLayout
+
+from novelwriter.extensions.expandpanel import NExpandablePanel
+from novelwriter.types import QtMouseLeft
+
+from tests.helpers import SimpleDialog
+
+
+@pytest.mark.gui
+def testNExpandablePanel_Main(qtbot, mockGUI):
+    """Test the NExpandablePanel class."""
+    dialog = SimpleDialog()
+    panel = NExpandablePanel(dialog)
+    dialog.addWidget(panel)
+    dialog.show()
+    qtbot.addWidget(dialog)
+
+    # Default state is expanded, with a default title
+    assert panel.isExpanded() is True
+    assert panel._ep_widget.isVisible() is True
+    assert panel._ep_toggle.isChecked() is True
+    assert panel._ep_label.text() == "Unnamed"
+
+    # Set a title
+    panel.setTitle("My Panel")
+    assert panel._ep_label.text() == "My Panel"
+
+    # Set the content layout
+    content = QVBoxLayout()
+    content.addWidget(QLabel("Some content", panel))
+    panel.setContentLayout(content)
+    assert panel._ep_widget.layout() is content
+
+    # Click the toggle button to collapse the panel
+    qtbot.mouseClick(panel._ep_toggle, QtMouseLeft)
+    assert panel.isExpanded() is False
+    assert panel._ep_widget.isVisible() is False
+    assert panel._ep_toggle.isChecked() is False
+
+    # Click the title label to expand the panel again
+    qtbot.mouseClick(panel._ep_label, QtMouseLeft)
+    assert panel.isExpanded() is True
+    assert panel._ep_widget.isVisible() is True
+    assert panel._ep_toggle.isChecked() is True
+
+    # Set the expanded state directly
+    panel.setExpanded(False)
+    assert panel.isExpanded() is False
+    assert panel._ep_widget.isVisible() is False
+    assert panel._ep_toggle.isChecked() is False
+
+    panel.setExpanded(True)
+    assert panel.isExpanded() is True
+    assert panel._ep_widget.isVisible() is True
+    assert panel._ep_toggle.isChecked() is True
+
+    # Setting the same state again should not change anything
+    panel.setExpanded(True)
+    assert panel.isExpanded() is True
+    assert panel._ep_widget.isVisible() is True
+
+    # Update the theme
+    panel.updateTheme()

--- a/tests/gui/test_itemdetails.py
+++ b/tests/gui/test_itemdetails.py
@@ -1,0 +1,123 @@
+"""
+novelWriter – GUI Item Details Tests
+====================================
+
+This file is a part of novelWriter
+Copyright (C) 2026 Veronica Berglyd Olsen and novelWriter contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""  # noqa
+
+from __future__ import annotations
+
+import pytest
+
+from novelwriter import SHARED
+from novelwriter.common import elide
+from novelwriter.constants import nwLabels, trConst
+from novelwriter.enum import nwChange
+
+from tests.helpers import C, buildTestProject
+
+
+@pytest.mark.gui
+def testGuiItemDetails_Display(qtbot, nwGUI, projPath, mockRnd):
+    """Test that the details panel displays the data of the currently
+    selected item, and updates or clears it as expected.
+    """
+    buildTestProject(nwGUI, projPath)
+    itemDetails = nwGUI.itemDetails
+    tree = SHARED.project.tree
+
+    # A document item populates all the fields
+    chapter = tree[C.hChapterDoc]
+    assert chapter is not None
+
+    itemDetails.updateViewBox(C.hChapterDoc)
+    assert itemDetails.labelData.text() == elide(chapter.itemName, 100)
+    assert itemDetails.statusData.text() == chapter.getImportStatus()[0]
+    assert itemDetails.classData.text() == trConst(nwLabels.CLASS_NAME[chapter.itemClass])
+    assert itemDetails.usageData.text() == chapter.describeMe()
+    assert itemDetails.cCountData.text() == f"{chapter.charCount:n}"
+    assert itemDetails.wCountData.text() == f"{chapter.wordCount:n}"
+    assert itemDetails.pCountData.text() == f"{chapter.paraCount:n}"
+
+    # A non-file item shows dashes for the counts instead
+    folder = tree[C.hChapterDir]
+    assert folder is not None
+    assert folder.isFileType() is False
+
+    itemDetails.updateViewBox(C.hChapterDir)
+    assert itemDetails.labelData.text() == elide(folder.itemName, 100)
+    assert itemDetails.cCountData.text() == "–"
+    assert itemDetails.wCountData.text() == "–"
+    assert itemDetails.pCountData.text() == "–"
+
+    # An invalid handle clears the details instead
+    itemDetails.updateViewBox(C.hInvalid)
+    assert itemDetails.labelData.text() == ""
+    assert itemDetails.cCountData.text() == ""
+
+    # A project item change for a different handle is ignored
+    itemDetails.updateViewBox(C.hChapterDoc)
+    itemDetails.onProjectItemChanged(C.hSceneDoc, nwChange.UPDATE)
+    assert itemDetails.labelData.text() == elide(chapter.itemName, 100)
+
+    # A create change for the current handle is not acted upon
+    itemDetails.onProjectItemChanged(C.hChapterDoc, nwChange.CREATE)
+    assert itemDetails.labelData.text() == elide(chapter.itemName, 100)
+
+    # A project item change for the currently viewed handle refreshes it
+    itemDetails.onProjectItemChanged(C.hChapterDoc, nwChange.UPDATE)
+    assert itemDetails.labelData.text() == elide(chapter.itemName, 100)
+
+    itemDetails.onProjectItemChanged(C.hChapterDoc, nwChange.DELETE)
+    assert itemDetails.labelData.text() == ""
+
+    # Explicitly requesting a refresh reloads the current handle
+    itemDetails.updateViewBox(C.hChapterDoc)
+    itemDetails.refreshDetails()
+    assert itemDetails.labelData.text() == elide(chapter.itemName, 100)
+
+
+@pytest.mark.gui
+def testGuiItemDetails_DelayedRefresh(qtbot, nwGUI, projPath, mockRnd):
+    """Test that the details panel does not refresh its content while
+    collapsed, and instead applies the pending update once expanded.
+    """
+    buildTestProject(nwGUI, projPath)
+    itemDetails = nwGUI.itemDetails
+    chapter = SHARED.project.tree[C.hChapterDoc]
+    assert chapter is not None
+
+    # Populate the panel while expanded, then collapse it
+    itemDetails.updateViewBox(C.hChapterDoc)
+    assert itemDetails.labelData.text() == elide(chapter.itemName, 100)
+
+    itemDetails.setExpanded(False)
+    assert itemDetails.isExpanded() is False
+
+    # While collapsed, an update is deferred rather than applied
+    scene = SHARED.project.tree[C.hSceneDoc]
+    assert scene is not None
+
+    itemDetails.updateViewBox(C.hSceneDoc)
+    assert itemDetails._refresh == {"handle": C.hSceneDoc}
+    assert itemDetails.labelData.text() == elide(chapter.itemName, 100)
+
+    # Expanding the panel applies the deferred update
+    itemDetails.setExpanded(True)
+    assert itemDetails.isExpanded() is True
+    assert itemDetails._refresh is None
+    assert itemDetails.labelData.text() == elide(scene.itemName, 100)


### PR DESCRIPTION
**Summary:**

This PR adds a new custom widget, an expandable panel, and uses it for the details panel below the project/novel/search view.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
