### PR TITLE
Apply line height on paste

### DIFF
--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -1412,11 +1412,19 @@ class GuiDocEditor(QTextEdit):
         return super().inputMethodQuery(query)
 
     def insertFromMimeData(self, source: QMimeData | None) -> None:
-        """Overload mime data insertion in the document."""
+        """Overload mime data insertion in the document.
+
+        * Blocks empty inserts, see #2598
+        * Ensures line height is applied, see #2874
+        """
         if source and source.hasText():
-            # Block empty inserts (Issue #2598)
             logger.debug("Inserted text into document")
-            super().insertFromMimeData(source)
+            cursor = self.textCursor()
+            cursor.beginEditBlock()
+            cursor.insertText(source.text())
+            cursor.endEditBlock()
+            self.setTextCursor(cursor)
+            self.ensureCursorVisible(centre=False)
 
     ##
     #  Public Slots

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -2847,9 +2847,7 @@ def testGuiDocEditor_LineHeightPaste(qtbot, nwGUI, projPath, mockRnd):
     mime.setText("Pasted first line.\nPasted second line.\nPasted third line.")
     docEditor.insertFromMimeData(mime)
 
-    assert docEditor.getText().startswith(
-        "Pasted first line.\nPasted second line.\nPasted third line."
-    )
+    assert docEditor.getText().startswith("Pasted first line.\nPasted second line.\nPasted third line.")
     assert allBlocksHaveLineHeight(150)
 
 

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -2820,6 +2820,40 @@ def testGuiDocEditor_LineHeight(qtbot, nwGUI, projPath, mockRnd):
 
 
 @pytest.mark.gui
+def testGuiDocEditor_LineHeightPaste(qtbot, nwGUI, projPath, mockRnd):
+    """Test that pasting multi-line text keeps the configured line
+    height on every resulting block, including the ones created after
+    a line break in the pasted text (Issue #2874).
+    """
+    buildTestProject(NWProject(), projPath)
+    nwGUI.openProject(projPath)
+    docEditor = nwGUI.docEditor
+    document = docEditor.document()
+
+    def allBlocksHaveLineHeight(height: int) -> bool:
+        block = document.firstBlock()
+        while block.isValid():
+            if block.blockFormat().lineHeight() != height:
+                return False
+            block = block.next()
+        return True
+
+    CONFIG.lineHeight = 1.50
+    assert docEditor.loadText(C.hSceneDoc) is True
+    assert allBlocksHaveLineHeight(150)
+
+    docEditor.setCursorPosition(0)
+    mime = QMimeData()
+    mime.setText("Pasted first line.\nPasted second line.\nPasted third line.")
+    docEditor.insertFromMimeData(mime)
+
+    assert docEditor.getText().startswith(
+        "Pasted first line.\nPasted second line.\nPasted third line."
+    )
+    assert allBlocksHaveLineHeight(150)
+
+
+@pytest.mark.gui
 def testGuiDocEditor_LineHeightDoubleReturn(qtbot, nwGUI, projPath, mockRnd):
     """Test that a blank-line paragraph break (two consecutive Return
     presses) works normally with a non-default line height set on


### PR DESCRIPTION
**Summary:**

This PR fixes an issue where the line height was only applied to the first line of pasted text.

**Related Issue(s):**

Closes #2874

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
