### PR TITLE
Allow excluding root folders from writing goals

### DIFF
--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -441,6 +441,15 @@ class ProjectItem:
         """Check if item is a novel document."""
         return self._layout == nwItemLayout.DOCUMENT
 
+    def isDailyTarget(self) -> bool:
+        """Check if item is a daily target item."""
+        return (
+            self._active
+            and self._class == nwItemClass.NOVEL
+            and self._layout == nwItemLayout.DOCUMENT
+            and self._root not in self._project.data.targetSkipRoots
+        )
+
     ##
     #  Special Setters
     ##

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -567,9 +567,9 @@ class NWProject:
 
     def updateCounts(self) -> None:
         """Update the total word and character count values."""
-        wNovel, wNotes, cNovel, cNotes = self._tree.sumCounts()
+        wNovel, wNotes, cNovel, cNotes, dailyWords = self._tree.sumCounts()
         self._data.setCurrCounts(wNovel=wNovel, wNotes=wNotes, cNovel=cNovel, cNotes=cNotes)
-        self._data.setDailyProgress(wNovel)
+        self._data.setDailyProgress(dailyWords)
 
     def countStatus(self) -> None:
         """Count how many times the various status flags are used in the

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -493,3 +493,16 @@ class ProjectData:
             count = checkInt(cNotes, 0)
             self._initCounts[3] = count
             self._currCounts[3] = count
+
+    ##
+    #  Methods
+    ##
+
+    def resetDailyProgress(self) -> None:
+        """Reset the daily progress counter to zero without affecting
+        the overall project target progress.
+        """
+        self._dailyLastDate = date.today()
+        self._dailyLastCount = self._targetInitCount - self._targetLastCount
+        self.setDailyProgress(self._targetLastCount)
+        self._project.setProjectChanged(True)

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -366,8 +366,9 @@ class ProjectData:
 
     def setTargetSkipRoots(self, updated: list[str]) -> None:
         """Set the target skip root handles dictionary."""
-        if updated != self._targetSkipRoots:
-            self._targetSkipRoots = set(updated)
+        skipRoots = {str(handle) for handle in updated}
+        if skipRoots != self._targetSkipRoots:
+            self._targetSkipRoots = skipRoots
             oldCount = self._targetLastCount
             self._project.updateCounts()
             if self._targetLastCount != oldCount:
@@ -445,7 +446,7 @@ class ProjectData:
     #  XML Init Setters
     ##
 
-    def setInitLastHandles(self, value: dict) -> None:
+    def setInitLastHandles(self, value: Any) -> None:
         """Set the full last handles dictionary to a new set of values.
         This is intended to be used at project load.
         """
@@ -455,7 +456,7 @@ class ProjectData:
                     self._lastHandle[key] = str(entry) if isHandle(entry) else None
             self._project.setProjectChanged(True)
 
-    def setInitTargetCount(self, value: str | None) -> None:
+    def setInitTargetCount(self, value: Any) -> None:
         """Set the initial target count."""
         count = checkInt(value, 0)
         self._targetInitCount = count

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import uuid
 
+from collections.abc import Sequence
 from datetime import date
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -78,6 +79,7 @@ class ProjectData:
         "_spellLang",
         "_status",
         "_targetDeadline",
+        "_targetSkipRoots",
         "_targetWordCount",
         "_titleFormat",
         "_uuid",
@@ -97,17 +99,20 @@ class ProjectData:
 
         # Project Settings
         self._doBackup = True
+        self._language = None
+        self._spellCheck = False
+        self._spellLang = None
+
+        # Writing Target
         self._targetWordCount = 0
         self._targetDeadline = None
+        self._targetSkipRoots: set[str] = set()
         self._remainingWordCount = 0
         self._dailyGoal = 0
         self._dailyGoalAuto = False
         self._dailyProgress = 0
         self._dailyLastCount = 0
         self._dailyLastDate = None
-        self._language = None
-        self._spellCheck = False
-        self._spellLang = None
 
         # Project Dictionaries
         self._initCounts = [0, 0, 0, 0]
@@ -183,6 +188,11 @@ class ProjectData:
     def targetDeadline(self) -> date | None:
         """Return the project deadline."""
         return self._targetDeadline
+
+    @property
+    def targetSkipRoots(self) -> set[str]:
+        """Return the set of target skip root handles."""
+        return self._targetSkipRoots
 
     @property
     def dailyGoal(self) -> int:
@@ -342,6 +352,12 @@ class ProjectData:
         if wCount != self._targetWordCount or deadline != self._targetDeadline:
             self._targetWordCount = checkInt(wCount, 0)
             self._targetDeadline = checkDateNone(deadline, None)
+            self._project.setProjectChanged(True)
+
+    def setTargetSkipRoots(self, value: Sequence[str]) -> None:
+        """Set the target skip root handles dictionary."""
+        if isinstance(value, Sequence):
+            self._targetSkipRoots = {str(handle) for handle in value}
             self._project.setProjectChanged(True)
 
     def setDailyTarget(self, value: Any, auto: Any) -> None:

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -79,6 +79,8 @@ class ProjectData:
         "_spellLang",
         "_status",
         "_targetDeadline",
+        "_targetInitCount",
+        "_targetLastCount",
         "_targetSkipRoots",
         "_targetWordCount",
         "_titleFormat",
@@ -105,6 +107,8 @@ class ProjectData:
 
         # Writing Target
         self._targetWordCount = 0
+        self._targetInitCount = 0
+        self._targetLastCount = 0
         self._targetDeadline = None
         self._targetSkipRoots: set[str] = set()
         self._remainingWordCount = 0
@@ -183,6 +187,11 @@ class ProjectData:
     def targetWordCount(self) -> int:
         """Return the project goal."""
         return self._targetWordCount
+
+    @property
+    def targetLastCount(self) -> int:
+        """Return the last recorded target count."""
+        return self._targetLastCount
 
     @property
     def targetDeadline(self) -> date | None:
@@ -347,18 +356,28 @@ class ProjectData:
             self._doBackup = checkBool(value, False)
             self._project.setProjectChanged(True)
 
-    def setProjectTarget(self, wCount: Any, deadline: Any) -> None:
+    def setProjectTarget(self, wCount: str | int | None, deadline: str | date | None, last: str | None = None) -> None:
         """Set the project goal."""
         if wCount != self._targetWordCount or deadline != self._targetDeadline:
             self._targetWordCount = checkInt(wCount, 0)
             self._targetDeadline = checkDateNone(deadline, None)
+            if last is not None:
+                self._targetInitCount = checkInt(last, 0)
+                self._targetLastCount = self._targetInitCount
             self._project.setProjectChanged(True)
 
     def setTargetSkipRoots(self, value: Sequence[str]) -> None:
         """Set the target skip root handles dictionary."""
         if isinstance(value, Sequence):
-            self._targetSkipRoots = {str(handle) for handle in value}
-            self._project.setProjectChanged(True)
+            updated = {str(handle) for handle in value}
+            current = self._targetSkipRoots
+            if updated != current:
+                self._targetSkipRoots = updated
+                oldTarget = self._targetLastCount
+                self._project.updateCounts()
+                if self._targetLastCount != oldTarget:
+                    self._targetInitCount += self._targetLastCount - oldTarget
+                self._project.setProjectChanged(True)
 
     def setDailyTarget(self, value: Any, auto: Any) -> None:
         """Set the daily goal."""
@@ -384,9 +403,10 @@ class ProjectData:
             self._dailyLastCount -= self._dailyProgress
             self._dailyLastDate = date.today()
 
-        offset = self._initCounts[0] - self._dailyLastCount
+        offset = self._targetInitCount - self._dailyLastCount
         self._dailyProgress = count - offset
         self._remainingWordCount = self._targetWordCount - offset
+        self._targetLastCount = count
 
     def setLanguage(self, value: str | None) -> None:
         """Set the project language."""

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 import uuid
 
-from collections.abc import Sequence
 from datetime import date
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -41,6 +40,8 @@ from novelwriter.common import (
 from novelwriter.core.status import ItemStatus
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from novelwriter.core.project import NWProject
 
 logger = logging.getLogger(__name__)
@@ -356,31 +357,23 @@ class ProjectData:
             self._doBackup = checkBool(value, False)
             self._project.setProjectChanged(True)
 
-    def setProjectTarget(self, wCount: str | int | None, deadline: str | date | None, last: str | None = None) -> None:
+    def setProjectTarget(self, count: str | int | None, deadline: str | date | None) -> None:
         """Set the project goal."""
-        if wCount != self._targetWordCount or deadline != self._targetDeadline:
-            self._targetWordCount = checkInt(wCount, 0)
+        if count != self._targetWordCount or deadline != self._targetDeadline:
+            self._targetWordCount = checkInt(count, 0)
             self._targetDeadline = checkDateNone(deadline, None)
-            if last is not None:
-                self._targetInitCount = checkInt(last, 0)
-                self._targetLastCount = self._targetInitCount
             self._project.setProjectChanged(True)
 
-    def setTargetSkipRoots(self, value: Sequence[str], init: bool = False) -> None:
+    def setTargetSkipRoots(self, updated: list[str]) -> None:
         """Set the target skip root handles dictionary."""
-        if isinstance(value, Sequence):
-            current = self._targetSkipRoots
-            updated = {str(handle) for handle in value}
-            if init:
-                self._targetSkipRoots = updated
-            elif updated != current:
-                self._targetSkipRoots = updated
-                oldCount = self._targetLastCount
-                self._project.updateCounts()
-                if self._targetLastCount != oldCount:
-                    self._targetInitCount += self._targetLastCount - oldCount
-                    self.setDailyProgress(self._targetLastCount)
-                self._project.setProjectChanged(True)
+        if updated != self._targetSkipRoots:
+            self._targetSkipRoots = set(updated)
+            oldCount = self._targetLastCount
+            self._project.updateCounts()
+            if self._targetLastCount != oldCount:
+                self._targetInitCount += self._targetLastCount - oldCount
+                self.setDailyProgress(self._targetLastCount)
+            self._project.setProjectChanged(True)
 
     def setDailyTarget(self, value: Any, auto: Any) -> None:
         """Set the daily goal."""
@@ -388,15 +381,6 @@ class ProjectData:
             self._dailyGoal = checkInt(value, 0)
             self._dailyGoalAuto = checkBool(auto, False)
             self._project.setProjectChanged(True)
-
-    def setDailyTargetCurrent(self, value: Any, last: Any) -> None:
-        """Set the current daily goal."""
-        if (lastDate := checkDateNone(last, None)) == date.today():
-            self._dailyLastCount = checkInt(value, self._dailyLastCount)
-            self._dailyLastDate = lastDate
-        else:
-            self._dailyLastCount = 0
-            self._dailyLastDate = date.today()
 
     def setDailyProgress(self, count: int) -> None:
         """Set the current daily goal progress."""
@@ -437,35 +421,6 @@ class ProjectData:
             self._lastHandle[component] = checkStringNone(value, None)
             self._project.setProjectChanged(True)
 
-    def setLastHandles(self, value: dict) -> None:
-        """Set the full last handles dictionary to a new set of values.
-        This is intended to be used at project load.
-        """
-        if isinstance(value, dict):
-            for key, entry in value.items():
-                if key in self._lastHandle:
-                    self._lastHandle[key] = str(entry) if isHandle(entry) else None
-            self._project.setProjectChanged(True)
-
-    def setInitCounts(self, wNovel: Any = None, wNotes: Any = None, cNovel: Any = None, cNotes: Any = None) -> None:
-        """Set the count totals for novel and note files."""
-        if wNovel is not None:
-            count = checkInt(wNovel, 0)
-            self._initCounts[0] = count
-            self._currCounts[0] = count
-        if wNotes is not None:
-            count = checkInt(wNotes, 0)
-            self._initCounts[1] = count
-            self._currCounts[1] = count
-        if cNovel is not None:
-            count = checkInt(cNovel, 0)
-            self._initCounts[2] = count
-            self._currCounts[2] = count
-        if cNotes is not None:
-            count = checkInt(cNotes, 0)
-            self._initCounts[3] = count
-            self._currCounts[3] = count
-
     def setCurrCounts(self, wNovel: Any = None, wNotes: Any = None, cNovel: Any = None, cNotes: Any = None) -> None:
         """Set the count totals for novel and note files."""
         if wNovel is not None:
@@ -485,3 +440,55 @@ class ProjectData:
                 if isinstance(entry, str):
                     self._autoReplace[key] = simplified(entry)
             self._project.setProjectChanged(True)
+
+    ##
+    #  XML Init Setters
+    ##
+
+    def setInitLastHandles(self, value: dict) -> None:
+        """Set the full last handles dictionary to a new set of values.
+        This is intended to be used at project load.
+        """
+        if isinstance(value, dict):
+            for key, entry in value.items():
+                if key in self._lastHandle:
+                    self._lastHandle[key] = str(entry) if isHandle(entry) else None
+            self._project.setProjectChanged(True)
+
+    def setInitTargetCount(self, value: str | None) -> None:
+        """Set the initial target count."""
+        count = checkInt(value, 0)
+        self._targetInitCount = count
+        self._targetLastCount = count
+
+    def setInitTargetSkipRoots(self, value: Sequence[str]) -> None:
+        """Set the initial target skip root handles dictionary."""
+        self._targetSkipRoots = {str(handle) for handle in value}
+
+    def setInitDailyTarget(self, value: Any, last: Any) -> None:
+        """Set the initial daily goal."""
+        if (lastDate := checkDateNone(last, None)) == date.today():
+            self._dailyLastCount = checkInt(value, self._dailyLastCount)
+            self._dailyLastDate = lastDate
+        else:
+            self._dailyLastCount = 0
+            self._dailyLastDate = date.today()
+
+    def setInitCounts(self, wNovel: Any = None, wNotes: Any = None, cNovel: Any = None, cNotes: Any = None) -> None:
+        """Set the count totals for novel and note files."""
+        if wNovel is not None:
+            count = checkInt(wNovel, 0)
+            self._initCounts[0] = count
+            self._currCounts[0] = count
+        if wNotes is not None:
+            count = checkInt(wNotes, 0)
+            self._initCounts[1] = count
+            self._currCounts[1] = count
+        if cNovel is not None:
+            count = checkInt(cNovel, 0)
+            self._initCounts[2] = count
+            self._currCounts[2] = count
+        if cNotes is not None:
+            count = checkInt(cNotes, 0)
+            self._initCounts[3] = count
+            self._currCounts[3] = count

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -366,17 +366,20 @@ class ProjectData:
                 self._targetLastCount = self._targetInitCount
             self._project.setProjectChanged(True)
 
-    def setTargetSkipRoots(self, value: Sequence[str]) -> None:
+    def setTargetSkipRoots(self, value: Sequence[str], init: bool = False) -> None:
         """Set the target skip root handles dictionary."""
         if isinstance(value, Sequence):
-            updated = {str(handle) for handle in value}
             current = self._targetSkipRoots
-            if updated != current:
+            updated = {str(handle) for handle in value}
+            if init:
                 self._targetSkipRoots = updated
-                oldTarget = self._targetLastCount
+            elif updated != current:
+                self._targetSkipRoots = updated
+                oldCount = self._targetLastCount
                 self._project.updateCounts()
-                if self._targetLastCount != oldTarget:
-                    self._targetInitCount += self._targetLastCount - oldTarget
+                if self._targetLastCount != oldCount:
+                    self._targetInitCount += self._targetLastCount - oldCount
+                    self.setDailyProgress(self._targetLastCount)
                 self._project.setProjectChanged(True)
 
     def setDailyTarget(self, value: Any, auto: Any) -> None:

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -44,6 +44,8 @@ from novelwriter.common import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from novelwriter.core.projectdata import ProjectData
     from novelwriter.core.status import ItemStatus
 
@@ -276,6 +278,8 @@ class ProjectXMLReader:
             elif xItem.tag == "dailyTarget":
                 data.setDailyTarget(xItem.text, xItem.attrib.get("auto"))
                 data.setDailyTargetCurrent(xItem.attrib.get("last"), xItem.attrib.get("date"))
+            elif xItem.tag == "targetSkipRoots":
+                data.setTargetSkipRoots(self._parseSequenceText(xItem))
             elif xItem.tag == "status":
                 self._parseStatusImport(xItem, data.itemStatus)
             elif xItem.tag == "importance":
@@ -447,7 +451,13 @@ class ProjectXMLReader:
                     color = f"{red}, {green}, {blue}"
                 sObject.add(key, xEntry.text or "", color, shape, count)
 
-    def _parseDictKeyText(self, xItem: ET.Element) -> dict:
+    def _parseSequenceText(self, xItem: ET.Element) -> list[str]:
+        """Parse a dictionary stored with key as an attribute and the
+        value as the text property.
+        """
+        return [checkString(xEntry.text, "") for xEntry in xItem if xEntry.tag == "entry"]
+
+    def _parseDictKeyText(self, xItem: ET.Element) -> dict[str, str]:
         """Parse a dictionary stored with key as an attribute and the
         value as the text property.
         """
@@ -522,6 +532,7 @@ class ProjectXMLWriter:
         self._packSingleValue(xSettings, "spellChecking", data.spellLang, attrib={"auto": yesNo(data.spellCheck)})
         self._packSingleValue(xSettings, "projectTarget", str(data.targetWordCount), attrib=targetAttr)
         self._packSingleValue(xSettings, "dailyTarget", str(data.dailyGoal), attrib=dailyAttr)
+        self._packListValues(xSettings, "targetSkipRoots", data.targetSkipRoots)
         self._packDictKeyValue(xSettings, "lastHandle", data.lastHandle)
         self._packDictKeyValue(xSettings, "autoReplace", data.autoReplace)
 
@@ -575,7 +586,15 @@ class ProjectXMLWriter:
         xItem = ET.SubElement(xParent, name, attrib=attrib or {})
         xItem.text = str(value) or ""
 
-    def _packDictKeyValue(self, xParent: ET.Element, name: str, data: dict) -> None:
+    def _packListValues(self, xParent: ET.Element, name: str, data: list | tuple | set) -> None:
+        """Pack the entries of a sequence into an XML element."""
+        xItem = ET.SubElement(xParent, name)
+        for value in data:
+            if len(str(value)) > 0:
+                xEntry = ET.SubElement(xItem, "entry")
+                xEntry.text = str(value) or ""
+
+    def _packDictKeyValue(self, xParent: ET.Element, name: str, data: Mapping[str, str | None]) -> None:
         """Pack the entries of a dictionary into an XML element."""
         xItem = ET.SubElement(xParent, name)
         for key, value in data.items():

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -274,18 +274,19 @@ class ProjectXMLReader:
                 data.setSpellLang(xItem.text)
                 data.setSpellCheck(xItem.attrib.get("auto"))
             elif xItem.tag == "projectTarget":
-                data.setProjectTarget(xItem.text, xItem.attrib.get("date"), xItem.attrib.get("last"))
+                data.setProjectTarget(xItem.text, xItem.attrib.get("date"))
+                data.setInitTargetCount(xItem.attrib.get("last"))
             elif xItem.tag == "dailyTarget":
                 data.setDailyTarget(xItem.text, xItem.attrib.get("auto"))
-                data.setDailyTargetCurrent(xItem.attrib.get("last"), xItem.attrib.get("date"))
+                data.setInitDailyTarget(xItem.attrib.get("last"), xItem.attrib.get("date"))
             elif xItem.tag == "targetSkipRoots":
-                data.setTargetSkipRoots(self._parseSequenceText(xItem), init=True)
+                data.setInitTargetSkipRoots(self._parseSequenceText(xItem))
             elif xItem.tag == "status":
                 self._parseStatusImport(xItem, data.itemStatus)
             elif xItem.tag == "importance":
                 self._parseStatusImport(xItem, data.itemImport)
             elif xItem.tag == "lastHandle":
-                data.setLastHandles(self._parseDictKeyText(xItem))
+                data.setInitLastHandles(self._parseDictKeyText(xItem))
             elif xItem.tag == "autoReplace":
                 if self._version >= 0x0102:
                     data.setAutoReplace(self._parseDictKeyText(xItem))

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -274,7 +274,7 @@ class ProjectXMLReader:
                 data.setSpellLang(xItem.text)
                 data.setSpellCheck(xItem.attrib.get("auto"))
             elif xItem.tag == "projectTarget":
-                data.setProjectTarget(xItem.text, xItem.attrib.get("date"))
+                data.setProjectTarget(xItem.text, xItem.attrib.get("date"), xItem.attrib.get("last"))
             elif xItem.tag == "dailyTarget":
                 data.setDailyTarget(xItem.text, xItem.attrib.get("auto"))
                 data.setDailyTargetCurrent(xItem.attrib.get("last"), xItem.attrib.get("date"))
@@ -519,6 +519,7 @@ class ProjectXMLWriter:
         # Save Project Settings
         targetAttr = {
             "date": data.targetDeadline.isoformat() if isinstance(data.targetDeadline, datetime.date) else "None",
+            "last": str(data.targetLastCount),
         }
         dailyAttr = {
             "auto": yesNo(data.dailyGoalAuto),

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -592,7 +592,7 @@ class ProjectXMLWriter:
         """Pack the entries of a sequence into an XML element."""
         xItem = ET.SubElement(xParent, name)
         for value in data:
-            if len(str(value)) > 0:
+            if len(str(value)) > 0:  # pragma: no branch
                 xEntry = ET.SubElement(xItem, "entry")
                 xEntry.text = str(value) or ""
 
@@ -600,6 +600,6 @@ class ProjectXMLWriter:
         """Pack the entries of a dictionary into an XML element."""
         xItem = ET.SubElement(xParent, name)
         for key, value in data.items():
-            if len(key) > 0:
+            if len(key) > 0:  # pragma: no branch
                 xEntry = ET.SubElement(xItem, "entry", attrib={"key": key})
                 xEntry.text = str(value) or ""

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -279,7 +279,7 @@ class ProjectXMLReader:
                 data.setDailyTarget(xItem.text, xItem.attrib.get("auto"))
                 data.setDailyTargetCurrent(xItem.attrib.get("last"), xItem.attrib.get("date"))
             elif xItem.tag == "targetSkipRoots":
-                data.setTargetSkipRoots(self._parseSequenceText(xItem))
+                data.setTargetSkipRoots(self._parseSequenceText(xItem), init=True)
             elif xItem.tag == "status":
                 self._parseStatusImport(xItem, data.itemStatus)
             elif xItem.tag == "importance":

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -438,12 +438,13 @@ class ProjectTree:
 
         return True
 
-    def sumCounts(self) -> tuple[int, int, int, int]:
+    def sumCounts(self) -> tuple[int, int, int, int, int]:
         """Loop over all entries and add up the word and char counts."""
         novelWords = 0
         notesWords = 0
         novelChars = 0
         notesChars = 0
+        dailyWords = 0
         for item in self._items.values():
             if item.itemLayout == nwItemLayout.NOTE:
                 notesWords += item.wordCount
@@ -451,7 +452,9 @@ class ProjectTree:
             elif item.itemLayout == nwItemLayout.DOCUMENT:
                 novelWords += item.wordCount
                 novelChars += item.charCount
-        return novelWords, notesWords, novelChars, notesChars
+            if item.isDailyTarget():
+                dailyWords += item.wordCount
+        return novelWords, notesWords, novelChars, notesChars, dailyWords
 
     ##
     #  Tree Item Methods

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -52,7 +52,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatFileFilter, qtAddAction, qtLambda, simplified
 from novelwriter.constants import nwLabels, trConst
 from novelwriter.core.status import CUSTOM_COL, ItemStatus, StatusEntry
-from novelwriter.enum import nwStandardButton, nwStatusShape, nwToolButton
+from novelwriter.enum import nwItemClass, nwStandardButton, nwStatusShape, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel, NFixedPage, NScrollableForm
 from novelwriter.extensions.modified import NComboBox, NDialog, NIconToolButton, NSpinBox
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
@@ -215,9 +215,11 @@ class GuiProjectSettings(NDialog):
         targetDeadline = targetDeadline if self.goalsPage.targetDeadlineEnabled.isChecked() else None
         dailyGoalAuto = self.goalsPage.dailyGoalAuto.isChecked()
         dailyGoal = self.goalsPage.dailyGoal.value()
+        targetSkipRoots = [handle for handle, switch in self.goalsPage.skipRoots.items() if not switch.isChecked()]
 
         project.data.setProjectTarget(targetWordCount, targetDeadline)
         project.data.setDailyTarget(dailyGoal, dailyGoalAuto)
+        project.data.setTargetSkipRoots(targetSkipRoots)
 
         if self.statusPage.changed:
             logger.debug("Updating status labels")
@@ -255,6 +257,8 @@ class GuiProjectSettings(NDialog):
 
 
 class _SettingsPage(NScrollableForm):
+    """General Project Settings."""
+
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
@@ -329,12 +333,16 @@ class _SettingsPage(NScrollableForm):
 
 
 class _GoalsPage(NScrollableForm):
+    """Project Writing Goals."""
+
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent=parent)
 
         data = SHARED.project.data
         self.setHelpTextStyle(SHARED.theme.helpText)
-        self.setRowIndent(0)
+
+        # Writing Goals
+        self.addGroupLabel(self.tr("Writing Goals"))
 
         # Project Goals
         self.targetWordCount = NSpinBox(self, minVal=0, maxVal=9999999, step=1000)
@@ -387,10 +395,22 @@ class _GoalsPage(NScrollableForm):
         self.targetDeadlineEnabled.toggled.connect(self.targetDeadline.setEnabled)
         self.targetDeadlineEnabled.toggled.connect(self.dailyGoalAuto.setEnabled)
 
+        # Skip Roots
+        self.addGroupLabel(self.tr("Included Novel Root Folders"))
+
+        self.skipRoots: dict[str, NSwitch] = {}
+        for handle, item in SHARED.project.tree.iterRoots(nwItemClass.NOVEL):
+            switch = NSwitch(self)
+            switch.setChecked(handle not in data.targetSkipRoots)
+            self.skipRoots[handle] = switch
+            self.addRow(item.itemName, switch)
+
         self.finalise()
 
 
 class _StatusPage(NFixedPage):
+    """Project Status or Importance Settings."""
+
     C_DATA = 0
     C_LABEL = 0
     C_USAGE = 1
@@ -780,6 +800,8 @@ class _StatusPage(NFixedPage):
 
 
 class _ReplacePage(NFixedPage):
+    """Project Auto-Replace Settings."""
+
     C_KEY = 0
     C_REPL = 1
 

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -54,8 +54,6 @@ class GuiMainStatus(QStatusBar):
         self._refTime = -1.0
         self._userIdle = False
         self._debugInfo = False
-        self._sessProg = 0
-        self._projProg = 0
 
         iPx = SHARED.theme.baseIconHeight
         pPx = SHARED.theme.getTextWidth("0" * 18)
@@ -150,12 +148,11 @@ class GuiMainStatus(QStatusBar):
 
     def initProjectSettings(self) -> None:
         """Apply project settings."""
-        self.updateGoals(self._projProg, self._sessProg)
+        data = SHARED.project.data
+        self.updateGoals(data.targetLastCount, data.dailyProgress)
 
     def clearStatus(self) -> None:
         """Reset all widgets on the status bar to default values."""
-        self._sessProg = 0
-        self._projProg = 0
         self.sessBar.setVisible(False)
         self.projBar.setVisible(False)
         self.updateGoals(0, 0)
@@ -222,8 +219,6 @@ class GuiMainStatus(QStatusBar):
     def updateGoals(self, pProg: int, sProg: int) -> None:
         """Update the current project and session goals."""
         data = SHARED.project.data
-        self._projProg = pProg
-        self._sessProg = sProg
 
         if (dailyTarget := data.getEffectiveDailyGoal()) > 0:
             self.sessBar.setVisible(True)

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -36,6 +36,7 @@ from novelwriter.constants import nwConst, nwLabels, nwStats, trStats
 from novelwriter.extensions.modified import NClickableLabel, NIconToolButton
 from novelwriter.extensions.progressbars import NColorRangeProgress
 from novelwriter.extensions.statusled import StatusLED
+from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 
 if TYPE_CHECKING:
     from novelwriter.types import T_MsgSeverity
@@ -57,7 +58,7 @@ class GuiMainStatus(QStatusBar):
 
         iPx = SHARED.theme.baseIconHeight
         iSz = SHARED.theme.baseIconSize
-        pPx = SHARED.theme.getTextWidth("0" * 18)
+        pPx = SHARED.theme.getTextWidth("0" * 16)
 
         self.messageBox = _MessageWidget(self)
         self.insertWidget(0, self.messageBox)
@@ -192,6 +193,9 @@ class GuiMainStatus(QStatusBar):
         self.dayReset.refreshTheme()
         self.dayProg.refreshTheme()
         self.projProg.refreshTheme()
+
+        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
+        self.dayReset.setStyleSheet(buttonStyle)
 
     ##
     #  Setters

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -33,7 +33,7 @@ from PyQt6.QtWidgets import QApplication, QHBoxLayout, QLabel, QStatusBar, QWidg
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatPercent, formatTime, languageName
 from novelwriter.constants import nwConst, nwLabels, nwStats, trStats
-from novelwriter.extensions.modified import NClickableLabel
+from novelwriter.extensions.modified import NClickableLabel, NIconToolButton
 from novelwriter.extensions.progressbars import NColorRangeProgress
 from novelwriter.extensions.statusled import StatusLED
 
@@ -56,6 +56,7 @@ class GuiMainStatus(QStatusBar):
         self._debugInfo = False
 
         iPx = SHARED.theme.baseIconHeight
+        iSz = SHARED.theme.baseIconSize
         pPx = SHARED.theme.getTextWidth("0" * 18)
 
         self.messageBox = _MessageWidget(self)
@@ -65,20 +66,26 @@ class GuiMainStatus(QStatusBar):
         # =================
 
         # The Daily Progress Bar
-        self.sessBar = NColorRangeProgress(self, pPx, iPx + 4, 1)
-        self.sessBar.setValue(0)
-        self.sessBar.setMaximum(1)
-        self.sessBar.setVisible(False)
-        self.sessBar.setBarRangeColors(start="red", mid="yellow", end="green")
-        self.addPermanentWidget(self.sessBar)
+        self.dayReset = NIconToolButton(self, iSz, "revert:reset")
+        self.dayReset.setToolTip(self.tr("Reset Daily Progress"))
+        self.dayReset.setVisible(False)
+        self.dayReset.clicked.connect(self._resetDailyProgress)
+        self.addPermanentWidget(self.dayReset)
+
+        self.dayProg = NColorRangeProgress(self, pPx, iPx + 4, 1)
+        self.dayProg.setValue(0)
+        self.dayProg.setMaximum(1)
+        self.dayProg.setVisible(False)
+        self.dayProg.setBarRangeColors(start="red", mid="yellow", end="green")
+        self.addPermanentWidget(self.dayProg)
 
         # The Project Progress Bar
-        self.projBar = NColorRangeProgress(self, pPx, iPx + 4, 1)
-        self.projBar.setValue(0)
-        self.projBar.setMaximum(1)
-        self.projBar.setVisible(False)
-        self.projBar.setBarColor("blue")
-        self.addPermanentWidget(self.projBar)
+        self.projProg = NColorRangeProgress(self, pPx, iPx + 4, 1)
+        self.projProg.setValue(0)
+        self.projProg.setMaximum(1)
+        self.projProg.setVisible(False)
+        self.projProg.setBarColor("blue")
+        self.addPermanentWidget(self.projProg)
 
         # The Spell Checker Language
         self.langIcon = QLabel("", self)
@@ -153,8 +160,9 @@ class GuiMainStatus(QStatusBar):
 
     def clearStatus(self) -> None:
         """Reset all widgets on the status bar to default values."""
-        self.sessBar.setVisible(False)
-        self.projBar.setVisible(False)
+        self.dayReset.setVisible(False)
+        self.dayProg.setVisible(False)
+        self.projProg.setVisible(False)
         self.updateGoals(0, 0)
 
         self.setRefTime(-1.0)
@@ -181,8 +189,9 @@ class GuiMainStatus(QStatusBar):
         self.docIcon.setColors(colNone, colSaved, colUnsaved)
         self.projIcon.setColors(colNone, colSaved, colUnsaved)
 
-        self.sessBar.refreshTheme()
-        self.projBar.refreshTheme()
+        self.dayReset.refreshTheme()
+        self.dayProg.refreshTheme()
+        self.projProg.refreshTheme()
 
     ##
     #  Setters
@@ -221,22 +230,24 @@ class GuiMainStatus(QStatusBar):
         data = SHARED.project.data
 
         if (dailyTarget := data.getEffectiveDailyGoal()) > 0:
-            self.sessBar.setVisible(True)
-            self.sessBar.setMaximum(dailyTarget)
-            self.sessBar.setValue(min(sProg, dailyTarget))
-            self.sessBar.setCentreText(formatPercent(sProg, divisor=dailyTarget, prec=1))
-            self.sessBar.setToolTip(self.tr("Daily Progress: {0}/{1}").format(f"{sProg:n}", f"{dailyTarget:n}"))
+            self.dayReset.setVisible(True)
+            self.dayProg.setVisible(True)
+            self.dayProg.setMaximum(dailyTarget)
+            self.dayProg.setValue(min(sProg, dailyTarget))
+            self.dayProg.setCentreText(formatPercent(sProg, divisor=dailyTarget, prec=1))
+            self.dayProg.setToolTip(self.tr("Daily Progress: {0}/{1}").format(f"{sProg:n}", f"{dailyTarget:n}"))
         else:
-            self.sessBar.setVisible(False)
+            self.dayReset.setVisible(False)
+            self.dayProg.setVisible(False)
 
         if (projTarget := data.targetWordCount) > 0:
-            self.projBar.setVisible(True)
-            self.projBar.setMaximum(projTarget)
-            self.projBar.setValue(min(pProg, projTarget))
-            self.projBar.setCentreText(formatPercent(pProg, divisor=projTarget, prec=1))
-            self.projBar.setToolTip(self.tr("Project Progress: {0}/{1}").format(f"{pProg:n}", f"{projTarget:n}"))
+            self.projProg.setVisible(True)
+            self.projProg.setMaximum(projTarget)
+            self.projProg.setValue(min(pProg, projTarget))
+            self.projProg.setCentreText(formatPercent(pProg, divisor=projTarget, prec=1))
+            self.projProg.setToolTip(self.tr("Project Progress: {0}/{1}").format(f"{pProg:n}", f"{projTarget:n}"))
         else:
-            self.projBar.setVisible(False)
+            self.projProg.setVisible(False)
 
     def updateTime(self, idleTime: float = 0.0) -> None:
         """Update the session clock."""
@@ -289,6 +300,13 @@ class GuiMainStatus(QStatusBar):
         state = not CONFIG.showSessionTime
         self.timeText.setVisible(state)
         CONFIG.showSessionTime = state
+
+    @pyqtSlot()
+    def _resetDailyProgress(self) -> None:
+        """Ask for confirmation and reset the daily progress counter."""
+        if SHARED.question(self.tr("Do you want to reset the daily progress count?")):
+            SHARED.project.data.resetDailyProgress()
+            self.initProjectSettings()
 
     ##
     #  Debug

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1284,7 +1284,7 @@ class GuiMain(QMainWindow):
                     cTotal = data.currCounts[0]
 
             self.mainStatus.setProjectStats(cTotal, cTotal - iTotal)
-            self.mainStatus.updateGoals(data.currCounts[0], data.dailyProgress)
+            self.mainStatus.updateGoals(data.targetLastCount, data.dailyProgress)
 
     @pyqtSlot(int)
     def _mainStackChanged(self, index: int) -> None:

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 21:47:35">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2379" autoCount="430" editTime="110592">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:30:18">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2380" autoCount="430" editTime="110602">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -8,8 +8,11 @@
     <doBackup>no</doBackup>
     <language>en_GB</language>
     <spellChecking auto="yes">None</spellChecking>
-    <projectTarget date="None">15000</projectTarget>
-    <dailyTarget auto="no" last="100" date="2026-07-20">1000</dailyTarget>
+    <projectTarget date="None" last="1137">15000</projectTarget>
+    <dailyTarget auto="no" last="100" date="2026-07-23">1000</dailyTarget>
+    <targetSkipRoots>
+      <entry>d2d81f4831814</entry>
+    </targetSkipRoots>
     <lastHandle>
       <entry key="editor">636b6aa9b697b</entry>
       <entry key="viewer">636b6aa9b697b</entry>

--- a/tests/_files/nwProject-1.5.nwx
+++ b/tests/_files/nwProject-1.5.nwx
@@ -8,9 +8,11 @@
     <doBackup>no</doBackup>
     <language>en_GB</language>
     <spellChecking auto="yes">None</spellChecking>
-    <projectTarget date="2026-08-20" last="0">100000</projectTarget>
+    <projectTarget date="2026-08-20" last="1137">100000</projectTarget>
     <dailyTarget auto="no" last="0" date="2026-07-20">1000</dailyTarget>
-    <targetSkipRoots />
+    <targetSkipRoots>
+      <entry>d2d81f4831814</entry>
+    </targetSkipRoots>
     <lastHandle>
       <entry key="editor">636b6aa9b697b</entry>
       <entry key="viewer">636b6aa9b697b</entry>

--- a/tests/_files/nwProject-1.5.nwx
+++ b/tests/_files/nwProject-1.5.nwx
@@ -8,8 +8,9 @@
     <doBackup>no</doBackup>
     <language>en_GB</language>
     <spellChecking auto="yes">None</spellChecking>
-    <projectTarget date="2026-08-20">100000</projectTarget>
+    <projectTarget date="2026-08-20" last="0">100000</projectTarget>
     <dailyTarget auto="no" last="0" date="2026-07-20">1000</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">636b6aa9b697b</entry>
       <entry key="viewer">636b6aa9b697b</entry>

--- a/tests/_reference/coreProject_NewFileFolder_nwProject.nwx
+++ b/tests/_reference/coreProject_NewFileFolder_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 17:43:21">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:18:11">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>None</language>
     <spellChecking auto="no">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
-    <dailyTarget auto="no" last="19" date="2026-07-19">0</dailyTarget>
+    <projectTarget date="None" last="10">0</projectTarget>
+    <dailyTarget auto="no" last="10" date="2026-07-19">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/coreProject_NewRoot_nwProject.nwx
+++ b/tests/_reference/coreProject_NewRoot_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 17:43:21">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:18:11">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>None</language>
     <spellChecking auto="no">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="9">0</projectTarget>
     <dailyTarget auto="no" last="9" date="2026-07-19">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/coreTools_DocDuplicator_nwProject.nwx
+++ b/tests/_reference/coreTools_DocDuplicator_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 17:43:20">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:22:46">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>None</language>
     <spellChecking auto="no">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="28">0</projectTarget>
     <dailyTarget auto="no" last="28" date="2026-07-19">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/coreTools_ProjectBuilderA_nwProject.nwx
+++ b/tests/_reference/coreTools_ProjectBuilderA_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 17:43:20">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:18:10">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Project A</name>
     <author>Jane Doe</author>
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>en_GB</language>
     <spellChecking auto="no">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="0">0</projectTarget>
     <dailyTarget auto="no" last="0" date="2026-07-19">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/coreTools_ProjectBuilderB_nwProject.nwx
+++ b/tests/_reference/coreTools_ProjectBuilderB_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 17:43:20">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:18:10">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="1" autoCount="0" editTime="0">
     <name>Test Project B</name>
     <author>Jane Doe</author>
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>en_GB</language>
     <spellChecking auto="no">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="0">0</projectTarget>
     <dailyTarget auto="no" last="0" date="2026-07-19">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/guiEditor_Main_Final_nwProject.nwx
+++ b/tests/_reference/guiEditor_Main_Final_nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 17:44:01">
-  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="4">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:25:45">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="3" autoCount="2" editTime="5">
     <name>New Project</name>
     <author>Jane Doe</author>
   </project>
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>None</language>
     <spellChecking auto="no">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
-    <dailyTarget auto="no" last="201" date="2026-07-19">0</dailyTarget>
+    <projectTarget date="None" last="174">0</projectTarget>
+    <dailyTarget auto="no" last="174" date="2026-07-23">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">000000000000f</entry>
       <entry key="viewer">000000000000f</entry>

--- a/tests/_reference/guiEditor_Main_Initial_nwProject.nwx
+++ b/tests/_reference/guiEditor_Main_Initial_nwProject.nwx
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="6" timeStamp="2026-07-18 15:37:29">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:23:34">
   <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="2" autoCount="1" editTime="0">
     <name>New Project</name>
     <author>Jane Doe</author>
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>None</language>
     <spellChecking auto="no">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="9">0</projectTarget>
     <dailyTarget auto="no" last="9" date="2026-07-19">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">000000000000c</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/projectXML_ReadLegacy10.nwx
+++ b/tests/_reference/projectXML_ReadLegacy10.nwx
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>None</language>
     <spellChecking auto="yes">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="0">0</projectTarget>
     <dailyTarget auto="no" last="0" date="2020-05-28">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/projectXML_ReadLegacy11.nwx
+++ b/tests/_reference/projectXML_ReadLegacy11.nwx
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>None</language>
     <spellChecking auto="yes">None</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="0">0</projectTarget>
     <dailyTarget auto="no" last="0" date="2020-06-26">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/projectXML_ReadLegacy12.nwx
+++ b/tests/_reference/projectXML_ReadLegacy12.nwx
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>en_GB</language>
     <spellChecking auto="yes">en_GB</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="0">0</projectTarget>
     <dailyTarget auto="no" last="0" date="2021-08-30">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/projectXML_ReadLegacy13.nwx
+++ b/tests/_reference/projectXML_ReadLegacy13.nwx
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>en_GB</language>
     <spellChecking auto="yes">en_GB</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="0">0</projectTarget>
     <dailyTarget auto="no" last="0" date="2022-10-25">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/_reference/projectXML_ReadLegacy14.nwx
+++ b/tests/_reference/projectXML_ReadLegacy14.nwx
@@ -8,8 +8,9 @@
     <doBackup>yes</doBackup>
     <language>en_GB</language>
     <spellChecking auto="yes">en_GB</spellChecking>
-    <projectTarget date="None">0</projectTarget>
+    <projectTarget date="None" last="0">0</projectTarget>
     <dailyTarget auto="no" last="0" date="2022-10-15">0</dailyTarget>
+    <targetSkipRoots />
     <lastHandle>
       <entry key="editor">None</entry>
       <entry key="viewer">None</entry>

--- a/tests/core/test_projectdata.py
+++ b/tests/core/test_projectdata.py
@@ -227,6 +227,17 @@ def testProjectData_TargetSkipRoots(mockGUI, mockRnd, fncPath, ipsumText):
     assert data.dailyProgress == writtenWords
     assert data._targetInitCount == startWords
 
+    # Excluding an empty root is still a change in roots, but since it
+    # has no words, the reference count and the baseline are untouched
+    thirdRoot = project.newRoot(nwItemClass.NOVEL)
+    project.setProjectChanged(False)
+    data.setTargetSkipRoots([thirdRoot])
+    assert project.projChanged is True
+    assert data.targetSkipRoots == {thirdRoot}
+    assert data.targetLastCount == newWords
+    assert data.dailyProgress == writtenWords
+    assert data._targetInitCount == startWords
+
 
 @pytest.mark.core
 def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):

--- a/tests/core/test_projectdata.py
+++ b/tests/core/test_projectdata.py
@@ -94,7 +94,7 @@ def testProjectData_Language(mockGUI):
 
 @pytest.mark.core
 def testProjectData_LastHandle(mockGUI):
-    """Test the setLastHandle and setLastHandles setters."""
+    """Test the setLastHandle and setInitLastHandles setters."""
     project = MockProject()
     data = ProjectData(project)  # type: ignore
 
@@ -107,13 +107,13 @@ def testProjectData_LastHandle(mockGUI):
     data.setLastHandle("0123456789abc", "editor")
     assert data.getLastHandle("editor") == "0123456789abc"
 
-    # setLastHandles requires a dict
+    # setInitLastHandles requires a dict
     project.changed = 0
-    data.setLastHandles(["not", "a", "dict"])  # type: ignore
+    data.setInitLastHandles(["not", "a", "dict"])  # type: ignore
     assert project.changed == 0
 
     # Unknown keys in the dict are skipped, known keys are updated
-    data.setLastHandles({"unknownKey": "0123456789abc", "editor": "0123456789abd"})
+    data.setInitLastHandles({"unknownKey": "0123456789abc", "editor": "0123456789abd"})
     assert data.getLastHandle("editor") == "0123456789abd"
 
 
@@ -150,7 +150,7 @@ def testProjectData_AutoReplace(mockGUI):
 
 @pytest.mark.core
 def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):
-    """Test the setDailyTargetCurrent setter. A stored reference count
+    """Test the setInitDailyTarget setter. A stored reference count
     must only be restored when it was recorded on the same day; a count
     from any other day is stale and must be discarded so it cannot leak
     into today's progress calculation.
@@ -162,18 +162,18 @@ def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):
     data = ProjectData(project)  # type: ignore
 
     # A record from the same day is restored as-is
-    data.setDailyTargetCurrent(60, "2026-07-22")
+    data.setInitDailyTarget(60, "2026-07-22")
     assert data.dailyLastCount == 60
     assert data._dailyLastDate == date(2026, 7, 22)
 
     # A record from an earlier day is stale and discarded, and the date
     # is bumped to today so it isn't mistaken for a fresh record later
-    data.setDailyTargetCurrent(100, "2026-07-20")
+    data.setInitDailyTarget(100, "2026-07-20")
     assert data.dailyLastCount == 0
     assert data._dailyLastDate == date(2026, 7, 22)
 
     # A missing/invalid date is treated the same as a stale record
-    data.setDailyTargetCurrent(100, None)
+    data.setInitDailyTarget(100, None)
     assert data.dailyLastCount == 0
     assert data._dailyLastDate == date(2026, 7, 22)
 
@@ -181,7 +181,7 @@ def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):
     # loaded. The stale count must not offset today's progress
     data = ProjectData(project)  # type: ignore
     data.setInitCounts(wNovel=500)
-    data.setDailyTargetCurrent(100, "2026-07-20")
+    data.setInitDailyTarget(100, "2026-07-20")
     data.setDailyProgress(500)
     assert data.dailyProgress == 0
 
@@ -221,7 +221,7 @@ def testProjectData_DailyProgress(monkeypatch, mockGUI):
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, None)
     data.setInitCounts(wNovel=560)
-    data.setDailyTargetCurrent(60, "2026-07-20")
+    data.setInitDailyTarget(60, "2026-07-20")
 
     # No new typing yet, so progress should still read 60, and the
     # remaining count must match the earlier session, not be reduced by

--- a/tests/core/test_projectdata.py
+++ b/tests/core/test_projectdata.py
@@ -26,7 +26,11 @@ from datetime import date
 import pytest
 
 from novelwriter.core import projectdata
+from novelwriter.core.project import NWProject
 from novelwriter.core.projectdata import ProjectData
+from novelwriter.enum import nwItemClass
+
+from tests.helpers import C, buildTestProject
 
 
 class MockProject:
@@ -149,6 +153,82 @@ def testProjectData_AutoReplace(mockGUI):
 
 
 @pytest.mark.core
+def testProjectData_TargetSkipRoots(mockGUI, mockRnd, fncPath, ipsumText):
+    """Test the setTargetSkipRoots setter against a real project tree.
+    Excluding a root folder causes a step change in the daily reference
+    count, so the target baseline must be corrected by the same amount
+    to keep today's progress continuous, and re-setting the same roots
+    must be a no-op.
+    """
+    project = NWProject()
+    buildTestProject(project, fncPath)
+    data = project.data
+    tree = project.tree
+
+    # A project file loaded with no skip roots set starts out empty
+    data.setInitTargetSkipRoots([])
+    assert data.targetSkipRoots == set()
+
+    # Add a second Novel root folder with a file of lorem ipsum text
+    secondRoot = project.newRoot(nwItemClass.NOVEL)
+    secondDoc = project.newFile("Second Chapter", secondRoot) or ""
+    project.storage.getDocument(secondDoc).writeDocument("## Second Chapter\n\n" + ipsumText[0])
+    project.index.reIndexHandle(secondDoc)
+
+    secondWords = tree[secondDoc].wordCount  # type: ignore
+    assert secondWords > 0
+
+    # Establish a baseline as if the project had just been loaded, with
+    # both Novel roots counted, and nothing written yet this session
+    startWords = tree.sumCounts()[0]
+    data.setInitTargetCount(startWords)
+    data.setProjectTarget(10000, None)
+    project.updateCounts()
+    assert data.dailyProgress == 0
+    assert data.targetLastCount == startWords
+
+    # Some more text is written in the original chapter, in a root that
+    # stays included, which shows up as today's progress
+    doc = project.storage.getDocument(C.hSceneDoc)
+    doc.writeDocument((doc.readDocument() or "") + "\n\n" + ipsumText[1])
+    project.index.reIndexHandle(C.hSceneDoc)
+    project.updateCounts()
+
+    writtenWords = data.dailyProgress
+    newWords = tree.sumCounts()[0]
+    assert writtenWords > 0
+    assert data.targetLastCount == newWords
+
+    # Excluding the second root drops the reference count by its word
+    # count. The baseline must shift by the same amount so that today's
+    # progress, made entirely in the other root, stays continuous
+    project.setProjectChanged(False)
+    data.setTargetSkipRoots([secondRoot])
+    assert project.projChanged is True
+    assert data.targetSkipRoots == {secondRoot}
+    assert data.targetLastCount == newWords - secondWords
+    assert data.dailyProgress == writtenWords
+    assert data._targetInitCount == startWords - secondWords
+
+    # Setting the same root again, even wrapped in a fresh list, is a no-op
+    project.setProjectChanged(False)
+    data.setTargetSkipRoots([secondRoot])
+    assert project.projChanged is False
+    assert data.targetLastCount == newWords - secondWords
+    assert data.dailyProgress == writtenWords
+
+    # Re-including the root restores the total, and progress is still
+    # continuous across the second step change
+    project.setProjectChanged(False)
+    data.setTargetSkipRoots([])
+    assert project.projChanged is True
+    assert data.targetSkipRoots == set()
+    assert data.targetLastCount == newWords
+    assert data.dailyProgress == writtenWords
+    assert data._targetInitCount == startWords
+
+
+@pytest.mark.core
 def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):
     """Test the setInitDailyTarget setter. A stored reference count
     must only be restored when it was recorded on the same day; a count
