### PR TITLE
Move non-palette theme colours

### DIFF
--- a/docs/source/more/customise.rst
+++ b/docs/source/more/customise.rst
@@ -116,13 +116,13 @@ A colour theme ``.toml`` file consists of the following settings:
    link            = "blue"
    linkVisited     = "blue"
    accent          = "#3087c6"
-   toggle          = "blue:96"
-   searchMatch     = "orange:96"
 
    [GUI]
-   helpText  = "#5c5c5c"
-   fadedText = "#6c6c6c"
-   errorText = "red"
+   helpText    = "#5c5c5c"
+   fadedText   = "#6c6c6c"
+   errorText   = "red"
+   toggle      = "blue:96"
+   searchMatch = "orange:96"
 
    [Syntax]
    background     = "base"
@@ -204,7 +204,7 @@ There are several ways to enter colour values:
    if the theme is included in the app, but not for user themes.
 
 .. versionadded:: 26.2
-   The ``toggle`` and ``searchMatch`` settings were added to the ``[Palette]`` section. The file
+   The ``toggle`` and ``searchMatch`` settings were added to the ``[GUI]`` section. The file
    format was also converted from conf to toml, and a number of the colour settings were renamed to
    camelCase format. The following values were renamed:
 

--- a/novelwriter/assets/themes/aura.toml
+++ b/novelwriter/assets/themes/aura.toml
@@ -66,13 +66,13 @@ highlightedText = "default"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#603bb1"
-toggle          = "#462392"
-searchMatch     = "yellow:80"
 
 [GUI]
-helpText  = "faded:L125"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded:L125"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#462392"
+searchMatch = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/aura_bright.toml
+++ b/novelwriter/assets/themes/aura_bright.toml
@@ -64,13 +64,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "purple"
-toggle          = "purple:128"
-searchMatch     = "yellow:80"
 
 [GUI]
-helpText  = "faded:D125"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded:D125"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "purple:128"
+searchMatch = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/aura_soft.toml
+++ b/novelwriter/assets/themes/aura_soft.toml
@@ -66,13 +66,13 @@ highlightedText = "#edecee"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#6a4da3"
-toggle          = "#381f6b"
-searchMatch     = "yellow:80"
 
 [GUI]
-helpText  = "faded:L125"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded:L125"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#381f6b"
+searchMatch = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_garden_dark.toml
+++ b/novelwriter/assets/themes/b2t_garden_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "default"
 link            = "green"
 linkVisited     = "green"
 accent          = "#bd5d0f"
-toggle          = "#bd5d0f80"
-searchMatch     = "#dd843c60"
 
 [GUI]
-helpText  = "#aab1aa"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#aab1aa"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#bd5d0f80"
+searchMatch = "#dd843c60"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_garden_light.toml
+++ b/novelwriter/assets/themes/b2t_garden_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "#1c8217"
 linkVisited     = "#1c8217"
 accent          = "#bd5d0f"
-toggle          = "#bd5d0f60"
-searchMatch     = "#d9772660"
 
 [GUI]
-helpText  = "#696d69"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#696d69"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#bd5d0f60"
+searchMatch = "#d9772660"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_suburb_dark.toml
+++ b/novelwriter/assets/themes/b2t_suburb_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "#1e202f"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "red"
-toggle          = "red:128"
-searchMatch     = "red:128"
 
 [GUI]
-helpText  = "#9b9fb6"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#9b9fb6"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "red:128"
+searchMatch = "red:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_suburb_light.toml
+++ b/novelwriter/assets/themes/b2t_suburb_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#fe81b5"
-toggle          = "#fe81b57f"
-searchMatch     = "#fe81b57f"
 
 [GUI]
