### PR TITLE
Cleanup of main GUI return key handling

### DIFF
--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -26,9 +26,10 @@ import logging
 from enum import Enum
 
 from PyQt6.QtCore import QModelIndex, QPoint, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QActionGroup, QPainter, QPalette, QResizeEvent
+from PyQt6.QtGui import QActionGroup, QPainter, QPalette, QResizeEvent, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QFrame,
     QHBoxLayout,
     QInputDialog,
@@ -47,7 +48,15 @@ from novelwriter.extensions.modified import NIconToolButton, NTreeView
 from novelwriter.extensions.novelselector import NovelSelector
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.models.novelmodel import NovelModel
-from novelwriter.types import QtHeaderStretch, QtHeaderToContents, QtScrollAlwaysOff, QtScrollAsNeeded, QtSizeExpanding
+from novelwriter.types import (
+    QtHeaderStretch,
+    QtHeaderToContents,
+    QtModShift,
+    QtScrollAlwaysOff,
+    QtScrollAsNeeded,
+    QtSizeExpanding,
+    QtWidgetShortcut,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +84,12 @@ class GuiNovelView(QWidget):
         self.outerBox.setSpacing(0)
 
         self.setLayout(self.outerBox)
+
+        # Keyboard Shortcuts
+        self.keyOpenItem = QShortcut(self.novelTree)
+        self.keyOpenItem.setKeys(["Return", "Enter", "Shift+Return", "Shift+Enter"])
+        self.keyOpenItem.setContext(QtWidgetShortcut)
+        self.keyOpenItem.activated.connect(self.novelTree.openSelectedItem)
 
         # Function Mappings
         self.setActive = self.novelBar.setActive
@@ -482,6 +497,18 @@ class GuiNovelTree(NTreeView):
         """Process size changed."""
         super().resizeEvent(event)
         self.resizeColumns()
+
+    ##
+    #  Public Slots
+    ##
+
+    @pyqtSlot()
+    def openSelectedItem(self) -> None:
+        """Open the currently selected item, or view it if Shift is held."""
+        index = self.currentIndex()
+        if (model := self._getModel()) and (tHandle := model.handle(index)) and (sTitle := model.key(index)):
+            mode = nwDocMode.VIEW if QApplication.keyboardModifiers() == QtModShift else nwDocMode.EDIT
+            self.novelView.openDocumentRequest.emit(tHandle, mode, sTitle, False)
 
     ##
     #  Private Slots

--- a/novelwriter/gui/outline.py
+++ b/novelwriter/gui/outline.py
@@ -29,9 +29,10 @@ from time import time
 from typing import Final
 
 from PyQt6.QtCore import QT_TRANSLATE_NOOP, Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QAction, QIcon
+from PyQt6.QtGui import QAction, QIcon, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QFileDialog,
     QFrame,
     QGridLayout,
@@ -61,10 +62,12 @@ from novelwriter.types import (
     QtAlignRight,
     QtAlignRightTop,
     QtDecorationRole,
+    QtModShift,
     QtScrollAlwaysOff,
     QtScrollAsNeeded,
     QtSizeExpanding,
     QtUserRole,
+    QtWidgetShortcut,
 )
 
 logger = logging.getLogger(__name__)
@@ -98,6 +101,12 @@ class GuiOutlineView(QWidget):
         self.outerBox.addWidget(self.splitOutline)
 
         self.setLayout(self.outerBox)
+
+        # Keyboard Shortcuts
+        self.keyOpenItem = QShortcut(self.outlineTree)
+        self.keyOpenItem.setKeys(["Return", "Enter", "Shift+Return", "Shift+Enter"])
+        self.keyOpenItem.setContext(QtWidgetShortcut)
+        self.keyOpenItem.activated.connect(self.outlineTree.openSelectedItem)
 
         # Connect Signals
         self.outlineTree.hiddenStateChanged.connect(self._updateMenuColumns)
@@ -520,6 +529,14 @@ class GuiOutlineTree(QTreeWidget):
     ##
     #  Public Slots
     ##
+
+    @pyqtSlot()
+    def openSelectedItem(self) -> None:
+        """Open the currently selected item, or view it if Shift is held."""
+        tHandle, sTitle = self.getSelectedHandle()
+        if tHandle:
+            mode = nwDocMode.VIEW if QApplication.keyboardModifiers() == QtModShift else nwDocMode.EDIT
+            self.outlineView.openDocumentRequest.emit(tHandle, mode, sTitle or "", False)
 
     @pyqtSlot(bool, Enum)
     def menuColumnToggled(self, isChecked: bool, hItem: nwOutline) -> None:

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -29,6 +29,7 @@ from PyQt6.QtCore import QModelIndex, QPoint, Qt, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QAction, QIcon, QMouseEvent, QPainter, QPalette, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
+    QApplication,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -56,6 +57,7 @@ from novelwriter.types import (
     QtHeaderFixed,
     QtHeaderStretch,
     QtHeaderToContents,
+    QtModShift,
     QtMouseLeft,
     QtMouseMiddle,
     QtScrollAlwaysOff,
@@ -131,6 +133,11 @@ class GuiProjectView(QWidget):
         self.keyContext.setKey("Ctrl+.")
         self.keyContext.setContext(QtWidgetShortcut)
         self.keyContext.activated.connect(self.projTree.openContextMenu)
+
+        self.keyOpenItem = QShortcut(self.projTree)
+        self.keyOpenItem.setKeys(["Return", "Enter", "Shift+Return", "Shift+Enter"])
+        self.keyOpenItem.setContext(QtWidgetShortcut)
+        self.keyOpenItem.activated.connect(self.projTree.openSelectedItem)
 
         # Signals
         self.selectedItemChanged.connect(self.projBar.treeSelectionChanged)
@@ -821,6 +828,13 @@ class GuiProjectTree(QTreeView):
     ##
     #  Public Slots
     ##
+
+    @pyqtSlot()
+    def openSelectedItem(self) -> None:
+        """Open the currently selected file, or view it if Shift is held."""
+        if (node := self._getNode(self.currentIndex())) and node.item.isFileType():
+            mode = nwDocMode.VIEW if QApplication.keyboardModifiers() == QtModShift else nwDocMode.EDIT
+            self.projView.openDocumentRequest.emit(node.item.itemHandle, mode, "", False)
 
     @pyqtSlot()
     def moveItemUp(self) -> None:

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -28,7 +28,7 @@ from time import time
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QModelIndex, QRect, Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QAction, QCursor, QKeyEvent, QPainter, QPalette
+from PyQt6.QtGui import QAction, QCursor, QKeyEvent, QPainter, QPalette, QShortcut
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QApplication,
@@ -65,6 +65,7 @@ from novelwriter.types import (
     QtModShift,
     QtSelected,
     QtUserRole,
+    QtWidgetShortcut,
 )
 
 if TYPE_CHECKING:
@@ -141,6 +142,7 @@ class GuiProjectSearch(QWidget):
         self.searchText.setPlaceholderText(self.tr("Search for"))
         self.searchText.setClearButtonEnabled(True)
         self.searchText.addAction(self.searchAction, QLineEdit.ActionPosition.TrailingPosition)
+        self.searchText.returnPressed.connect(self._processSearch)
 
         # Search Filters
         self.searchFilters = _SearchFilters(self)
@@ -170,6 +172,12 @@ class GuiProjectSearch(QWidget):
 
         if selModel := self.searchResult.selectionModel():  # pragma: no branch
             selModel.currentChanged.connect(self._searchResultSelected)
+
+        # Keyboard Shortcuts
+        self.keyOpenResult = QShortcut(self.searchResult)
+        self.keyOpenResult.setKeys(["Return", "Enter", "Shift+Return", "Shift+Enter"])
+        self.keyOpenResult.setContext(QtWidgetShortcut)
+        self.keyOpenResult.activated.connect(self._openSelectedResult)
 
         # Assemble
         self.headerBox = QHBoxLayout()
@@ -234,17 +242,6 @@ class GuiProjectSearch(QWidget):
             self.tbCase.refreshTheme()
             self.tbWord.refreshTheme()
             self.tbRegEx.refreshTheme()
-
-    def processReturn(self) -> None:
-        """Process a return keypress forwarded from the main GUI."""
-        if self.searchText.hasFocus():
-            self._processSearch()
-        elif self.searchResult.hasFocus() and (result := self._model.result(self.searchResult.currentIndex())):
-            handle, start, length = result
-            if QApplication.keyboardModifiers() == QtModShift:
-                self.openDocumentRequest.emit(handle, nwDocMode.VIEW, "", True)
-            else:
-                self.openDocumentSelectRequest.emit(handle, start, length, False)
 
     def beginSearch(self, text: str = "") -> None:
         """Focus the search box and select its text, if any."""
@@ -315,6 +312,16 @@ class GuiProjectSearch(QWidget):
     ##
     #  Private Slots
     ##
+
+    @pyqtSlot()
+    def _openSelectedResult(self) -> None:
+        """Open the currently selected search result."""
+        if result := self._model.result(self.searchResult.currentIndex()):
+            handle, start, length = result
+            if QApplication.keyboardModifiers() == QtModShift:
+                self.openDocumentRequest.emit(handle, nwDocMode.VIEW, "", True)
+            else:
+                self.openDocumentSelectRequest.emit(handle, start, length, False)
 
     @pyqtSlot()
     def _processSearch(self) -> None:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -50,7 +50,7 @@ from novelwriter.dialogs.preferences import GuiNeedsUpdate, GuiPreferences
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
 from novelwriter.dialogs.wordlist import GuiWordList
 from novelwriter.editor.editor import GuiDocEditor
-from novelwriter.enum import nwDocAction, nwDocInsert, nwDocMode, nwFocus, nwItemType, nwView
+from novelwriter.enum import nwDocAction, nwDocInsert, nwDocMode, nwFocus, nwView
 from novelwriter.extensions.progressbars import NProgressSimple
 from novelwriter.gui.itemdetails import GuiItemDetails
 from novelwriter.gui.mainmenu import GuiMainMenu
@@ -65,7 +65,6 @@ from novelwriter.tools.dictionaries import GuiDictionaries
 from novelwriter.tools.noveldetails import GuiNovelDetails
 from novelwriter.tools.welcome import GuiWelcome
 from novelwriter.tools.writingstats import GuiWritingStats
-from novelwriter.types import QtModShift
 from novelwriter.viewer.viewer import GuiDocViewer
 from novelwriter.viewer.viewerpanel import GuiDocViewerPanel
 
@@ -685,30 +684,19 @@ class GuiMain(QMainWindow):
 
     @pyqtSlot()
     def openSelectedItem(self) -> None:
-        """Open the selected item from the tree that is currently
-        active. It is not checked that the item is actually a document.
-        That should be handled by the openDocument function.
+        """Open the selected item in the tree view that is currently
+        active. Used by the main menu's Open Document action to forward
+        the request to whichever tree widget is visible.
         """
         if SHARED.hasProject:
-            tHandle = None
-            sTitle = None
             if self.projView.treeHasFocus():
-                tHandle = self.projView.getSelectedHandle()
+                self.projView.projTree.openSelectedItem()
             elif self.novelView.treeHasFocus():
-                tHandle, sTitle = self.novelView.getSelectedHandle()
+                self.novelView.novelTree.openSelectedItem()
             elif self.outlineView.treeHasFocus():
-                tHandle, sTitle = self.outlineView.getSelectedHandle()
+                self.outlineView.outlineTree.openSelectedItem()
             else:
                 logger.warning("No item selected")
-                return
-
-            if tHandle and SHARED.project.tree.checkType(tHandle, nwItemType.FILE):
-                if QApplication.keyboardModifiers() == QtModShift:
-                    self.viewDocument(tHandle)
-                else:
-                    self.openDocument(tHandle, sTitle=sTitle, changeFocus=False, doScroll=False)
-
-        return
 
     def rebuildIndex(self) -> None:
         """Rebuild the entire index."""

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from time import time
 
 from PyQt6.QtCore import QEvent, Qt, QTimer, pyqtSlot
-from PyQt6.QtGui import QCloseEvent, QCursor, QIcon, QShortcut
+from PyQt6.QtGui import QCloseEvent, QCursor, QIcon
 from PyQt6.QtWidgets import (
     QApplication,
     QFileDialog,
@@ -299,11 +299,6 @@ class GuiMain(QMainWindow):
         # Set Up Auto-Save Document Timer
         self.asDocTimer = QTimer(self)
         self.asDocTimer.timeout.connect(self._autoSaveDocument)
-
-        # Shortcuts
-        self.keyReturn = QShortcut(self)
-        self.keyReturn.setKeys(["Return", "Enter", "Shift+Return", "Shift+Enter"])
-        self.keyReturn.activated.connect(self._keyPressReturn)
 
         # Initialise Main GUI
         self.initMain()
@@ -1262,14 +1257,6 @@ class GuiMain(QMainWindow):
                     cTotal = SHARED.project.data.currCounts[0]
 
             self.mainStatus.setProjectStats(cTotal, cTotal - iTotal)
-
-    @pyqtSlot()
-    def _keyPressReturn(self) -> None:
-        """Process a return or enter keypress in the main window."""
-        if self.projStack.currentWidget() == self.projSearch:
-            self.projSearch.processReturn()
-        else:
-            self.openSelectedItem()
 
     @pyqtSlot(int)
     def _mainStackChanged(self, index: int) -> None:

--- a/tests/gui/test_search.py
+++ b/tests/gui/test_search.py
@@ -40,7 +40,7 @@ from tests.helpers import C, buildTestProject
 
 
 @pytest.mark.gui
-def testGuiProjectSearch_Interaction(qtbot, monkeypatch, nwGUI, fncPath, mockRnd, ipsumText):
+def testGuiProjectSearch_Interaction(qtbot, nwGUI, fncPath, mockRnd, ipsumText):
     """Test running a search and interacting with the result tree via
     the keyboard, mouse and selection.
     """
@@ -62,7 +62,7 @@ def testGuiProjectSearch_Interaction(qtbot, monkeypatch, nwGUI, fncPath, mockRnd
 
     # Pressing return while the search box has focus re-runs the search
     search.searchText.setFocus()
-    search.processReturn()
+    qtbot.keyClick(search.searchText, QtKeyReturn)
     assert model.rowCount(root) == 2
 
     chapterIdx = model.index(0, 0, root)
@@ -101,15 +101,13 @@ def testGuiProjectSearch_Interaction(qtbot, monkeypatch, nwGUI, fncPath, mockRnd
 
     # Press return on the selected match to open it at its position
     search.searchResult.setFocus()
-    with monkeypatch.context() as mp:
-        mp.setattr(search.searchResult, "hasFocus", lambda *a: True)
-        with qtbot.waitSignal(search.openDocumentSelectRequest, timeout=1000) as signal:
-            qtbot.keyClick(search, QtKeyReturn)
-        assert signal.args == [handle, start, length, False]
+    with qtbot.waitSignal(search.openDocumentSelectRequest, timeout=1000) as signal:
+        qtbot.keyClick(search.searchResult, QtKeyReturn)
+    assert signal.args == [handle, start, length, False]
 
-        with qtbot.waitSignal(search.openDocumentRequest, timeout=1000) as signal:
-            qtbot.keyClick(search, QtKeyReturn, Qt.KeyboardModifier.ShiftModifier)
-        assert signal.args == [handle, nwDocMode.VIEW, "", True]
+    with qtbot.waitSignal(search.openDocumentRequest, timeout=1000) as signal:
+        qtbot.keyClick(search.searchResult, QtKeyReturn, Qt.KeyboardModifier.ShiftModifier)
+    assert signal.args == [handle, nwDocMode.VIEW, "", True]
 
     assert nwGUI.docEditor.docHandle == handle
 
@@ -124,10 +122,9 @@ def testGuiProjectSearch_Interaction(qtbot, monkeypatch, nwGUI, fncPath, mockRnd
 
     # Press return with no selection does nothing
     search.searchResult.setCurrentIndex(QModelIndex())
-    with monkeypatch.context() as mp:
-        mp.setattr(search.searchResult, "hasFocus", lambda *a: True)
-        with qtbot.assertNotEmitted(search.openDocumentSelectRequest):
-            qtbot.keyClick(search, QtKeyReturn)
+    search.searchResult.setFocus()
+    with qtbot.assertNotEmitted(search.openDocumentSelectRequest):
+        qtbot.keyClick(search.searchResult, QtKeyReturn)
 
 
 @pytest.mark.gui

--- a/tests/test_guimain.py
+++ b/tests/test_guimain.py
@@ -43,7 +43,7 @@ from novelwriter.editor.editor import GuiDocEditor
 from novelwriter.enum import nwDocAction, nwDocMode, nwFocus, nwItemClass, nwItemType, nwState, nwTheme, nwView
 from novelwriter.gui.noveltree import GuiNovelView
 from novelwriter.gui.outline import GuiOutlineView
-from novelwriter.gui.projtree import GuiProjectTree
+from novelwriter.gui.projtree import GuiProjectTree, GuiProjectView
 from novelwriter.guimain import GuiMain
 from novelwriter.manuscript.manuscript import GuiManuscript
 from novelwriter.shared import _GuiAlert
@@ -230,9 +230,11 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     nwGUI.projStack.setCurrentIndex(0)
     with monkeypatch.context() as mp:
         mp.setattr(GuiProjectTree, "hasFocus", lambda *a: True)
+        mp.setattr(GuiNovelView, "treeHasFocus", lambda *a: False)
+        mp.setattr(GuiOutlineView, "treeHasFocus", lambda *a: False)
         assert nwGUI.docEditor.docHandle is None
         nwGUI.projView.projTree.setSelectedHandle(sHandle)
-        nwGUI._keyPressReturn()
+        nwGUI.projView.projTree.openSelectedItem()
         assert nwGUI.docEditor.docHandle == sHandle
         nwGUI.closeDocument()
 
@@ -244,24 +246,57 @@ def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     # Novel Tree has focus
     nwGUI._changeView(nwView.NOVEL)
     with monkeypatch.context() as mp:
+        mp.setattr(GuiProjectView, "treeHasFocus", lambda *a: False)
         mp.setattr(GuiNovelView, "treeHasFocus", lambda *a: True)
         assert nwGUI.docEditor.docHandle is None
+
         model = nwGUI.novelView.novelTree._getModel()
         assert model is not None
+
+        # No selection is ignored
+        nwGUI.novelView.novelTree.setCurrentIndex(model.createIndex(9999, 0))
+        nwGUI.novelView.novelTree.openSelectedItem()
+        assert nwGUI.docEditor.docHandle is None
+
         nwGUI.novelView.novelTree.setCurrentIndex(model.createIndex(2, 0))
-        nwGUI._keyPressReturn()
+        nwGUI.novelView.novelTree.openSelectedItem()
         assert nwGUI.docEditor.docHandle == sHandle
         nwGUI.closeDocument()
+
+        # The main GUI dispatcher also routes to the novel tree
+        nwGUI.openSelectedItem()
+        assert nwGUI.docEditor.docHandle == sHandle
+        nwGUI.closeDocument()
+
+        # ... and to viewing the document when Shift is held
+        with monkeypatch.context() as mpShift:
+            mpShift.setattr(QApplication, "keyboardModifiers", lambda: QtModShift)
+            nwGUI.openSelectedItem()
+        assert nwGUI.docViewer.docHandle == sHandle
+        nwGUI.closeDocViewer()
 
     # Project Outline has focus
     nwGUI._changeView(nwView.OUTLINE)
     nwGUI._switchFocus(nwFocus.OUTLINE)
     with monkeypatch.context() as mp:
+        mp.setattr(GuiProjectView, "treeHasFocus", lambda *a: False)
+        mp.setattr(GuiNovelView, "treeHasFocus", lambda *a: False)
         mp.setattr(GuiOutlineView, "treeHasFocus", lambda *a: True)
         assert nwGUI.docEditor.docHandle is None
+
+        # No selection is ignored
+        nwGUI.outlineView.outlineTree.clearSelection()
+        nwGUI.outlineView.outlineTree.openSelectedItem()
+        assert nwGUI.docEditor.docHandle is None
+
         selItem = nwGUI.outlineView.outlineTree.topLevelItem(2)
         nwGUI.outlineView.outlineTree.setCurrentItem(selItem)
-        nwGUI._keyPressReturn()
+        nwGUI.outlineView.outlineTree.openSelectedItem()
+        assert nwGUI.docEditor.docHandle == sHandle
+        nwGUI.closeDocument()
+
+        # The main GUI dispatcher also routes to the outline tree
+        nwGUI.openSelectedItem()
         assert nwGUI.docEditor.docHandle == sHandle
         nwGUI.closeDocument()
 
@@ -807,9 +842,8 @@ def testGuiMain_Viewing(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     nwGUI.closeDocViewer()
     assert nwGUI.docViewer.docHandle is None
     nwGUI.projView.setSelectedHandle(C.hSceneDoc)
-    with monkeypatch.context() as mp:
-        mp.setattr(nwGUI.projView.projTree, "hasFocus", lambda *a: True)
-        qtbot.keyClick(nwGUI.projView.projTree, QtKeyReturn, modifier=QtModShift, delay=KEY_DELAY)
+    nwGUI.projView.projTree.setFocus()
+    qtbot.keyClick(nwGUI.projView.projTree, QtKeyReturn, modifier=QtModShift, delay=KEY_DELAY)
     assert nwGUI.docViewer.docHandle == C.hSceneDoc
 
     # If the viewer fails to load the document, nothing else happens


### PR DESCRIPTION
**Summary:**

This is just an internal code cleanup that moves the handling of return key presses into the GUI classes that they are used for. Previously, the main GUI class controlled these keypresses.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
