### PR TITLE
Remove the redundant last project count read

### DIFF
--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -449,10 +449,6 @@ class ProjectData:
                     self._lastHandle[key] = str(entry) if isHandle(entry) else None
             self._project.setProjectChanged(True)
 
-    def setInitTargetCount(self, value: Any) -> None:
-        """Set the initial target count."""
-        self._targetLastCount = checkInt(value, 0)
-
     def setInitTargetSkipRoots(self, value: Sequence[str]) -> None:
         """Set the initial target skip root handles dictionary."""
         self._targetSkipRoots = {str(handle) for handle in value}

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -275,7 +275,6 @@ class ProjectXMLReader:
                 data.setSpellCheck(xItem.attrib.get("auto"))
             elif xItem.tag == "projectTarget":
                 data.setProjectTarget(xItem.text, xItem.attrib.get("date"))
-                data.setInitTargetCount(xItem.attrib.get("last"))
             elif xItem.tag == "dailyTarget":
                 data.setDailyTarget(xItem.text, xItem.attrib.get("auto"))
                 data.setInitDailyTarget(xItem.attrib.get("last"), xItem.attrib.get("date"))

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-23 16:30:18">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2380" autoCount="430" editTime="110602">
+<novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-24 02:55:11">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2381" autoCount="430" editTime="110605">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -9,7 +9,7 @@
     <language>en_GB</language>
     <spellChecking auto="yes">None</spellChecking>
     <projectTarget date="None" last="1137">15000</projectTarget>
-    <dailyTarget auto="no" last="100" date="2026-07-23">1000</dailyTarget>
+    <dailyTarget auto="no" last="0" date="2026-07-24">1000</dailyTarget>
     <targetSkipRoots>
       <entry>d2d81f4831814</entry>
     </targetSkipRoots>

--- a/tests/_files/nwProject-1.5.nwx
+++ b/tests/_files/nwProject-1.5.nwx
@@ -8,7 +8,7 @@
     <doBackup>no</doBackup>
     <language>en_GB</language>
     <spellChecking auto="yes">None</spellChecking>
-    <projectTarget date="2026-08-20" last="1137">100000</projectTarget>
+    <projectTarget date="2026-08-20" last="0">100000</projectTarget>
     <dailyTarget auto="no" last="0" date="2026-07-20">1000</dailyTarget>
     <targetSkipRoots>
       <entry>d2d81f4831814</entry>

--- a/tests/core/test_projectdata.py
+++ b/tests/core/test_projectdata.py
@@ -272,7 +272,6 @@ def testProjectData_DailyTargetCurrent(monkeypatch, mockGUI):
     # End-to-end: a project file with a daily target set two days ago is
     # loaded. The stale count must not offset today's progress
     data = ProjectData(project)  # type: ignore
-    data.setInitTargetCount(500)
     data.setInitDailyTarget(100, "2026-07-20")
     data.setDailyProgress(0, 500)
     assert data.dailyProgress == 0
@@ -292,7 +291,6 @@ def testProjectData_DailyProgress(monkeypatch, mockGUI):
     project = MockProject()
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, None)
-    data.setInitTargetCount(500)
 
     # First update of a session with no prior daily record and nothing
     # written yet: the progress is zero, and the remaining word count is
@@ -313,7 +311,6 @@ def testProjectData_DailyProgress(monkeypatch, mockGUI):
     # 60-word progress forward
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, None)
-    data.setInitTargetCount(560)
     data.setInitDailyTarget(60, "2026-07-20")
 
     # No new typing yet in this session, so progress should still read
@@ -358,7 +355,6 @@ def testProjectData_EffectiveDailyGoal(monkeypatch, mockGUI):
     project = MockProject()
     data = ProjectData(project)  # type: ignore
     data.setProjectTarget(1000, date(2026, 7, 24))
-    data.setInitTargetCount(400)
     data.setDailyProgress(0, 400)
     assert data._remainingWordCount == 600
 


### PR DESCRIPTION
**Summary:**

The project target last count in the xml is no longer needed, so the read was removed, but write remains as useful meta data.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