@@ -180,7 +260,7 @@ def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):
     # End-to-end: a project file with a daily target set two days ago is
     # loaded. The stale count must not offset today's progress
     data = ProjectData(project)  # type: ignore
-    data.setInitCounts(wNovel=500)
+    data.setInitTargetCount(500)
     data.setInitDailyTarget(100, "2026-07-20")
     data.setDailyProgress(500)
     assert data.dailyProgress == 0
@@ -199,7 +279,7 @@ def testProjectData_DailyProgress(monkeypatch, mockGUI):
     project = MockProject()
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, None)
-    data.setInitCounts(wNovel=500)
+    data.setInitTargetCount(500)
 
     # First update of a session with no prior daily record: the progress
     # is measured from the initial count, and the remaining word count is
@@ -220,7 +300,7 @@ def testProjectData_DailyProgress(monkeypatch, mockGUI):
     # 60-word progress forward
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, None)
-    data.setInitCounts(wNovel=560)
+    data.setInitTargetCount(560)
     data.setInitDailyTarget(60, "2026-07-20")
 
     # No new typing yet, so progress should still read 60, and the
@@ -263,7 +343,7 @@ def testProjectData_EffectiveDailyGoal(monkeypatch, mockGUI):
     project = MockProject()
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, date(2026, 7, 24))
-    data.setInitCounts(wNovel=400)
+    data.setInitTargetCount(400)
     data.setDailyProgress(400)
     assert data._remainingWordCount == 600
 

