### PR TITLE
Fix font loading on older Qt versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,11 @@ ToC.txt
 /prof/
 /htmlcov/
 /tests/temp
+/tests/_temp
 /tests/lipsum/cache
 /tests/lipsum/meta
+/tests/_lipsum/cache
+/tests/_lipsum/meta
 /.pytest_cache
 /pytestdebug.log
 

--- a/novelwriter/config.py
+++ b/novelwriter/config.py
@@ -534,7 +534,10 @@ class Config:
             self.guiFont = fontMatcher(value)
         elif value and isinstance(value, str):
             font = QFont()
-            font.fromString(value)
+            if self.checkMinQtVersion(0x060B00):  # Qt 6.11+
+                font.fromString(value)
+            else:
+                font.fromString(",".join(value.split(",")[:16]))
             self.guiFont = fontMatcher(font)
         else:
             font = QFont()
@@ -556,7 +559,10 @@ class Config:
             self.textFont = fontMatcher(value)
         elif value and isinstance(value, str):
             font = QFont()
-            font.fromString(value)
+            if self.checkMinQtVersion(0x060B00):  # Qt 6.11+
+                font.fromString(value)
+            else:
+                font.fromString(",".join(value.split(",")[:16]))
             self.textFont = fontMatcher(font)
         else:
             fontFam = QFontDatabase.families()


### PR DESCRIPTION
**Summary:**

This PR fixes loading a font setting saved with Qt 6.11 and loaded on earlier Qt versions. The string serialisation format changed in 6.11, so older versions cannot parse it.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