-helpText  = "#65697c"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#65697c"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#fe81b57f"
+searchMatch = "#fe81b57f"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_classic_o_dark.toml
+++ b/novelwriter/assets/themes/b4t_classic_o_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#1bbba5"
-toggle          = "#1bbba57f"
-searchMatch     = "#b35ee860"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#1bbba57f"
+searchMatch = "#b35ee860"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_classic_o_light.toml
+++ b/novelwriter/assets/themes/b4t_classic_o_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#0c9c89"
-toggle          = "#0c9c897f"
-searchMatch     = "#e6c8f9"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#0c9c897f"
+searchMatch = "#e6c8f9"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_modern_c_dark.toml
+++ b/novelwriter/assets/themes/b4t_modern_c_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "yellow"
-toggle          = "#1b2c9d"
-searchMatch     = "cyan:64"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#1b2c9d"
+searchMatch = "cyan:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_modern_c_light.toml
+++ b/novelwriter/assets/themes/b4t_modern_c_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "yellow"
-toggle          = "blue:128"
-searchMatch     = "cyan:64"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:128"
+searchMatch = "cyan:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/blue_streak_dark.toml
+++ b/novelwriter/assets/themes/blue_streak_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "default:L120"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue"
-toggle          = "blue:128"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "blue:L125"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue:L125"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:128"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/blue_streak_light.toml
+++ b/novelwriter/assets/themes/blue_streak_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue"
-toggle          = "blue:96"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:96"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/castle_day.toml
+++ b/novelwriter/assets/themes/castle_day.toml
@@ -64,13 +64,13 @@ highlightedText = "base:L110"
 link            = "#5068b6"
 linkVisited     = "#5068b6"
 accent          = "#cf7c6d"
-toggle          = "#b2c1f5"
-searchMatch     = "yellow:80"
 
 [GUI]
-helpText  = "default:L180"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:L180"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#b2c1f5"
+searchMatch = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/castle_night.toml
+++ b/novelwriter/assets/themes/castle_night.toml
@@ -64,13 +64,13 @@ highlightedText = "default:L110"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "red:D150"
-toggle          = "#2c3c6b"
-searchMatch     = "#3d496b"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#2c3c6b"
+searchMatch = "#3d496b"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/catppuccin_latte.toml
+++ b/novelwriter/assets/themes/catppuccin_latte.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "lavender"
 accent          = "purple"
-toggle          = "#ccd0da"
-searchMatch     = "blue:80"
 
 [GUI]
-helpText  = "#7c7f93"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#7c7f93"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#ccd0da"
+searchMatch = "blue:80"
 
 [Syntax]
 background     = "#eff1f5"

--- a/novelwriter/assets/themes/catppuccin_mocha.toml
+++ b/novelwriter/assets/themes/catppuccin_mocha.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "lavender"
 accent          = "purple"
-toggle          = "#313244"
-searchMatch     = "blue:80"
 
 [GUI]
-helpText  = "#9399b2"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#9399b2"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#313244"
+searchMatch = "blue:80"
 
 [Syntax]
 background     = "#1e1e2e"

--- a/novelwriter/assets/themes/chalky_soil.toml
+++ b/novelwriter/assets/themes/chalky_soil.toml
@@ -64,13 +64,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "green"
-toggle          = "green:128"
-searchMatch     = "blue:80"
 
 [GUI]
-helpText  = "default:L140"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:L140"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "green:128"
+searchMatch = "blue:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/chernozem.toml
+++ b/novelwriter/assets/themes/chernozem.toml
@@ -64,13 +64,13 @@ highlightedText = "#241d1d"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#5a8d55"
-toggle          = "#5a8d557f"
-searchMatch     = "red:96"
 
 [GUI]
-helpText  = "#a39891"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#a39891"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#5a8d557f"
+searchMatch = "red:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/cyberpunk_night.toml
+++ b/novelwriter/assets/themes/cyberpunk_night.toml
@@ -65,13 +65,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "#320050"
 accent          = "#321e50"
-toggle          = "#321e50"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#321e50"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/default_dark.toml
+++ b/novelwriter/assets/themes/default_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#2c98f7"
-toggle          = "blue:128"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "#a4a4a4"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#a4a4a4"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:128"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/default_light.toml
+++ b/novelwriter/assets/themes/default_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#3087c6"
-toggle          = "blue:96"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "#5c5c5c"
-fadedText = "#6c6c6c"
-errorText = "red"
+helpText    = "#5c5c5c"
+fadedText   = "#6c6c6c"
+errorText   = "red"
+toggle      = "blue:96"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/dracula.toml
+++ b/novelwriter/assets/themes/dracula.toml
@@ -82,13 +82,13 @@ highlightedText = "#f8f8f2"
 link            = "cyan"
 linkVisited     = "cyan"
 accent          = "#a681da"
-toggle          = "#a681da7f"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "#ccacf9"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#ccacf9"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#a681da7f"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/espresso.toml
+++ b/novelwriter/assets/themes/espresso.toml
@@ -66,13 +66,13 @@ highlightedText = "default"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue"
-toggle          = "faded"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "faded"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/everforest_dark.toml
+++ b/novelwriter/assets/themes/everforest_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#a7c080"
-toggle          = "#a7c0807f"
-searchMatch     = "orange:80"
 
 [GUI]
