### PR TITLE
Change daily progress accounting

### DIFF
--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -53,6 +53,7 @@ class ProjectItem:
         "_charInit",
         "_class",
         "_cursorPos",
+        "_dailyTarget",
         "_expanded",
         "_handle",
         "_heading",
@@ -94,6 +95,9 @@ class ProjectItem:
         self._cursorPos = 0  # Last cursor position
         self._charInit = 0  # Initial character count
         self._wordInit = 0  # Initial word count
+
+        # Internals
+        self._dailyTarget = False  # Whether the item is included in the project goal
 
     def __repr__(self) -> str:
         """Return a string representation of the item."""
@@ -273,6 +277,8 @@ class ProjectItem:
         self._charInit = self._charCount
         self._wordInit = self._wordCount
 
+        self._updateDailyTarget()
+
         return True
 
     @classmethod
@@ -297,6 +303,7 @@ class ProjectItem:
         new._cursorPos = source._cursorPos
         new._charInit = source._charInit
         new._wordInit = source._wordInit
+        new._dailyTarget = source._dailyTarget
         return new
 
     ##
@@ -445,12 +452,7 @@ class ProjectItem:
         """Return the total word count and session change for items
         included in the project goal.
         """
-        if (
-            self._active
-            and self._class == nwItemClass.NOVEL
-            and self._layout == nwItemLayout.DOCUMENT
-            and self._root not in self._project.data.targetSkipRoots
-        ):
+        if self._dailyTarget and self._root not in self._project.data.targetSkipRoots:
             return self._wordCount, self._wordCount - self._wordInit
         return 0, 0
 
@@ -472,12 +474,12 @@ class ProjectItem:
         if self._layout == nwItemLayout.NO_LAYOUT:
             # If no layout is set, pick one
             if self.isNovelLike():
-                self._layout = nwItemLayout.DOCUMENT
+                self.setLayout(nwItemLayout.DOCUMENT)
             else:
-                self._layout = nwItemLayout.NOTE
+                self.setLayout(nwItemLayout.NOTE)
         elif not self.documentAllowed():
             # Change layout to note if it is not in an allowed folder
-            self._layout = nwItemLayout.NOTE
+            self.setLayout(nwItemLayout.NOTE)
 
         if self._status is None:
             self.setStatus("New")  # This forces a default value lookup
@@ -514,6 +516,10 @@ class ProjectItem:
         else:
             self._root = None
 
+        if self._dailyTarget:
+            # May have moved between skipped/non-skipped roots
+            self._project.markCountsDirty()
+
     def setOrder(self, order: Any) -> None:
         """Set the item order, and ensure that it is valid. This value
         is purely a meta value, and not actually used by novelWriter at
@@ -544,6 +550,7 @@ class ProjectItem:
         else:
             logger.error("Unrecognised item class '%s'", value)
             self._class = nwItemClass.NO_CLASS
+        self._processDailyTarget()
 
     def setLayout(self, value: Any) -> None:
         """Set the item layout from either a proper nwItemLayout, or set
@@ -556,6 +563,7 @@ class ProjectItem:
         else:
             logger.error("Unrecognised item layout '%s'", value)
             self._layout = nwItemLayout.NO_LAYOUT
