### PR TITLE
Missed accent text

### DIFF
--- a/novelwriter/models/searchmodel.py
+++ b/novelwriter/models/searchmodel.py
@@ -28,8 +28,8 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QAbstractItemModel, QModelIndex, Qt
 from PyQt6.QtGui import QBrush, QIcon
-from PyQt6.QtWidgets import QApplication
 
+from novelwriter import SHARED
 from novelwriter.common import minmax
 from novelwriter.types import (
     QtAlignRight,
@@ -170,7 +170,7 @@ class SearchResultModel(QAbstractItemModel):
         super().__init__()
         self._rows: list[SearchNode] = []
         self._map: dict[str, tuple[int, float]] = {}
-        self._color = QApplication.palette().highlight()
+        self._color = QBrush(SHARED.theme.accentText)
         logger.debug("Ready: SearchResultModel")
 
     def __del__(self) -> None:  # pragma: no cover
@@ -286,7 +286,7 @@ class SearchResultModel(QAbstractItemModel):
 
     def updateTheme(self) -> None:
         """Update the highlight color and document icons."""
-        self._color = QApplication.palette().highlight()
+        self._color = QBrush(SHARED.theme.accentText)
         if self._rows:
             for node in self._rows:
                 node.refreshIcon()

--- a/tests/models/test_searchmodel.py
+++ b/tests/models/test_searchmodel.py
@@ -24,9 +24,10 @@ from __future__ import annotations
 import pytest
 
 from PyQt6.QtCore import QModelIndex
+from PyQt6.QtGui import QBrush
 from PyQt6.QtTest import QAbstractItemModelTester
-from PyQt6.QtWidgets import QApplication
 
+from novelwriter import SHARED
 from novelwriter.core.project import NWProject
 from novelwriter.models.searchmodel import SearchNode, SearchResultModel
 from novelwriter.types import QtDisplayRole, QtForegroundRole, QtUserRole
@@ -124,7 +125,7 @@ def testSearchModel_Interface(mockGUI, mockRnd, fncPath):
     assert model.data(model.index(0, 1, root), QtDisplayRole) == "(1)"
     assert model.data(sceneIdx, QtDisplayRole) == "New Scene"
     assert model.data(model.index(1, 1, root), QtDisplayRole) == "(2+)"
-    assert model.data(model.index(1, 1, root), QtForegroundRole) == QApplication.palette().highlight()
+    assert model.data(model.index(1, 1, root), QtForegroundRole) == QBrush(SHARED.theme.accentText)
     assert model.handle(titleIdx) == title.itemHandle
     assert model.handle(sceneIdx) == scene.itemHandle
     assert model.result(titleIdx) is None


### PR DESCRIPTION
**Summary:**

The number of search hits in the project search panel also needs to use accentText instead of highlight.

**Related Issue(s):**

Related to #2910

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