-helpText  = "#a9a49d"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#a9a49d"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#a7c0807f"
+searchMatch = "orange:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/everforest_light.toml
+++ b/novelwriter/assets/themes/everforest_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#93b259"
-toggle          = "#93b2597f"
-searchMatch     = "orange:72"
 
 [GUI]
-helpText  = "#829181"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#829181"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#93b2597f"
+searchMatch = "orange:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/floral_daydream.toml
+++ b/novelwriter/assets/themes/floral_daydream.toml
@@ -64,13 +64,13 @@ highlightedText = "#ffffff"
 link            = "#4781d8"
 linkVisited     = "#4781d8"
 accent          = "#e4688d"
-toggle          = "#e4688d7f"
-searchMatch     = "#e4688d50"
 
 [GUI]
-helpText  = "#d14a73"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#d14a73"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#e4688d7f"
+searchMatch = "#e4688d50"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/floral_midnight.toml
+++ b/novelwriter/assets/themes/floral_midnight.toml
@@ -64,13 +64,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#a85c8b"
-toggle          = "#8b55d67f"
-searchMatch     = "purple:96"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#8b55d67f"
+searchMatch = "purple:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/full_moon.toml
+++ b/novelwriter/assets/themes/full_moon.toml
@@ -64,13 +64,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#5495ce"
-toggle          = "#5495ce7f"
-searchMatch     = "default:64"
 
 [GUI]
-helpText  = "#586a72"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#586a72"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#5495ce7f"
+searchMatch = "default:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/grey_dark.toml
+++ b/novelwriter/assets/themes/grey_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#2c98f7"
-toggle          = "#9999997f"
-searchMatch     = "#9999997f"
 
 [GUI]
-helpText  = "default:D120"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:D120"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#9999997f"
+searchMatch = "#9999997f"
 
 [Syntax]
 background     = "#363636"

--- a/novelwriter/assets/themes/grey_light.toml
+++ b/novelwriter/assets/themes/grey_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#3087c6"
-toggle          = "#9999997f"
-searchMatch     = "#9999997f"
 
 [GUI]
-helpText  = "default:L225"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:L225"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#9999997f"
+searchMatch = "#9999997f"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/horizon_dark.toml
+++ b/novelwriter/assets/themes/horizon_dark.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "#21bfc2"
 linkVisited     = "#21bfc2"
 accent          = "#fab28e"
-toggle          = "#393c5f"
-searchMatch     = "purple:104"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#393c5f"
+searchMatch = "purple:104"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/horizon_light.toml
+++ b/novelwriter/assets/themes/horizon_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "#1eaeae"
 linkVisited     = "#1eaeae"
 accent          = "#f6661e"
-toggle          = "#ebb2a4"
-searchMatch     = "purple:80"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#ebb2a4"
+searchMatch = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/jewel_case_dark.toml
+++ b/novelwriter/assets/themes/jewel_case_dark.toml
@@ -64,13 +64,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#a85066"
-toggle          = "#113579"
-searchMatch     = "green:104"
 
 [GUI]
-helpText  = "#8297ad"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#8297ad"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#113579"
+searchMatch = "green:104"
 
 [Syntax]
 background     = "#141925"

--- a/novelwriter/assets/themes/jewel_case_light.toml
+++ b/novelwriter/assets/themes/jewel_case_light.toml
@@ -64,13 +64,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#d15b6d"
-toggle          = "#a9d1ff"
-searchMatch     = "green:80"
 
 [GUI]
-helpText  = "#596b7e"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#596b7e"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#a9d1ff"
+searchMatch = "green:80"
 
 [Syntax]
 background     = "#f6f9fc"

--- a/novelwriter/assets/themes/lcars.toml
+++ b/novelwriter/assets/themes/lcars.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "purple"
 linkVisited     = "purple"
 accent          = "orange"
-toggle          = "orange:96"
-searchMatch     = "red:96"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "orange:96"
+searchMatch = "red:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/light_owl.toml
+++ b/novelwriter/assets/themes/light_owl.toml
@@ -86,13 +86,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#3087c6"
-toggle          = "#3087c666"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#3087c666"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/new_moon.toml
+++ b/novelwriter/assets/themes/new_moon.toml
@@ -66,13 +66,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#4386c5"
-toggle          = "#4386c57f"
-searchMatch     = "default:80"
 
 [GUI]