+        self._processDailyTarget()
 
     def setStatus(self, value: Any) -> None:
         """Set the item status by looking it up in the valid status
@@ -575,6 +583,7 @@ class ProjectItem:
             self._active = state
         else:
             self._active = False
+        self._processDailyTarget()
 
     def setExpanded(self, state: Any) -> None:
         """Set the expanded status of an item in the project tree."""
@@ -619,3 +628,22 @@ class ProjectItem:
             self._cursorPos = max(0, position)
         else:
             self._cursorPos = 0
+
+    ##
+    #  Internal Functions
+    ##
+
+    def _updateDailyTarget(self) -> None:
+        """Update whether the item is included in the project goal. This
+        does not check if the item is skipped.
+        """
+        self._dailyTarget = self._active and self._class == nwItemClass.NOVEL and self._layout == nwItemLayout.DOCUMENT
+
+    def _processDailyTarget(self) -> None:
+        """Update the daily target status of the item and notify the
+        project of any changes.
+        """
+        oldStatus = self._dailyTarget
+        self._updateDailyTarget()
+        if oldStatus != self._dailyTarget:
+            self._project.markCountsDirty()

--- a/novelwriter/core/item.py
+++ b/novelwriter/core/item.py
@@ -92,8 +92,8 @@ class ProjectItem:
         self._wordCount = 0  # Current word count
         self._paraCount = 0  # Current paragraph count
         self._cursorPos = 0  # Last cursor position
-        self._wordInit = 0  # Initial character count
-        self._charInit = 0  # Initial word count
+        self._charInit = 0  # Initial character count
+        self._wordInit = 0  # Initial word count
 
     def __repr__(self) -> str:
         """Return a string representation of the item."""
@@ -181,7 +181,7 @@ class ProjectItem:
 
     @property
     def initCount(self) -> int:
-        return self._wordInit if CONFIG.useCharCount else self._charInit
+        return self._charInit if CONFIG.useCharCount else self._wordInit
 
     @property
     def cursorPos(self) -> int:
@@ -270,8 +270,8 @@ class ProjectItem:
             self._paraCount = 0
             self._cursorPos = 0
 
-        self._wordInit = self._charCount
-        self._charInit = self._wordCount
+        self._charInit = self._charCount
+        self._wordInit = self._wordCount
 
         return True
 
@@ -295,8 +295,8 @@ class ProjectItem:
         new._wordCount = source._wordCount
         new._paraCount = source._paraCount
         new._cursorPos = source._cursorPos
-        new._wordInit = source._wordInit
         new._charInit = source._charInit
+        new._wordInit = source._wordInit
         return new
 
     ##
@@ -441,14 +441,18 @@ class ProjectItem:
         """Check if item is a novel document."""
         return self._layout == nwItemLayout.DOCUMENT
 
-    def isDailyTarget(self) -> bool:
-        """Check if item is a daily target item."""
-        return (
+    def dailyProgress(self) -> tuple[int, int]:
+        """Return the total word count and session change for items
+        included in the project goal.
+        """
+        if (
             self._active
             and self._class == nwItemClass.NOVEL
             and self._layout == nwItemLayout.DOCUMENT
             and self._root not in self._project.data.targetSkipRoots
-        )
+        ):
+            return self._wordCount, self._wordCount - self._wordInit
+        return 0, 0
 
     ##
     #  Special Setters

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -567,9 +567,9 @@ class NWProject:
 
     def updateCounts(self) -> None:
         """Update the total word and character count values."""
-        wNovel, wNotes, cNovel, cNotes, dailyWords = self._tree.sumCounts()
+        wNovel, wNotes, cNovel, cNotes, wSession, wTarget = self._tree.sumCounts()
         self._data.setCurrCounts(wNovel=wNovel, wNotes=wNotes, cNovel=cNovel, cNotes=cNotes)
-        self._data.setDailyProgress(dailyWords)
+        self._data.setDailyProgress(wSession, wTarget)
 
     def countStatus(self) -> None:
         """Count how many times the various status flags are used in the

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -78,6 +78,7 @@ class NWProject:
 
     __slots__ = (
         "_changed",
+        "_countsDirty",
         "_data",
         "_index",
         "_langData",
@@ -105,6 +106,7 @@ class NWProject:
         self._changed = False  # The project has unsaved changes
         self._valid = False  # The project was successfully loaded
         self._state = NWProjectState.UNKNOWN
+        self._countsDirty = False  # The word counts need to be recalculated
 
         # Internal Mapping
         self.tr = partial(QCoreApplication.translate, "NWProject")
@@ -180,6 +182,11 @@ class NWProject:
     def currentTotalCount(self) -> int:
         """Return the current total word count from the tree."""
         return self._tree.model.root.count
+
+    @property
+    def countsDirty(self) -> bool:
+        """Return whether the word counts need to be recalculated."""
+        return self._countsDirty
 
     ##
     #  Item Methods
@@ -570,6 +577,13 @@ class NWProject:
         wNovel, wNotes, cNovel, cNotes, wSession, wTarget = self._tree.sumCounts()
         self._data.setCurrCounts(wNovel=wNovel, wNotes=wNotes, cNovel=cNovel, cNotes=cNotes)
         self._data.setDailyProgress(wSession, wTarget)
+        self._countsDirty = False
+
+    def markCountsDirty(self) -> None:
+        """Flag that an item's goal eligibility has changed, so the word
+        counts are stale and must be recalculated.
+        """
+        self._countsDirty = True
 
     def countStatus(self) -> None:
         """Count how many times the various status flags are used in the

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -80,7 +80,6 @@ class ProjectData:
         "_spellLang",
         "_status",
         "_targetDeadline",
-        "_targetInitCount",
         "_targetLastCount",
         "_targetSkipRoots",
         "_targetWordCount",
@@ -108,7 +107,6 @@ class ProjectData:
 
         # Writing Target
         self._targetWordCount = 0
-        self._targetInitCount = 0
         self._targetLastCount = 0
         self._targetDeadline = None
         self._targetSkipRoots: set[str] = set()
@@ -369,11 +367,7 @@ class ProjectData:
         skipRoots = {str(handle) for handle in updated}
         if skipRoots != self._targetSkipRoots:
             self._targetSkipRoots = skipRoots
-            oldCount = self._targetLastCount
             self._project.updateCounts()
-            if self._targetLastCount != oldCount:
-                self._targetInitCount += self._targetLastCount - oldCount
-                self.setDailyProgress(self._targetLastCount)
             self._project.setProjectChanged(True)
 
     def setDailyTarget(self, value: Any, auto: Any) -> None:
@@ -383,18 +377,17 @@ class ProjectData:
             self._dailyGoalAuto = checkBool(auto, False)
             self._project.setProjectChanged(True)
 
-    def setDailyProgress(self, count: int) -> None:
-        """Set the current daily goal progress."""
+    def setDailyProgress(self, session: int, target: int) -> None:
+        """Set the current daily and project goal progress."""
         if self._dailyLastDate != date.today():
             # The date has changed since the last update or was not set.
             # In either case, we shift to a new day with new counts.
             self._dailyLastCount -= self._dailyProgress
             self._dailyLastDate = date.today()
 
-        offset = self._targetInitCount - self._dailyLastCount
-        self._dailyProgress = count - offset
-        self._remainingWordCount = self._targetWordCount - offset
-        self._targetLastCount = count
+        self._dailyProgress = self._dailyLastCount + session
+        self._remainingWordCount = self._targetWordCount - (target - self._dailyProgress)
+        self._targetLastCount = target
 
     def setLanguage(self, value: str | None) -> None:
         """Set the project language."""
@@ -458,9 +451,7 @@ class ProjectData:
 
     def setInitTargetCount(self, value: Any) -> None:
         """Set the initial target count."""
-        count = checkInt(value, 0)
-        self._targetInitCount = count
-        self._targetLastCount = count
+        self._targetLastCount = checkInt(value, 0)
 
     def setInitTargetSkipRoots(self, value: Sequence[str]) -> None:
         """Set the initial target skip root handles dictionary."""
@@ -503,6 +494,7 @@ class ProjectData:
         the overall project target progress.
         """
         self._dailyLastDate = date.today()
-        self._dailyLastCount = self._targetInitCount - self._targetLastCount
-        self.setDailyProgress(self._targetLastCount)
+        self._dailyLastCount -= self._dailyProgress
+        self._dailyProgress = 0
+        self._remainingWordCount = self._targetWordCount - self._targetLastCount
         self._project.setProjectChanged(True)

--- a/novelwriter/core/tree.py
+++ b/novelwriter/core/tree.py
@@ -438,13 +438,14 @@ class ProjectTree:
 
         return True
 
-    def sumCounts(self) -> tuple[int, int, int, int, int]:
+    def sumCounts(self) -> tuple[int, int, int, int, int, int]:
         """Loop over all entries and add up the word and char counts."""
         novelWords = 0
         notesWords = 0
         novelChars = 0
         notesChars = 0
-        dailyWords = 0
+        sessionWords = 0
+        targetWords = 0
         for item in self._items.values():
             if item.itemLayout == nwItemLayout.NOTE:
                 notesWords += item.wordCount
@@ -452,9 +453,12 @@ class ProjectTree:
             elif item.itemLayout == nwItemLayout.DOCUMENT:
                 novelWords += item.wordCount
                 novelChars += item.charCount
-            if item.isDailyTarget():
-                dailyWords += item.wordCount
-        return novelWords, notesWords, novelChars, notesChars, dailyWords
+
+            wTarget, wSession = item.dailyProgress()
+            sessionWords += wSession
+            targetWords += wTarget
+
+        return novelWords, notesWords, novelChars, notesChars, sessionWords, targetWords
 
     ##
     #  Tree Item Methods

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -1263,7 +1263,7 @@ class GuiMain(QMainWindow):
             self.mainStatus.updateGoals(0, 0)
 
         currentTotalCount = SHARED.project.currentTotalCount
-        if self._lastTotalCount != currentTotalCount:
+        if self._lastTotalCount != currentTotalCount or SHARED.project.countsDirty:
             self._lastTotalCount = currentTotalCount
 
             data = SHARED.project.data

--- a/tests/core/test_item.py
+++ b/tests/core/test_item.py
@@ -183,9 +183,9 @@ def testProjectItem_Setters(mockGUI, mockRnd, fncPath):
     item._wordInit = 12
     item._charInit = 34
     CONFIG.useCharCount = False
-    assert item.initCount == 34
-    CONFIG.useCharCount = True
     assert item.initCount == 12
+    CONFIG.useCharCount = True
+    assert item.initCount == 34
     CONFIG.useCharCount = False
 
     # CursorPos

--- a/tests/core/test_projectdata.py
+++ b/tests/core/test_projectdata.py
@@ -155,21 +155,17 @@ def testProjectData_AutoReplace(mockGUI):
 @pytest.mark.core
 def testProjectData_TargetSkipRoots(mockGUI, mockRnd, fncPath, ipsumText):
     """Test the setTargetSkipRoots setter against a real project tree.
-    Excluding a root folder causes a step change in the daily reference
-    count, so the target baseline must be corrected by the same amount
-    to keep today's progress continuous, and re-setting the same roots
-    must be a no-op.
+    The daily progress is tracked per item from the session baseline,
+    so excluding or including a root only changes today's progress by
+    what was actually written in that root this session, not by its
+    full word count, and re-setting the same roots must be a no-op.
     """
     project = NWProject()
     buildTestProject(project, fncPath)
-    data = project.data
     tree = project.tree
 
-    # A project file loaded with no skip roots set starts out empty
-    data.setInitTargetSkipRoots([])
-    assert data.targetSkipRoots == set()
-
-    # Add a second Novel root folder with a file of lorem ipsum text
+    # Add a second Novel root folder with a file of lorem ipsum text,
+    # written before the session baseline below is established
     secondRoot = project.newRoot(nwItemClass.NOVEL)
     secondDoc = project.newFile("Second Chapter", secondRoot) or ""
     project.storage.getDocument(secondDoc).writeDocument("## Second Chapter\n\n" + ipsumText[0])
@@ -178,12 +174,20 @@ def testProjectData_TargetSkipRoots(mockGUI, mockRnd, fncPath, ipsumText):
     secondWords = tree[secondDoc].wordCount  # type: ignore
     assert secondWords > 0
 
-    # Establish a baseline as if the project had just been loaded, with
-    # both Novel roots counted, and nothing written yet this session
-    startWords = tree.sumCounts()[0]
-    data.setInitTargetCount(startWords)
+    # Reload the project so the per-item session baseline is set to the
+    # word counts as they stand now, as if the project had just been
+    # opened with both Novel roots counted. The daily progress carried
+    # over from the earlier in-memory build isn't relevant here, so it
+    # is explicitly reset to a known-zero starting point
+    project.saveProject(autoSave=True)
+    assert project.openProject(fncPath) is True
+    data = project.data
+    tree = project.tree
     data.setProjectTarget(10000, None)
-    project.updateCounts()
+    data.resetDailyProgress()
+
+    startWords = tree.sumCounts()[5]
+    assert data.targetSkipRoots == set()
     assert data.dailyProgress == 0
     assert data.targetLastCount == startWords
 
@@ -195,20 +199,19 @@ def testProjectData_TargetSkipRoots(mockGUI, mockRnd, fncPath, ipsumText):
     project.updateCounts()
 
     writtenWords = data.dailyProgress
-    newWords = tree.sumCounts()[0]
+    newWords = tree.sumCounts()[5]
     assert writtenWords > 0
     assert data.targetLastCount == newWords
 
-    # Excluding the second root drops the reference count by its word
-    # count. The baseline must shift by the same amount so that today's
-    # progress, made entirely in the other root, stays continuous
+    # Excluding the second root drops the project total by its word
+    # count, but since none of those words were written this session,
+    # today's progress is unaffected
     project.setProjectChanged(False)
     data.setTargetSkipRoots([secondRoot])
     assert project.projChanged is True
     assert data.targetSkipRoots == {secondRoot}
     assert data.targetLastCount == newWords - secondWords
     assert data.dailyProgress == writtenWords
-    assert data._targetInitCount == startWords - secondWords
 
     # Setting the same root again, even wrapped in a fresh list, is a no-op
     project.setProjectChanged(False)
@@ -218,17 +221,16 @@ def testProjectData_TargetSkipRoots(mockGUI, mockRnd, fncPath, ipsumText):
     assert data.dailyProgress == writtenWords
 
     # Re-including the root restores the total, and progress is still
-    # continuous across the second step change
+    # unaffected since none of its words were written this session
     project.setProjectChanged(False)
     data.setTargetSkipRoots([])
     assert project.projChanged is True
     assert data.targetSkipRoots == set()
     assert data.targetLastCount == newWords
     assert data.dailyProgress == writtenWords
-    assert data._targetInitCount == startWords
 
     # Excluding an empty root is still a change in roots, but since it
-    # has no words, the reference count and the baseline are untouched
+    # has no words, the total and progress are untouched
     thirdRoot = project.newRoot(nwItemClass.NOVEL)
     project.setProjectChanged(False)
     data.setTargetSkipRoots([thirdRoot])
@@ -236,7 +238,6 @@ def testProjectData_TargetSkipRoots(mockGUI, mockRnd, fncPath, ipsumText):
     assert data.targetSkipRoots == {thirdRoot}
     assert data.targetLastCount == newWords
     assert data.dailyProgress == writtenWords
-    assert data._targetInitCount == startWords
 
 
 @pytest.mark.core
@@ -273,16 +274,17 @@ def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):
     data = ProjectData(project)  # type: ignore
     data.setInitTargetCount(500)
     data.setInitDailyTarget(100, "2026-07-20")
