### PR TITLE
Fix styles issues

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -92,7 +92,7 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
 
     # Valid Input Options
     shortOpt = "hvidc"
-    longOpt = ["help", "version", "info", "debug", "color", "style=", "config=", "data=", "meminfo"]
+    longOpt = ["help", "version", "info", "debug", "color", "config=", "data=", "meminfo"]
 
     helpMsg = (
         f"novelWriter {__version__} ({__date__})\n"
@@ -118,7 +118,6 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
         " -d, --debug    Print debug output. Includes --info.\n"
         " -c, --color    Add ANSI colors to log output.\n"
         "     --meminfo  Show memory usage information in the status bar.\n"
-        "     --style=   Sets Qt style flag. Defaults to 'Fusion'.\n"
         "     --config=  Alternative config file.\n"
         "     --data=    Alternative user data path.\n"
     )
@@ -129,7 +128,6 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     fmtLong = False
     confPath = None
     dataPath = None
-    qtStyle = "Fusion"
     cmdOpen = None
 
     # Parse Options
@@ -160,8 +158,6 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
             fmtColor = not NO_COLOR
         elif inOpt == "--meminfo":
             CONFIG.memInfo = True
-        elif inOpt == "--style":
-            qtStyle = inArg
         elif inOpt == "--config":
             confPath = inArg
         elif inOpt == "--data":
@@ -250,7 +246,7 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     from novelwriter.guimain import GuiMain
 
     # Create App
-    app = _createApp(qtStyle)
+    app = _createApp()
 
     # Connect the exception handler before making the main GUI
     sys.excepthook = exceptionHandler
@@ -279,12 +275,12 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
     sys.exit(app.exec())
 
 
-def _createApp(style: str) -> QApplication:
+def _createApp() -> QApplication:
     """Create the app. This is done in a function to make it easier to
     block app creation during testing.
     """
     app = QApplication([CONFIG.appName])
-    app.setStyle(style)
+    app.setStyle("Fusion")
     app.setApplicationName(CONFIG.appName)
     app.setApplicationVersion(__version__)
     app.setOrganizationDomain(__domain__)

--- a/novelwriter/dialogs/about.py
+++ b/novelwriter/dialogs/about.py
@@ -25,7 +25,8 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from PyQt6.QtWidgets import QDialogButtonBox, QHBoxLayout, QLabel, QTextBrowser, QVBoxLayout, QWidget
+from PyQt6.QtGui import QPalette
+from PyQt6.QtWidgets import QDialogButtonBox, QFrame, QHBoxLayout, QLabel, QTextBrowser, QVBoxLayout, QWidget
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatLink, readTextFile
@@ -33,7 +34,7 @@ from novelwriter.enum import nwStandardButton
 from novelwriter.extensions.configlayout import NColorLabel
 from novelwriter.extensions.modified import NDialog
 from novelwriter.extensions.versioninfo import VersionInfoWidget
-from novelwriter.types import QtAlignRightTop, QtHexArgb, QtRoleDestruct
+from novelwriter.types import QtAlignRightTop, QtRoleDestruct
 
 if TYPE_CHECKING:
     from PyQt6.QtGui import QCloseEvent
@@ -52,6 +53,10 @@ class GuiAbout(NDialog):
 
         self.setWindowTitle(self.tr("About novelWriter"))
         self.resize(700, 500)
+
+        baseCol = self.palette().window().color()
+        basePalette = self.palette()
+        basePalette.setColor(QPalette.ColorRole.Base, baseCol)
 
         # Logo and Banner
         self.nwImage = SHARED.theme.getDecoration("nw-text", h=36)
@@ -77,6 +82,8 @@ class GuiAbout(NDialog):
 
         self.txtCredits = QTextBrowser(self)
         self.txtCredits.setOpenExternalLinks(True)
+        self.txtCredits.setFrameStyle(QFrame.Shape.NoFrame)
+        self.txtCredits.setPalette(basePalette)
         self.txtCredits.setViewportMargins(0, 8, 8, 0)
 
         # Buttons
@@ -106,7 +113,6 @@ class GuiAbout(NDialog):
         self.setLayout(self.outerBox)
         self.setSizeGripEnabled(True)
 
