### PR TITLE
Add staging branch

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - staging
       - release
     paths:
       - i18n/*.ts

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - staging
       - release
   pull_request:
     branches:
       - main
+      - staging
       - release
 
 jobs:

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - staging
       - release
   pull_request:
     branches:
       - main
+      - staging
       - release
 
 jobs:

--- a/.github/workflows/test_mac.yml
+++ b/.github/workflows/test_mac.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - staging
       - release
   pull_request:
     branches:
       - main
+      - staging
       - release
 
 jobs:

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - staging
       - release
   pull_request:
     branches:
       - main
+      - staging
       - release
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,14 +83,19 @@ uv run run_tests.py --help
 
 ## Picking the Correct Branch for a Pull Request
 
-Pre-releases are made from the `main` branch, and full releases are made from the `release` branch.
-If you are submitting a fix to a current release you must do so from the `release` branch. If you
-make such a fix on the `main` branch, **it cannot be included in a patch release**. This also
-applies to the documentation for the latest release published on the main website.
+* `main` is used for continuous development and new features.
+* `staging` is used for beta releases and release candidates and is dormant between cycles.
+* `release` is used for the current active release, and fixes for that release.
+
+Specifically:
+
+Pre-releases are made from the `staging` branch, and full releases are made from the `release`
+branch. If you are submitting a fix to a current release you must do so from the `release` branch.
+If you make such a fix on the `main` branch, **it cannot be included in a patch release**. This
+also applies to the documentation for the latest release published on the main website.
 
 New features are only added in full releases, so a feature pull request must be made to the `main`
-branch. However, if the `main` branch is very close to a new full release, pull requests may not be
-merged until the release is completed.
+branch. Fixes to a pre-release must be made to the `staging` branch.
 
 This project uses GitHub milestones to plan releases, and only pull requests included in the
 current release cycle will be merged to `main`. Milestone tickets are not set in stone and are
@@ -103,7 +108,7 @@ Make sure the pull request follows these rules:
 
 * The `main` branch is the default branch. For general changes, please make a new branch in your
   own fork from the current `main` branch. Do not make pull requests from your copy of the `main`
-  branch. The same applies to the `release` branch.
+  branch. The same applies to the `staging` and `release` branches.
 * Please provide a description of the changes in the pull request under the summary section of the
   pull request template, and reference any related issues by providing the issue number. Do not
   post links to issue numbers as that breaks the integration. Stating the issue number is enough.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ code, please also read the full
 
 Project credits are available in [CREDITS.md](https://github.com/vkbo/novelWriter/blob/main/CREDITS.md).
 
-**Note:** New features and pre-releases are made on the `main` branch. Full releases are made from
-the `release` branch. So if you're submitting a fix to a current release, **including changes to
-documentation**, they must be made to the `release` branch.
+**Note:** New features are added on the `main` branch and pre-releases are made on the `staging`
+branch. Full releases are made from the `release` branch. So if you're submitting a fix to a
+current release, **including changes to documentation**, they must be made to the `release` branch.
 
 
 ### Translations


### PR DESCRIPTION
**Summary:**

This PR updates workflows and repo documents to support a staging branch. This branch will mostly be dormant, but used for the Beta and RC release cycle so the 4-6 weeks that runs does not block the main branch from having feature updates.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