-helpText  = "#999eaa"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#999eaa"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#4386c57f"
+searchMatch = "default:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/night_owl.toml
+++ b/novelwriter/assets/themes/night_owl.toml
@@ -86,13 +86,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#2c98f7"
-toggle          = "#2c98f766"
-searchMatch     = "orange:128"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#2c98f766"
+searchMatch = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/noctis.toml
+++ b/novelwriter/assets/themes/noctis.toml
@@ -98,13 +98,13 @@ highlightedText = "default"
 link            = "#40d4e7"
 linkVisited     = "blue"
 accent          = "#49e9a6"
-toggle          = "#49e9a657"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "#e4b781"
-fadedText = "faded"
-errorText = "#e3541c"
+helpText    = "#e4b781"
+fadedText   = "faded"
+errorText   = "#e3541c"
+toggle      = "#49e9a657"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/noctis_lux.toml
+++ b/novelwriter/assets/themes/noctis_lux.toml
@@ -98,13 +98,13 @@ highlightedText = "default"
 link            = "#00c6e0"
 linkVisited     = "blue"
 accent          = "#00b368"
-toggle          = "#00b36867"
-searchMatch     = "orange:64"
 
 [GUI]
-helpText  = "#fa8900"
-fadedText = "faded"
-errorText = "#ff530f"
+helpText    = "#fa8900"
+fadedText   = "faded"
+errorText   = "#ff530f"
+toggle      = "#00b36867"
+searchMatch = "orange:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/nord.toml
+++ b/novelwriter/assets/themes/nord.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "cyan"
-toggle          = "blue:128"
-searchMatch     = "purple:128"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:128"
+searchMatch = "purple:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/nordlicht.toml
+++ b/novelwriter/assets/themes/nordlicht.toml
@@ -64,13 +64,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "cyan"
-toggle          = "blue:128"
-searchMatch     = "purple:80"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:128"
+searchMatch = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/otium_dark.toml
+++ b/novelwriter/assets/themes/otium_dark.toml
@@ -64,13 +64,13 @@ highlightedText = "#1b1c22"
 link            = "green"
 linkVisited     = "green"
 accent          = "#698a6e"
-toggle          = "#698a6e7f"
-searchMatch     = "purple:128"
 
 [GUI]
-helpText  = "#a0a3a8"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#a0a3a8"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#698a6e7f"
+searchMatch = "purple:128"
 
 [Syntax]
 background     = "#1b1c22"

--- a/novelwriter/assets/themes/otium_light.toml
+++ b/novelwriter/assets/themes/otium_light.toml
@@ -64,13 +64,13 @@ highlightedText = "#ffffff"
 link            = "green"
 linkVisited     = "green"
 accent          = "#6c9173"
-toggle          = "#6c91737f"
-searchMatch     = "purple:80"
 
 [GUI]
-helpText  = "#57565e"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#57565e"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#6c91737f"
+searchMatch = "purple:80"
 
 [Syntax]
 background     = "#f8f7f3"

--- a/novelwriter/assets/themes/paragon.toml
+++ b/novelwriter/assets/themes/paragon.toml
@@ -65,13 +65,13 @@ highlightedText = "base"
 link            = "cyan"
 linkVisited     = "cyan"
 accent          = "cyan"
-toggle          = "cyan:128"
-searchMatch     = "orange:80"
 
 [GUI]
-helpText  = "#949baa"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#949baa"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "cyan:128"
+searchMatch = "orange:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/primer_light.toml
+++ b/novelwriter/assets/themes/primer_light.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "green"
-toggle          = "green:128"
-searchMatch     = "#b6e3ff"
 
 [GUI]
-helpText  = "#424a53"
-fadedText = "#8c959f"
-errorText = "red"
+helpText    = "#424a53"
+fadedText   = "#8c959f"
+errorText   = "red"
+toggle      = "green:128"
+searchMatch = "#b6e3ff"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/primer_night.toml
+++ b/novelwriter/assets/themes/primer_night.toml
@@ -66,13 +66,13 @@ highlightedText = "default"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#207c59"
-toggle          = "#207c597f"
-searchMatch     = "#1f6feb80"
 
 [GUI]