-        self._setStyleSheet()
         self._fillCreditsPage()
 
         logger.debug("Ready: GuiAbout")
@@ -134,8 +140,3 @@ class GuiAbout(NDialog):
             self.txtCredits.setHtml(html)
         else:
             self.txtCredits.setHtml("Error loading credits text ...")
-
-    def _setStyleSheet(self) -> None:
-        """Set stylesheet text document."""
-        baseCol = self.palette().window().color().name(QtHexArgb)
-        self.txtCredits.setStyleSheet(f"QTextBrowser {{border: none; background: {baseCol};}} ")

--- a/novelwriter/editor/editfooter.py
+++ b/novelwriter/editor/editfooter.py
@@ -57,6 +57,9 @@ class GuiDocEditFooter(QWidget):
         self._trLineCount = self.tr("Line: {0} ({1})")
         self._trSelectCount = self.tr("Selected: {0}")
 
+        self._lineNo = -1
+        self._linePc = -1
+
         # Main Widget Settings
         self.setContentsMargins(0, 0, 0, 0)
         self.setAutoFillBackground(True)
@@ -209,10 +212,12 @@ class GuiDocEditFooter(QWidget):
     def updateLineCount(self, cursor: QTextCursor) -> None:
         """Update the line and document position counter."""
         if document := cursor.document():  # pragma: no branch
-            cPos = cursor.position() + 1
-            cLine = cursor.blockNumber() + 1
-            cCount = max(document.characterCount(), 1)
-            self.linesText.setText(self._trLineCount.format(f"{cLine:n}", f"{100 * cPos // cCount:d}\u202f%"))
+            lineNo = cursor.blockNumber() + 1
+            linePc = 100 * (cursor.position() + 1) // max(document.characterCount(), 1)
+            if lineNo != self._lineNo or linePc != self._linePc:
+                self.linesText.setText(self._trLineCount.format(f"{lineNo:n}", f"{linePc:d}\u202f%"))
+                self._lineNo = lineNo
+                self._linePc = linePc
 
     def updateMainCount(self, count: int, selection: bool) -> None:
         """Update main counter information."""

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QEvent, QModelIndex, QSize, Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QPainter, QPaintEvent, QPalette
+from PyQt6.QtGui import QColor, QPainter, QPaintEvent, QPalette
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -39,6 +39,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QSplitter,
     QSplitterHandle,
+    QTabWidget,
     QToolButton,
     QTreeView,
     QWidget,
@@ -380,6 +381,31 @@ class NIconToggleButton(QToolButton):
         """Refresh the icon for theme updates."""
         if self._icon:  # pragma: no branch
             self.setIcon(SHARED.theme.getToggleIcon(self._icon, self._size.width(), self._size.height()))
+
+
+class NTabWidget(QTabWidget):
+    """Custom: Modified QTabWidget.
+
+    A tab widget that highlights the currently selected tab's label
+    using the app theme.
+    """
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent=parent)
+        self.setDocumentMode(True)
+        self.currentChanged.connect(self._updateTabColors)
+
+    def refreshTheme(self) -> None:
+        """Refresh the tab colours for theme updates."""
+        self._updateTabColors(self.currentIndex())
+
+    @pyqtSlot(int)
+    def _updateTabColors(self, index: int) -> None:
+        """Highlight the currently selected tab with the theme highlight colour."""
+        if tabBar := self.tabBar():  # pragma: no branch
+            hCol = self.palette().highlight().color()
+            for i in range(tabBar.count()):
+                tabBar.setTabTextColor(i, hCol if i == index else QColor())
 
 
 class NClickableLabel(QLabel):

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -242,7 +242,7 @@ class GuiProjectSearch(QWidget):
         colBase = palette.base().color().name(QtHexArgb)
         colFocus = palette.highlight().color().name(QtHexArgb)
 