--- a/tests/core/test_projectxml.py
+++ b/tests/core/test_projectxml.py
@@ -170,9 +170,7 @@ def testProjectXMLReader_ReadCurrent(monkeypatch, mockGUI, tstPaths, fncPath):
     assert data.targetDeadline == date.fromisoformat("2026-08-20")
     assert data.dailyGoal == 1000
     assert data.dailyGoalAuto is False
-    # The fixture's daily target date (2026-07-20) is stale by the time this
-    # test runs, so the loaded reference count must be discarded and the
-    # date bumped to today rather than kept as the stale loaded value
+    assert data.targetSkipRoots == {"d2d81f4831814"}
     assert data._dailyLastDate == date.today()
     assert data._dailyLastCount == 0
 

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -680,7 +680,7 @@ def testProjectTree_OtherMethods(qtbot, monkeypatch, mockGUI, fncPath, mockRnd):
     ]
 
     # Refresh All
-    assert tree.sumCounts() == (9, 0, 40, 0)
+    assert tree.sumCounts() == (9, 0, 40, 0, 9)
     assert tree.model.root.count == 9
 
     # Items with no layout (e.g. folders created directly) are not counted
@@ -688,7 +688,7 @@ def testProjectTree_OtherMethods(qtbot, monkeypatch, mockGUI, fncPath, mockRnd):
     assert noLayoutHandle is not None
     tree[noLayoutHandle].setLayout(nwItemLayout.NO_LAYOUT)  # type: ignore
     tree[noLayoutHandle].setWordCount(99)  # type: ignore