-helpText  = "#8b949e"
-fadedText = "#6e7681"
-errorText = "#f85149"
+helpText    = "#8b949e"
+fadedText   = "#6e7681"
+errorText   = "#f85149"
+toggle      = "#207c597f"
+searchMatch = "#1f6feb80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/rose_pine.toml
+++ b/novelwriter/assets/themes/rose_pine.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "red"
 linkVisited     = "red"
 accent          = "red"
-toggle          = "red:128"
-searchMatch     = "cyan:194"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "red:128"
+searchMatch = "cyan:194"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/rose_pine_dawn.toml
+++ b/novelwriter/assets/themes/rose_pine_dawn.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "red"
 linkVisited     = "red"
 accent          = "red"
-toggle          = "red:128"
-searchMatch     = "blue:88"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "red:128"
+searchMatch = "blue:88"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/ruby_day.toml
+++ b/novelwriter/assets/themes/ruby_day.toml
@@ -64,13 +64,13 @@ highlightedText = "base"
 link            = "#da3d3d"
 linkVisited     = "#da3d3d"
 accent          = "#c43939"
-toggle          = "#ff9e9e"
-searchMatch     = "purple:104"
 
 [GUI]
-helpText  = "#756777"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#756777"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#ff9e9e"
+searchMatch = "purple:104"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/ruby_night.toml
+++ b/novelwriter/assets/themes/ruby_night.toml
@@ -64,13 +64,13 @@ highlightedText = "#ebd9d9"
 link            = "red"
 linkVisited     = "red"
 accent          = "#a52a2c"
-toggle          = "#830a0c"
-searchMatch     = "purple:104"
 
 [GUI]
-helpText  = "#a5a1b3"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#a5a1b3"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#830a0c"
+searchMatch = "purple:104"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/selenium_dark.toml
+++ b/novelwriter/assets/themes/selenium_dark.toml
@@ -64,13 +64,13 @@ highlightedText = "#e4e0ec"
 link            = "#9267d3"
 linkVisited     = "#9267d3"
 accent          = "red:D120"
-toggle          = "#35303f"
-searchMatch     = "#df597070"
 
 [GUI]
-helpText  = "#888095"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#888095"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#35303f"
+searchMatch = "#df597070"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/selenium_light.toml
+++ b/novelwriter/assets/themes/selenium_light.toml
@@ -64,13 +64,13 @@ highlightedText = "#f0eff3"
 link            = "#623a9b"
 linkVisited     = "#623a9b"
 accent          = "red"
-toggle          = "#c1bccd"
-searchMatch     = "red:80"
 
 [GUI]
-helpText  = "default"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#c1bccd"
+searchMatch = "red:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sepia_dark.toml
+++ b/novelwriter/assets/themes/sepia_dark.toml
@@ -64,13 +64,13 @@ highlightedText = "#e7d4c9"
 link            = "orange"
 linkVisited     = "orange"
 accent          = "#885b4d"
-toggle          = "orange:80"
-searchMatch     = "cyan:88"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "orange:80"
+searchMatch = "cyan:88"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sepia_light.toml
+++ b/novelwriter/assets/themes/sepia_light.toml
@@ -64,13 +64,13 @@ highlightedText = "#f7efe6"
 link            = "#ac5828"
 linkVisited     = "#ac5828"
 accent          = "#a57f66"
-toggle          = "#a57f667f"
-searchMatch     = "cyan:96"
 
 [GUI]
-helpText  = "#836050"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#836050"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#a57f667f"
+searchMatch = "cyan:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/snazzy.toml
+++ b/novelwriter/assets/themes/snazzy.toml
@@ -79,13 +79,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue"
-toggle          = "blue:96"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "red"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:96"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/solarized_dark.toml
+++ b/novelwriter/assets/themes/solarized_dark.toml
@@ -85,13 +85,13 @@ highlightedText = "default"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "cyan"
-toggle          = "cyan:96"
-searchMatch     = "yellow:128"
 
 [GUI]
-helpText  = "cyan"
-fadedText = "faded"
-errorText = "red"
+helpText    = "cyan"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "cyan:96"
+searchMatch = "yellow:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/solarized_light.toml
+++ b/novelwriter/assets/themes/solarized_light.toml
@@ -85,13 +85,13 @@ highlightedText = "default"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "cyan"
-toggle          = "cyan:96"
-searchMatch     = "yellow:96"
 
 [GUI]