-        self.setStyleSheet(
+        self.searchText.setStyleSheet(
             f"QLineEdit {{border: 1px solid {colBase}; padding: 2px;}} "
             f"QLineEdit:focus {{border: 1px solid {colFocus};}} "
         )

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -66,7 +66,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-STYLES_FLAT_TABS = "flatTabWidget"
 STYLES_MIN_TOOLBUTTON = "minimalToolButton"
 STYLES_BIG_TOOLBUTTON = "bigToolButton"
 
@@ -777,14 +776,6 @@ class GuiTheme:
         text = palette.text().color()
         text.setAlpha(48)
         tCol = text.name(QtHexArgb)
-        hCol = palette.highlight().color().name(QtHexArgb)
-
-        # Flat Tab Widget and Tab Bar:
-        self._styleSheets[STYLES_FLAT_TABS] = (
-            "QTabWidget::pane {border: 0;} "
-            "QTabWidget QTabBar::tab {border: 0; padding: 4px 8px;} "
-            f"QTabWidget QTabBar::tab:selected {{color: {hCol};}} "
-        )
 
         # Minimal Tool Button
         self._styleSheets[STYLES_MIN_TOOLBUTTON] = (

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -48,7 +48,6 @@ from PyQt6.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QSplitter,
-    QTabWidget,
     QTextBrowser,
     QTreeWidget,
     QTreeWidgetItem,
@@ -60,12 +59,12 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatInt, formatPercent, fuzzyTime
 from novelwriter.constants import nwHeadFmt, nwLabels, nwStats, nwUnicode, trStats
 from novelwriter.enum import nwStandardButton
-from novelwriter.extensions.modified import NIconToolButton, NToolDialog
+from novelwriter.extensions.modified import NIconToolButton, NTabWidget, NToolDialog
 from novelwriter.extensions.progressbars import NProgressCircle
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.formats.tokenizer import HeadingFormatter
 from novelwriter.formats.toqdoc import ToQTextDocument
-from novelwriter.gui.theme import STYLES_FLAT_TABS, STYLES_MIN_TOOLBUTTON
+from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.manuscript.buildsettings import BuildCollection, BuildSettings
 from novelwriter.manuscript.docbuild import DocumentBuilder
 from novelwriter.manuscript.manusbuild import GuiManuscriptBuild
@@ -169,7 +168,7 @@ class GuiManuscript(NToolDialog):
         self.buildStats = _StatisticsWidget(self)
         self.buildStats.setExpandedState(SHARED.project.options.getList("GuiManuscript", "statsExpanded", []))
 
-        self.detailsTabs = QTabWidget(self)
+        self.detailsTabs = NTabWidget(self)
         self.detailsTabs.addTab(self.buildDetails, self.tr("Details"))
         self.detailsTabs.addTab(self.buildOutline, self.tr("Outline"))
         self.detailsTabs.addTab(self.buildStats, self.tr("Statistics"))
@@ -303,7 +302,7 @@ class GuiManuscript(NToolDialog):
         self.tbCopy.setStyleSheet(buttonStyle)
         self.tbEdit.setStyleSheet(buttonStyle)
 
-        self.detailsTabs.setStyleSheet(SHARED.theme.getStyleSheet(STYLES_FLAT_TABS))
+        self.detailsTabs.refreshTheme()
 
         self.buildDetails.updateTheme()
         self.buildOutline.updateTheme()

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -266,10 +266,10 @@ class _OpenProjectPage(QWidget):
         super().__init__(parent=parent)
 
         # Panel Background
-        base = self.palette().base().color()
-        base.setAlpha(PANEL_ALPHA)
-        bPalette = self.palette()
-        bPalette.setColor(QPalette.ColorRole.Base, base)
+        baseCol = self.palette().base().color()
+        baseCol.setAlpha(PANEL_ALPHA)
+        basePalette = self.palette()
+        basePalette.setColor(QPalette.ColorRole.Base, baseCol)
 
         # List View
         self.listModel = _ProjectListModel(self)
@@ -280,7 +280,7 @@ class _OpenProjectPage(QWidget):
         self.listWidget.setModel(self.listModel)
         self.listWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.listWidget.setFrameStyle(QFrame.Shape.NoFrame)
-        self.listWidget.setPalette(bPalette)
+        self.listWidget.setPalette(basePalette)
         self.listWidget.clicked.connect(self._projectSelected)
         self.listWidget.doubleClicked.connect(self._projectDoubleClicked)
         self.listWidget.customContextMenuRequested.connect(self._openContextMenu)
@@ -296,7 +296,7 @@ class _OpenProjectPage(QWidget):
         self.selectedPath = QLineEdit(self)
         self.selectedPath.setReadOnly(True)
         self.selectedPath.setFrame(False)
-        self.selectedPath.setPalette(bPalette)
+        self.selectedPath.setPalette(basePalette)
         self.selectedPath.setTextMargins(4, 4, 4, 4)
         self.selectedPath.addAction(self.aMissing, QLineEdit.ActionPosition.TrailingPosition)
         self._trPath = self.tr("Path")

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -28,10 +28,11 @@ from pathlib import Path
 from typing import NamedTuple
 
 from PyQt6.QtCore import QAbstractListModel, QModelIndex, QObject, QPoint, QSize, Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QAction, QCloseEvent, QKeyEvent, QPainter, QPaintEvent, QPen, QShortcut
+from PyQt6.QtGui import QAction, QCloseEvent, QKeyEvent, QPainter, QPaintEvent, QPalette, QPen, QShortcut
 from PyQt6.QtWidgets import (
     QApplication,
     QFormLayout,
+    QFrame,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -59,7 +60,6 @@ from novelwriter.types import (
     QtAlignLeft,
     QtAlignRightTop,
     QtDisplayRole,
-    QtHexArgb,
     QtKeyDown,
     QtKeyEnter,
     QtKeyReturn,
@@ -265,6 +265,12 @@ class _OpenProjectPage(QWidget):
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
+        # Panel Background
+        base = self.palette().base().color()
+        base.setAlpha(PANEL_ALPHA)
+        bPalette = self.palette()
+        bPalette.setColor(QPalette.ColorRole.Base, base)
+
         # List View
         self.listModel = _ProjectListModel(self)
         self.itemDelegate = _ProjectListItem(self)
@@ -273,6 +279,8 @@ class _OpenProjectPage(QWidget):
         self.listWidget.setItemDelegate(self.itemDelegate)
         self.listWidget.setModel(self.listModel)
         self.listWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.listWidget.setFrameStyle(QFrame.Shape.NoFrame)
+        self.listWidget.setPalette(bPalette)
         self.listWidget.clicked.connect(self._projectSelected)
         self.listWidget.doubleClicked.connect(self._projectDoubleClicked)
         self.listWidget.customContextMenuRequested.connect(self._openContextMenu)
@@ -287,6 +295,9 @@ class _OpenProjectPage(QWidget):
 
         self.selectedPath = QLineEdit(self)
         self.selectedPath.setReadOnly(True)
+        self.selectedPath.setFrame(False)
+        self.selectedPath.setPalette(bPalette)
+        self.selectedPath.setTextMargins(4, 4, 4, 4)
         self.selectedPath.addAction(self.aMissing, QLineEdit.ActionPosition.TrailingPosition)
         self._trPath = self.tr("Path")
 
@@ -308,14 +319,6 @@ class _OpenProjectPage(QWidget):
         self.setLayout(self.outerBox)
 
         self._selectFirstItem()
-
-        base = self.palette().base().color()
-        base.setAlpha(PANEL_ALPHA)
-        baseCol = base.name(QtHexArgb)
-        self.setStyleSheet(
-            f"QListView {{border: none; background: {baseCol};}} "
-            f"QLineEdit {{border: none; background: {baseCol}; padding: 4px;}} "
-        )
 
     ##
     #  Events
@@ -561,11 +564,14 @@ class _NewProjectPage(QWidget):
 
         base = self.palette().base().color()
         base.setAlpha(PANEL_ALPHA)
-        baseCol = base.name(QtHexArgb)
-        self.setStyleSheet(
-            f"QScrollArea {{border: none; background: {baseCol};}} "
-            f"_NewProjectForm {{border: none; background: {baseCol};}} "
-        )
+
+        panelPalette = self.palette()
+        panelPalette.setColor(QPalette.ColorRole.Base, base)
+        panelPalette.setColor(QPalette.ColorRole.Window, base)
+
+        self.scrollArea.setFrameStyle(QFrame.Shape.NoFrame)
+        self.scrollArea.setPalette(panelPalette)
+        self.projectForm.setPalette(panelPalette)
 
     ##
     #  Public Slots

--- a/novelwriter/viewer/viewerpanel.py
+++ b/novelwriter/viewer/viewerpanel.py
@@ -31,7 +31,6 @@ from PyQt6.QtWidgets import (
     QAbstractItemView,
     QFrame,
     QMenu,
-    QTabWidget,
     QToolButton,
     QTreeWidget,
     QTreeWidgetItem,
@@ -43,8 +42,8 @@ from novelwriter import SHARED
 from novelwriter.common import checkInt, qtAddAction
 from novelwriter.constants import nwLabels, nwLists, nwStyles, trConst
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass
-from novelwriter.extensions.modified import NIconToolButton
-from novelwriter.gui.theme import STYLES_FLAT_TABS, STYLES_MIN_TOOLBUTTON
+from novelwriter.extensions.modified import NIconToolButton, NTabWidget
+from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import QtDecorationRole, QtHeaderFixed, QtHeaderToContents, QtUserRole
 
 if TYPE_CHECKING:
@@ -84,7 +83,7 @@ class GuiDocViewerPanel(QWidget):
         self.optsButton.setMenu(self.optsMenu)
         self.optsButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
 
-        self.mainTabs = QTabWidget(self)
+        self.mainTabs = NTabWidget(self)
         self.mainTabs.addTab(self.tabBackRefs, self.tr("References"))
         self.mainTabs.setCornerWidget(self.optsButton, Qt.Corner.TopLeftCorner)
 
@@ -115,7 +114,7 @@ class GuiDocViewerPanel(QWidget):
         logger.debug("Theme Update: GuiDocViewerPanel")
 
         self.optsButton.setStyleSheet(SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON))
-        self.mainTabs.setStyleSheet(SHARED.theme.getStyleSheet(STYLES_FLAT_TABS))
+        self.mainTabs.refreshTheme()
         if not init:
             self.optsButton.refreshTheme()
             self.tabBackRefs.updateTheme()

--- a/tests/gui/test_theme.py
+++ b/tests/gui/test_theme.py
@@ -38,7 +38,6 @@ from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwTheme
 from novelwriter.gui.theme import (
     STYLES_BIG_TOOLBUTTON,
-    STYLES_FLAT_TABS,
     STYLES_MIN_TOOLBUTTON,
     GuiTheme,
     ThemeEntry,
@@ -417,7 +416,6 @@ def testGuiTheme_Methods(monkeypatch):
         assert theme.isDesktopDarkMode() is True
 
     # Stylesheets
-    assert theme.getStyleSheet(STYLES_FLAT_TABS) != ""
     assert theme.getStyleSheet(STYLES_MIN_TOOLBUTTON) != ""
     assert theme.getStyleSheet(STYLES_BIG_TOOLBUTTON) != ""
     assert theme.getStyleSheet("stuff") == ""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -102,7 +102,7 @@ def testInit_CreateApp(caplog, monkeypatch, fncPath):
     monkeypatch.setattr("PyQt6.QtWidgets.QApplication.setOrganizationDomain", lambda *a: None)
     monkeypatch.setattr("PyQt6.QtWidgets.QApplication.exec", lambda *a: 0)
 
-    app = _createApp("Fusion")
+    app = _createApp()
     assert isinstance(app, QApplication)
 
 
@@ -132,7 +132,7 @@ def testInit_Options(monkeypatch, fncPath):
 
     # Defaults
     with pytest.raises(SystemExit) as ex:
-        main([f"--config={fncPath}", f"--data={fncPath}", "--style=Fusion", "--meminfo"])
+        main([f"--config={fncPath}", f"--data={fncPath}", "--meminfo"])
     assert ex.value.code == 0
     assert CONFIG.memInfo is True
 


### PR DESCRIPTION
**Summary:**

This PR removes custom stylesheets from app with child widgets since the effect of these seems to have changed in recent Qt versions. Only a few places did this, and almost all could be done in other ways. The Fusion Qt style is also hard coded now.

Also fixed a minor performance issue where the line counter label on the editor footer was updated on each keypress even though the numbers only change on a new line,

**Related Issue(s):**

Closes #2871

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