-    data.setDailyProgress(500)
+    data.setDailyProgress(0, 500)
     assert data.dailyProgress == 0
 
 
 @pytest.mark.core
 def testProjectData_DailyProgress(monkeypatch, mockGUI):
-    """Test the setDailyProgress setter. The daily progress and the
-    remaining project word count must survive across sessions on the
-    same day, and must be recalculated when the clock ticks over to a
-    new day.
+    """Test the setDailyProgress setter. The daily word count passed in
+    is the cumulative session change since the project was last loaded,
+    not the change since the previous call, so it must be combined with
+    the carried-over daily baseline to survive across sessions on the
+    same day, and be recalculated when the clock ticks over to a new day.
     """
     monkeypatch.setattr(projectdata, "date", _FakeDate)
     _FakeDate._today = date(2026, 7, 20)
@@ -292,16 +294,16 @@ def testProjectData_DailyProgress(monkeypatch, mockGUI):
     data.setProjectTarget(1000, None)
     data.setInitTargetCount(500)
 
-    # First update of a session with no prior daily record: the progress
-    # is measured from the initial count, and the remaining word count is
+    # First update of a session with no prior daily record and nothing
+    # written yet: the progress is zero, and the remaining word count is
     # the full target less what already existed at the start of the day
-    data.setDailyProgress(500)
+    data.setDailyProgress(0, 500)
     assert data.dailyProgress == 0
     assert data._remainingWordCount == 500
 
-    # As the session progresses, the progress grows, but the remaining
-    # count for the day stays fixed at the start-of-day value
-    data.setDailyProgress(560)
+    # As the session progresses, the progress grows by the session word
+    # count, but the remaining count for the day stays fixed
+    data.setDailyProgress(60, 560)
     assert data.dailyProgress == 60
     assert data._remainingWordCount == 500
 
@@ -314,30 +316,32 @@ def testProjectData_DailyProgress(monkeypatch, mockGUI):
     data.setInitTargetCount(560)
     data.setInitDailyTarget(60, "2026-07-20")
 
-    # No new typing yet, so progress should still read 60, and the
-    # remaining count must match the earlier session, not be reduced by
-    # the 60 words a second time
-    data.setDailyProgress(560)
+    # No new typing yet in this session, so progress should still read
+    # 60, and the remaining count must match the earlier session, not
+    # be reduced by the 60 words a second time
+    data.setDailyProgress(0, 560)
     assert data.dailyProgress == 60
     assert data.dailyLastCount == 60
     assert data._remainingWordCount == 500
 
     # More words are added in the second session
-    data.setDailyProgress(600)
+    data.setDailyProgress(40, 600)
     assert data.dailyProgress == 100
     assert data._remainingWordCount == 500
 
     # The clock ticks over to the next day mid-session. Progress resets
     # for the new day, and the remaining count drops by the full amount
-    # written the previous day (100 words)
+    # written the previous day (100 words). The session word count keeps
+    # accumulating from the same session baseline, so 5 more words typed
+    # after the rollover means 45 in total this session
     _FakeDate._today = date(2026, 7, 21)
-    data.setDailyProgress(605)
+    data.setDailyProgress(45, 605)
     assert data.dailyProgress == 5
     assert data._remainingWordCount == 400
     assert data._dailyLastDate == date(2026, 7, 21)
 
     # Further typing on the new day accumulates from the new baseline
-    data.setDailyProgress(615)
+    data.setDailyProgress(55, 615)
     assert data.dailyProgress == 15
     assert data._remainingWordCount == 400
 
@@ -355,7 +359,7 @@ def testProjectData_EffectiveDailyGoal(monkeypatch, mockGUI):
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, date(2026, 7, 24))
     data.setInitTargetCount(400)
-    data.setDailyProgress(400)
+    data.setDailyProgress(0, 400)
     assert data._remainingWordCount == 600
 
     # With automatic calculation off, the fixed goal is always returned
@@ -369,16 +373,16 @@ def testProjectData_EffectiveDailyGoal(monkeypatch, mockGUI):
 
     # When the deadline is today, all the remaining words are due today
     data.setProjectTarget(1000, date(2026, 7, 20))
-    data.setDailyProgress(400)
+    data.setDailyProgress(0, 400)
     assert data.getEffectiveDailyGoal() == 600
 
     # When the deadline has passed, fall back to the fixed daily goal
     data.setProjectTarget(1000, date(2026, 7, 19))
-    data.setDailyProgress(400)
+    data.setDailyProgress(0, 400)
     assert data.getEffectiveDailyGoal() == 50
 
     # When the remaining word count isn't positive, also fall back
     data.setProjectTarget(400, date(2026, 7, 24))
-    data.setDailyProgress(400)
+    data.setDailyProgress(0, 400)
     assert data._remainingWordCount == 0
     assert data.getEffectiveDailyGoal() == 50

--- a/tests/core/test_projectxml.py
+++ b/tests/core/test_projectxml.py
@@ -49,6 +49,9 @@ class MockProject:
     def setProjectChanged(self, *a):
         """Fake project method."""
 
+    def markCountsDirty(self):
+        """Fake project method."""
+
 
 @pytest.fixture(autouse=True)
 def mockVersion(monkeypatch):

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -680,7 +680,7 @@ def testProjectTree_OtherMethods(qtbot, monkeypatch, mockGUI, fncPath, mockRnd):
     ]
 
     # Refresh All
-    assert tree.sumCounts() == (9, 0, 40, 0, 9)
+    assert tree.sumCounts() == (9, 0, 40, 0, 9, 9)
     assert tree.model.root.count == 9
 
     # Items with no layout (e.g. folders created directly) are not counted
@@ -688,7 +688,7 @@ def testProjectTree_OtherMethods(qtbot, monkeypatch, mockGUI, fncPath, mockRnd):
     assert noLayoutHandle is not None
     tree[noLayoutHandle].setLayout(nwItemLayout.NO_LAYOUT)  # type: ignore
     tree[noLayoutHandle].setWordCount(99)  # type: ignore
-    assert tree.sumCounts() == (9, 0, 40, 0, 9)
+    assert tree.sumCounts() == (9, 0, 40, 0, 9, 9)
     tree.remove(noLayoutHandle)
 
     for node in tree.nodes.values():

--- a/tests/gui/test_statusbar.py
+++ b/tests/gui/test_statusbar.py
@@ -140,7 +140,8 @@ def testGuiStatusBar_Main(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
 
     # Reset Daily Progress
     assert status.dayReset.isVisible() is True
-    SHARED.project.data.setDailyProgress(150)
+    SHARED.project.data.resetDailyProgress()
+    SHARED.project.data.setDailyProgress(150, 150)
     assert SHARED.project.data.dailyProgress == 150
 
     # Declining the confirmation leaves the progress untouched


### PR DESCRIPTION
**Summary:**

This is yet another iteration of the writing goals accounting calculation. The previous implementation would add or subtract the daily progress count when a document was moved or toggled active/inactive. And even that required editing something to trigger a recount.

This implementation instead sums up actual session diffs on each project item, which was already tracked for the display of word count change in ed editor footer. The counter now dynamically sums up the session word count changes of all items that qualify (active, novel document, not in skipped root) and changing the status of a document that hasn't been edited now has no effect on the session count. The project target count updates as before when documents change status that affects their inclusion, as they should.

A markCountsDirty flag was also added to the project class so when bulk changes are made to project items, the counts are updated on the next word count refresh even of there were no words added anywhere in the project. This count refresh already runs every 5 seconds.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