-helpText  = "cyan"
-fadedText = "faded"
-errorText = "red"
+helpText    = "cyan"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "cyan:96"
+searchMatch = "yellow:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sultana_light.toml
+++ b/novelwriter/assets/themes/sultana_light.toml
@@ -64,13 +64,13 @@ highlightedText = "#f9f4fc"
 link            = "#5577bb"
 linkVisited     = "#5577bb"
 accent          = "#ad6978"
-toggle          = "#ad69787f"
-searchMatch     = "yellow:80"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#ad69787f"
+searchMatch = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sultana_night.toml
+++ b/novelwriter/assets/themes/sultana_night.toml
@@ -64,13 +64,13 @@ highlightedText = "default"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#9e4c65"
-toggle          = "#9e4c657f"
-searchMatch     = "#a181647f"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "#9e4c657f"
+searchMatch = "#a181647f"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tango_dark.toml
+++ b/novelwriter/assets/themes/tango_dark.toml
@@ -80,13 +80,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue"
-toggle          = "blue:128"
-searchMatch     = "orange:128"
 
 [GUI]
-helpText  = "orange"
-fadedText = "faded"
-errorText = "red"
+helpText    = "orange"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:128"
+searchMatch = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tango_light.toml
+++ b/novelwriter/assets/themes/tango_light.toml
@@ -80,13 +80,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue:L150"
-toggle          = "blue:96"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "orange"
-fadedText = "faded"
-errorText = "red"
+helpText    = "orange"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:96"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/today_deuteranopia.toml
+++ b/novelwriter/assets/themes/today_deuteranopia.toml
@@ -91,13 +91,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue:L150"
-toggle          = "blue:96"
-searchMatch     = "yellow:96"
 
 [GUI]
-helpText  = "blue"
-fadedText = "faded"
-errorText = "yellow"
+helpText    = "blue"
+fadedText   = "faded"
+errorText   = "yellow"
+toggle      = "blue:96"
+searchMatch = "yellow:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/today_tritanopia.toml
+++ b/novelwriter/assets/themes/today_tritanopia.toml
@@ -91,13 +91,13 @@ highlightedText = "base"
 link            = "green"
 linkVisited     = "green"
 accent          = "green:L150"
-toggle          = "green:96"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "green:D110"
-fadedText = "faded"
-errorText = "red"
+helpText    = "green:D110"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "green:96"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow.toml
+++ b/novelwriter/assets/themes/tomorrow.toml
@@ -86,13 +86,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "blue"
-toggle          = "blue:96"
-searchMatch     = "orange:96"
 
 [GUI]
-helpText  = "#5c5c5c"
-fadedText = "faded"
-errorText = "red"
+helpText    = "#5c5c5c"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:96"
+searchMatch = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night.toml
+++ b/novelwriter/assets/themes/tomorrow_night.toml
@@ -86,13 +86,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#2c98f7"
-toggle          = "#2c98f766"
-searchMatch     = "orange:128"
 
 [GUI]
-helpText  = "#a4a4a4"
-fadedText = "#949494"
-errorText = "red"
+helpText    = "#a4a4a4"
+fadedText   = "#949494"
+errorText   = "red"
+toggle      = "#2c98f766"
+searchMatch = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night_blue.toml
+++ b/novelwriter/assets/themes/tomorrow_night_blue.toml
@@ -86,13 +86,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#2c98f7"
-toggle          = "#2c98f766"
-searchMatch     = "orange:128"
 
 [GUI]
-helpText  = "#a4a4a4"
-fadedText = "#949494"
-errorText = "red"
+helpText    = "#a4a4a4"
+fadedText   = "#949494"
+errorText   = "red"
+toggle      = "#2c98f766"
+searchMatch = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night_bright.toml
+++ b/novelwriter/assets/themes/tomorrow_night_bright.toml
@@ -86,13 +86,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#2c98f7"
-toggle          = "#2c98f757"
-searchMatch     = "orange:128"
 
 [GUI]
-helpText  = "#a4a4a4"
-fadedText = "#949494"
-errorText = "red"
+helpText    = "#a4a4a4"
+fadedText   = "#949494"
+errorText   = "red"
+toggle      = "#2c98f757"
+searchMatch = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night_eighties.toml
+++ b/novelwriter/assets/themes/tomorrow_night_eighties.toml
@@ -86,13 +86,13 @@ highlightedText = "#ffffff"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#2c98f7"
-toggle          = "#2c98f766"
-searchMatch     = "orange:128"
 
 [GUI]