-    assert tree.sumCounts() == (9, 0, 40, 0)
+    assert tree.sumCounts() == (9, 0, 40, 0, 9)
     tree.remove(noLayoutHandle)
 
     for node in tree.nodes.values():

--- a/tests/gui/test_statusbar.py
+++ b/tests/gui/test_statusbar.py
@@ -131,12 +131,29 @@ def testGuiStatusBar_Main(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     SHARED.project.data.setDailyTarget(500, False)
     SHARED.project.data.setProjectTarget(2000, None)
     status.updateGoals(100, 50)
-    assert status.sessBar.isVisible() is True
-    assert status.sessBar.maximum() == 500
-    assert status.sessBar.value() == 50
-    assert status.projBar.isVisible() is True
-    assert status.projBar.maximum() == 2000
-    assert status.projBar.value() == 100
+    assert status.dayProg.isVisible() is True
+    assert status.dayProg.maximum() == 500
+    assert status.dayProg.value() == 50
+    assert status.projProg.isVisible() is True
+    assert status.projProg.maximum() == 2000
+    assert status.projProg.value() == 100
+
+    # Reset Daily Progress
+    assert status.dayReset.isVisible() is True
+    SHARED.project.data.setDailyProgress(150)
+    assert SHARED.project.data.dailyProgress == 150
+
+    # Declining the confirmation leaves the progress untouched
+    with monkeypatch.context() as mp:
+        mp.setattr(SHARED, "question", lambda *a, **k: False)
+        status._resetDailyProgress()
+    assert SHARED.project.data.dailyProgress == 150
+
+    # Confirming resets the progress to zero
+    with monkeypatch.context() as mp:
+        mp.setattr(SHARED, "question", lambda *a, **k: True)
+        status._resetDailyProgress()
+    assert SHARED.project.data.dailyProgress == 0
 
     # Set message
     status.messageBox.setMessage("Hi!", "info", 10000)


### PR DESCRIPTION
**Summary:**

This PR adds a way to exclude root folders from writing goals, and reworks the counter itself to only count active documents in novel folders, skipping everything else. It also adds a reset button for the daily goal.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