-helpText  = "#a4a4a4"
-fadedText = "#949494"
-errorText = "red"
+helpText    = "#a4a4a4"
+fadedText   = "#949494"
+errorText   = "red"
+toggle      = "#2c98f766"
+searchMatch = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_black_green.toml
+++ b/novelwriter/assets/themes/vivid_black_green.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "green"
 linkVisited     = "green"
 accent          = "green:D125"
-toggle          = "green:96"
-searchMatch     = "red:128"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "green:96"
+searchMatch = "red:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_black_red.toml
+++ b/novelwriter/assets/themes/vivid_black_red.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "red"
 linkVisited     = "red"
 accent          = "red"
-toggle          = "red:128"
-searchMatch     = "green:72"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "red:128"
+searchMatch = "green:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_white_green.toml
+++ b/novelwriter/assets/themes/vivid_white_green.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "green"
 linkVisited     = "green"
 accent          = "green"
-toggle          = "green:96"
-searchMatch     = "red:72"
 
 [GUI]
-helpText  = "default:L250"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:L250"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "green:96"
+searchMatch = "red:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_white_red.toml
+++ b/novelwriter/assets/themes/vivid_white_red.toml
@@ -66,13 +66,13 @@ highlightedText = "base"
 link            = "red"
 linkVisited     = "red"
 accent          = "red"
-toggle          = "red:96"
-searchMatch     = "green:72"
 
 [GUI]
-helpText  = "default:L250"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:L250"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "red:96"
+searchMatch = "green:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/warpgate.toml
+++ b/novelwriter/assets/themes/warpgate.toml
@@ -65,13 +65,13 @@ highlightedText = "base"
 link            = "green"
 linkVisited     = "green"
 accent          = "green"
-toggle          = "cyan:80"
-searchMatch     = "green:128"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "cyan:80"
+searchMatch = "green:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/waterlily_dark.toml
+++ b/novelwriter/assets/themes/waterlily_dark.toml
@@ -64,13 +64,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#ff9fbd"
-toggle          = "blue:80"
-searchMatch     = "purple:80"
 
 [GUI]
-helpText  = "faded"
-fadedText = "faded"
-errorText = "red"
+helpText    = "faded"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "blue:80"
+searchMatch = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/waterlily_light.toml
+++ b/novelwriter/assets/themes/waterlily_light.toml
@@ -64,13 +64,13 @@ highlightedText = "base"
 link            = "blue"
 linkVisited     = "blue"
 accent          = "#e6859a"
-toggle          = "cyan:112"
-searchMatch     = "purple:80"
 
 [GUI]
-helpText  = "default:192"
-fadedText = "faded"
-errorText = "red"
+helpText    = "default:192"
+fadedText   = "faded"
+errorText   = "red"
+toggle      = "cyan:112"
+searchMatch = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -492,14 +492,14 @@ class GuiTheme:
             self._setPalette(section, "link", QPalette.ColorRole.Link)
             self._setPalette(section, "linkVisited", QPalette.ColorRole.LinkVisited)
             self.accentCol = self._readColor(section, "accent")  # Special handling 'til Qt 6.6
-            self.toggleCol = self._readColor(section, "toggle")
-            self.searchCol = self._readColor(section, "searchMatch")
 
         # GUI
         if section := data.get("GUI"):
             self.helpText = self._readColor(section, "helpText")
             self.fadedText = self._readColor(section, "fadedText")
             self.errorText = self._readColor(section, "errorText")
+            self.toggleCol = self._readColor(section, "toggle")
+            self.searchCol = self._readColor(section, "searchMatch")
 
         # Syntax
         self.syntaxTheme = SyntaxColors()

--- a/tests/gui/test_theme.py
+++ b/tests/gui/test_theme.py
@@ -821,13 +821,13 @@ def testGuiTheme_CheckTheme(theme):
             "link",
             "linkVisited",
             "accent",
-            "toggle",
-            "searchMatch",
         ],
         "GUI": [
             "helpText",
             "fadedText",
             "errorText",
+            "toggle",
+            "searchMatch",
         ],
         "Syntax": [
             "background",


### PR DESCRIPTION
**Summary:**

Move the two new theme colours `toggle` and `searchMatch` to the `GUI` section. They were erroneously placed in the `Palette` section, but that's for the Qt palette colours.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
