### PR TITLE
Tab widget colour and tool buttons

### DIFF
--- a/novelwriter/assets/themes/aura.toml
+++ b/novelwriter/assets/themes/aura.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#603bb1"
 
 [GUI]
-helpText    = "faded:L125"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#603bb1"
-toggle      = "#462392"
-searchMatch = "yellow:80"
+helpText     = "faded:L125"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#603bb1"
+activeButton = "#462392"
+activeBase   = "#353249"
+searchMatch  = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/aura_bright.toml
+++ b/novelwriter/assets/themes/aura_bright.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "purple"
 
 [GUI]
-helpText    = "faded:D125"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "purple"
-toggle      = "purple:128"
-searchMatch = "yellow:80"
+helpText     = "faded:D125"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "purple"
+activeButton = "purple:128"
+activeBase   = "#cec9d3"
+searchMatch  = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/aura_soft.toml
+++ b/novelwriter/assets/themes/aura_soft.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#6a4da3"
 
 [GUI]
-helpText    = "faded:L125"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#6a4da3"
-toggle      = "#381f6b"
-searchMatch = "yellow:80"
+helpText     = "faded:L125"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#6a4da3"
+activeButton = "#381f6b"
+activeBase   = "#353249"
+searchMatch  = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_garden_dark.toml
+++ b/novelwriter/assets/themes/b2t_garden_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "green"
 accent          = "#bd5d0f"
 
 [GUI]
-helpText    = "#aab1aa"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#1c8217"
-toggle      = "#bd5d0f80"
-searchMatch = "#dd843c60"
+helpText     = "#aab1aa"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#1c8217"
+activeButton = "#bd5d0f80"
+activeBase   = "#505350"
+searchMatch  = "#dd843c60"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_garden_light.toml
+++ b/novelwriter/assets/themes/b2t_garden_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "#1c8217"
 accent          = "#bd5d0f"
 
 [GUI]
-helpText    = "#696d69"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#4cb946"
-toggle      = "#bd5d0f60"
-searchMatch = "#d9772660"
+helpText     = "#696d69"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#4cb946"
+activeButton = "#bd5d0f60"
+activeBase   = "#dbd0c7"
+searchMatch  = "#d9772660"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_suburb_dark.toml
+++ b/novelwriter/assets/themes/b2t_suburb_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "red"
 
 [GUI]
-helpText    = "#9b9fb6"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "red"
-toggle      = "red:128"
-searchMatch = "red:128"
+helpText     = "#9b9fb6"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "red"
+activeButton = "red:128"
+activeBase   = "#444864"
+searchMatch  = "red:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b2t_suburb_light.toml
+++ b/novelwriter/assets/themes/b2t_suburb_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#fe81b5"
 
 [GUI]
-helpText    = "#65697c"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#f764a1"
-toggle      = "#fe81b57f"
-searchMatch = "#fe81b57f"
+helpText     = "#65697c"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#f764a1"
+activeButton = "#fe81b57f"
+activeBase   = "#d7cbd0"
+searchMatch  = "#fe81b57f"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_classic_o_dark.toml
+++ b/novelwriter/assets/themes/b4t_classic_o_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#1bbba5"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#1bbba5"
-toggle      = "#1bbba57f"
-searchMatch = "#b35ee860"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#1bbba5"
+activeButton = "#1bbba57f"
+activeBase   = "#333b47"
+searchMatch  = "#b35ee860"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_classic_o_light.toml
+++ b/novelwriter/assets/themes/b4t_classic_o_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#0c9c89"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#0c9c89"
-toggle      = "#0c9c897f"
-searchMatch = "#e6c8f9"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#0c9c89"
+activeButton = "#0c9c897f"
+activeBase   = "#d0d5dd"
+searchMatch  = "#e6c8f9"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_modern_c_dark.toml
+++ b/novelwriter/assets/themes/b4t_modern_c_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "yellow"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "yellow"
-toggle      = "#1b2c9d"
-searchMatch = "cyan:64"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "yellow"
+activeButton = "#1b2c9d"
+activeBase   = "#40424e"
+searchMatch  = "cyan:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/b4t_modern_c_light.toml
+++ b/novelwriter/assets/themes/b4t_modern_c_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "yellow"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "yellow"
-toggle      = "blue:128"
-searchMatch = "cyan:64"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "yellow"
+activeButton = "blue:128"
+activeBase   = "#d1d2dc"
+searchMatch  = "cyan:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/blue_streak_dark.toml
+++ b/novelwriter/assets/themes/blue_streak_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "blue"
 
 [GUI]
-helpText    = "blue:L125"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "blue:128"
-searchMatch = "orange:96"
+helpText     = "blue:L125"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "blue:128"
+activeBase   = "base:L150"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/blue_streak_light.toml
+++ b/novelwriter/assets/themes/blue_streak_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "blue"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue:D150"
-toggle      = "blue:96"
-searchMatch = "orange:96"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue:D150"
+activeButton = "blue:96"
+activeBase   = "base:D110"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/castle_day.toml
+++ b/novelwriter/assets/themes/castle_day.toml
@@ -66,12 +66,13 @@ linkVisited     = "#5068b6"
 accent          = "#cf7c6d"
 
 [GUI]
-helpText    = "default:L180"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#cf7c6d"
-toggle      = "#b2c1f5"
-searchMatch = "yellow:80"
+helpText     = "default:L180"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#cf7c6d"
+activeButton = "#b2c1f5"
+activeBase   = "base:D118"
+searchMatch  = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/castle_night.toml
+++ b/novelwriter/assets/themes/castle_night.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "red:D150"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "red:D150"
-toggle      = "#2c3c6b"
-searchMatch = "#3d496b"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "red:D150"
+activeButton = "#2c3c6b"
+activeBase   = "base:L160"
+searchMatch  = "#3d496b"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/catppuccin_latte.toml
+++ b/novelwriter/assets/themes/catppuccin_latte.toml
@@ -68,12 +68,13 @@ linkVisited     = "lavender"
 accent          = "purple"
 
 [GUI]
-helpText    = "#7c7f93"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "purple"
-toggle      = "#ccd0da"
-searchMatch = "blue:80"
+helpText     = "#7c7f93"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "purple"
+activeButton = "#ccd0da"
+activeBase   = "#bcc0cc"
+searchMatch  = "blue:80"
 
 [Syntax]
 background     = "#eff1f5"

--- a/novelwriter/assets/themes/catppuccin_mocha.toml
+++ b/novelwriter/assets/themes/catppuccin_mocha.toml
@@ -68,12 +68,13 @@ linkVisited     = "lavender"
 accent          = "purple"
 
 [GUI]
-helpText    = "#9399b2"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "purple"
-toggle      = "#313244"
-searchMatch = "blue:80"
+helpText     = "#9399b2"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "purple"
+activeButton = "#313244"
+activeBase   = "#45475a"
+searchMatch  = "blue:80"
 
 [Syntax]
 background     = "#1e1e2e"

--- a/novelwriter/assets/themes/chalky_soil.toml
+++ b/novelwriter/assets/themes/chalky_soil.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "green"
 
 [GUI]
-helpText    = "default:L140"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "green"
-toggle      = "green:128"
-searchMatch = "blue:80"
+helpText     = "default:L140"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "green"
+activeButton = "green:128"
+activeBase   = "base:D115"
+searchMatch  = "blue:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/chernozem.toml
+++ b/novelwriter/assets/themes/chernozem.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#5a8d55"
 
 [GUI]
-helpText    = "#a39891"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#6ca167"
-toggle      = "#5a8d557f"
-searchMatch = "red:96"
+helpText     = "#a39891"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#6ca167"
+activeButton = "#5a8d557f"
+activeBase   = "faded:80"
+searchMatch  = "red:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/cyberpunk_night.toml
+++ b/novelwriter/assets/themes/cyberpunk_night.toml
@@ -67,12 +67,13 @@ linkVisited     = "#320050"
 accent          = "#321e50"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#321e50"
-searchMatch = "orange:96"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#321e50"
+activeBase   = "#282828"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/default_dark.toml
+++ b/novelwriter/assets/themes/default_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#2c98f7"
 
 [GUI]
-helpText    = "#a4a4a4"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "blue:128"
-searchMatch = "orange:96"
+helpText     = "#a4a4a4"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "blue:128"
+activeBase   = "#4e4e4e"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/default_light.toml
+++ b/novelwriter/assets/themes/default_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#3087c6"
 
 [GUI]
-helpText    = "#5c5c5c"
-fadedText   = "#6c6c6c"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "blue:96"
-searchMatch = "orange:96"
+helpText     = "#5c5c5c"
+fadedText    = "#6c6c6c"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "blue:96"
+activeBase   = "#e0e0e0"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/dracula.toml
+++ b/novelwriter/assets/themes/dracula.toml
@@ -84,12 +84,13 @@ linkVisited     = "cyan"
 accent          = "#a681da"
 
 [GUI]
-helpText    = "#ccacf9"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#a681da"
-toggle      = "#a681da7f"
-searchMatch = "orange:96"
+helpText     = "#ccacf9"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#a681da"
+activeButton = "#a681da7f"
+activeBase   = "#333645"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/espresso.toml
+++ b/novelwriter/assets/themes/espresso.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "blue"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "orange"
-toggle      = "faded"
-searchMatch = "orange:96"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "orange"
+activeButton = "faded"
+activeBase   = "#51403c"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/everforest_dark.toml
+++ b/novelwriter/assets/themes/everforest_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#a7c080"
 
 [GUI]
-helpText    = "#a9a49d"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#a7c080"
-toggle      = "#a7c0807f"
-searchMatch = "orange:80"
+helpText     = "#a9a49d"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#a7c080"
+activeButton = "#a7c0807f"
+activeBase   = "#374145"
+searchMatch  = "orange:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/everforest_light.toml
+++ b/novelwriter/assets/themes/everforest_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#93b259"
 
 [GUI]
-helpText    = "#829181"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#93b259"
-toggle      = "#93b2597f"
-searchMatch = "orange:72"
+helpText     = "#829181"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#93b259"
+activeButton = "#93b2597f"
+activeBase   = "#e8e5d5"
+searchMatch  = "orange:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/floral_daydream.toml
+++ b/novelwriter/assets/themes/floral_daydream.toml
@@ -66,12 +66,13 @@ linkVisited     = "#4781d8"
 accent          = "#e4688d"
 
 [GUI]
-helpText    = "#d14a73"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#e4688d"
-toggle      = "#e4688d7f"
-searchMatch = "#e4688d50"
+helpText     = "#d14a73"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#e4688d"
+activeButton = "#e4688d7f"
+activeBase   = "#ffc7d8"
+searchMatch  = "#e4688d50"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/floral_midnight.toml
+++ b/novelwriter/assets/themes/floral_midnight.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#a85c8b"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#a85c8b"
-toggle      = "#8b55d67f"
-searchMatch = "purple:96"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#a85c8b"
+activeButton = "#8b55d67f"
+activeBase   = "#423e58"
+searchMatch  = "purple:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/full_moon.toml
+++ b/novelwriter/assets/themes/full_moon.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#5495ce"
 
 [GUI]
-helpText    = "#586a72"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#5495ce"
-toggle      = "#5495ce7f"
-searchMatch = "default:64"
+helpText     = "#586a72"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#5495ce"
+activeButton = "#5495ce7f"
+activeBase   = "#d4d9dd"
+searchMatch  = "default:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/grey_dark.toml
+++ b/novelwriter/assets/themes/grey_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#2c98f7"
 
 [GUI]
-helpText    = "default:D120"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#9999997f"
-searchMatch = "#9999997f"
+helpText     = "default:D120"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#9999997f"
+activeBase   = "#4e4e4e"
+searchMatch  = "#9999997f"
 
 [Syntax]
 background     = "#363636"

--- a/novelwriter/assets/themes/grey_light.toml
+++ b/novelwriter/assets/themes/grey_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#3087c6"
 
 [GUI]
-helpText    = "default:L225"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#9999997f"
-searchMatch = "#9999997f"
+helpText     = "default:L225"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#9999997f"
+activeBase   = "#e0e0e0"
+searchMatch  = "#9999997f"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/horizon_dark.toml
+++ b/novelwriter/assets/themes/horizon_dark.toml
@@ -68,12 +68,13 @@ linkVisited     = "#21bfc2"
 accent          = "#fab28e"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#fab28e"
-toggle      = "#393c5f"
-searchMatch = "purple:104"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#fab28e"
+activeButton = "#393c5f"
+activeBase   = "#2e303e"
+searchMatch  = "purple:104"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/horizon_light.toml
+++ b/novelwriter/assets/themes/horizon_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "#1eaeae"
 accent          = "#f6661e"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#e68656"
-toggle      = "#ebb2a4"
-searchMatch = "purple:80"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#e68656"
+activeButton = "#ebb2a4"
+activeBase   = "#fadad1"
+searchMatch  = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/jewel_case_dark.toml
+++ b/novelwriter/assets/themes/jewel_case_dark.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#a85066"
 
 [GUI]
-helpText    = "#8297ad"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#a85066"
-toggle      = "#113579"
-searchMatch = "green:104"
+helpText     = "#8297ad"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#a85066"
+activeButton = "#113579"
+activeBase   = "#2a364d"
+searchMatch  = "green:104"
 
 [Syntax]
 background     = "#141925"

--- a/novelwriter/assets/themes/jewel_case_light.toml
+++ b/novelwriter/assets/themes/jewel_case_light.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#d15b6d"
 
 [GUI]
-helpText    = "#596b7e"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#d15b6d"
-toggle      = "#a9d1ff"
-searchMatch = "green:80"
+helpText     = "#596b7e"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#d15b6d"
+activeButton = "#a9d1ff"
+activeBase   = "#bac7d1"
+searchMatch  = "green:80"
 
 [Syntax]
 background     = "#f6f9fc"

--- a/novelwriter/assets/themes/lcars.toml
+++ b/novelwriter/assets/themes/lcars.toml
@@ -68,12 +68,13 @@ linkVisited     = "purple"
 accent          = "orange"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "purple"
-toggle      = "orange:96"
-searchMatch = "red:96"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "purple"
+activeButton = "orange:96"
+activeBase   = "base:L300"
+searchMatch  = "red:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/light_owl.toml
+++ b/novelwriter/assets/themes/light_owl.toml
@@ -88,12 +88,13 @@ linkVisited     = "blue"
 accent          = "#3087c6"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#3087c666"
-searchMatch = "orange:96"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#3087c666"
+activeBase   = "#e0e0e0"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/new_moon.toml
+++ b/novelwriter/assets/themes/new_moon.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#4386c5"
 
 [GUI]
-helpText    = "#999eaa"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#4386c5"
-toggle      = "#4386c57f"
-searchMatch = "default:80"
+helpText     = "#999eaa"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#4386c5"
+activeButton = "#4386c57f"
+activeBase   = "#444444"
+searchMatch  = "default:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/night_owl.toml
+++ b/novelwriter/assets/themes/night_owl.toml
@@ -88,12 +88,13 @@ linkVisited     = "blue"
 accent          = "#2c98f7"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#2c98f766"
-searchMatch = "orange:128"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#2c98f766"
+activeBase   = "#32374d"
+searchMatch  = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/noctis.toml
+++ b/novelwriter/assets/themes/noctis.toml
@@ -100,12 +100,13 @@ linkVisited     = "blue"
 accent          = "#49e9a6"
 
 [GUI]
-helpText    = "#e4b781"
-fadedText   = "faded"
-errorText   = "#e3541c"
-accentText  = "cyan"
-toggle      = "#49e9a657"
-searchMatch = "orange:96"
+helpText     = "#e4b781"
+fadedText    = "faded"
+errorText    = "#e3541c"
+accentText   = "cyan"
+activeButton = "#49e9a657"
+activeBase   = "base:L175"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/noctis_lux.toml
+++ b/novelwriter/assets/themes/noctis_lux.toml
@@ -100,12 +100,13 @@ linkVisited     = "blue"
 accent          = "#00b368"
 
 [GUI]
-helpText    = "#fa8900"
-fadedText   = "faded"
-errorText   = "#ff530f"
-accentText  = "cyan"
-toggle      = "#00b36867"
-searchMatch = "orange:64"
+helpText     = "#fa8900"
+fadedText    = "faded"
+errorText    = "#ff530f"
+accentText   = "cyan"
+activeButton = "#00b36867"
+activeBase   = "base:D115"
+searchMatch  = "orange:64"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/nord.toml
+++ b/novelwriter/assets/themes/nord.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "cyan"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "cyan"
-toggle      = "blue:128"
-searchMatch = "purple:128"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "cyan"
+activeButton = "blue:128"
+activeBase   = "#434c5e"
+searchMatch  = "purple:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/nordlicht.toml
+++ b/novelwriter/assets/themes/nordlicht.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "cyan"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "cyan"
-toggle      = "blue:128"
-searchMatch = "purple:80"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "cyan"
+activeButton = "blue:128"
+activeBase   = "#d8dee9"
+searchMatch  = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/otium_dark.toml
+++ b/novelwriter/assets/themes/otium_dark.toml
@@ -66,12 +66,13 @@ linkVisited     = "green"
 accent          = "#698a6e"
 
 [GUI]
-helpText    = "#a0a3a8"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#698a6e"
-toggle      = "#698a6e7f"
-searchMatch = "purple:128"
+helpText     = "#a0a3a8"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#698a6e"
+activeButton = "#698a6e7f"
+activeBase   = "#3b3c47"
+searchMatch  = "purple:128"
 
 [Syntax]
 background     = "#1b1c22"

--- a/novelwriter/assets/themes/otium_light.toml
+++ b/novelwriter/assets/themes/otium_light.toml
@@ -66,12 +66,13 @@ linkVisited     = "green"
 accent          = "#6c9173"
 
 [GUI]
-helpText    = "#57565e"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#6c9173"
-toggle      = "#6c91737f"
-searchMatch = "purple:80"
+helpText     = "#57565e"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#6c9173"
+activeButton = "#6c91737f"
+activeBase   = "base:D115"
+searchMatch  = "purple:80"
 
 [Syntax]
 background     = "#f8f7f3"

--- a/novelwriter/assets/themes/paragon.toml
+++ b/novelwriter/assets/themes/paragon.toml
@@ -67,12 +67,13 @@ linkVisited     = "cyan"
 accent          = "cyan"
 
 [GUI]
-helpText    = "#949baa"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "cyan:D120"
-toggle      = "cyan:128"
-searchMatch = "orange:80"
+helpText     = "#949baa"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "cyan:D120"
+activeButton = "cyan:128"
+activeBase   = "#394452"
+searchMatch  = "orange:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/primer_light.toml
+++ b/novelwriter/assets/themes/primer_light.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "green"
 
 [GUI]
-helpText    = "#424a53"
-fadedText   = "#8c959f"
-errorText   = "red"
-accentText  = "green"
-toggle      = "green:128"
-searchMatch = "#b6e3ff"
+helpText     = "#424a53"
+fadedText    = "#8c959f"
+errorText    = "red"
+accentText   = "green"
+activeButton = "green:128"
+activeBase   = "#dde3e8"
+searchMatch  = "#b6e3ff"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/primer_night.toml
+++ b/novelwriter/assets/themes/primer_night.toml
@@ -68,12 +68,13 @@ linkVisited     = "blue"
 accent          = "#207c59"
 
 [GUI]
-helpText    = "#8b949e"
-fadedText   = "#6e7681"
-errorText   = "#f85149"
-accentText  = "#207c59"
-toggle      = "#207c597f"
-searchMatch = "#1f6feb80"
+helpText     = "#8b949e"
+fadedText    = "#6e7681"
+errorText    = "#f85149"
+accentText   = "#207c59"
+activeButton = "#207c597f"
+activeBase   = "#30363d"
+searchMatch  = "#1f6feb80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/rose_pine.toml
+++ b/novelwriter/assets/themes/rose_pine.toml
@@ -68,12 +68,13 @@ linkVisited     = "red"
 accent          = "red"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "red"
-toggle      = "red:128"
-searchMatch = "cyan:194"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "red"
+activeButton = "red:128"
+activeBase   = "#403d52"
+searchMatch  = "cyan:194"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/rose_pine_dawn.toml
+++ b/novelwriter/assets/themes/rose_pine_dawn.toml
@@ -68,12 +68,13 @@ linkVisited     = "red"
 accent          = "red"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "red"
-toggle      = "red:128"
-searchMatch = "blue:88"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "red"
+activeButton = "red:128"
+activeBase   = "#dfdad9"
+searchMatch  = "blue:88"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/ruby_day.toml
+++ b/novelwriter/assets/themes/ruby_day.toml
@@ -66,12 +66,13 @@ linkVisited     = "#da3d3d"
 accent          = "#c43939"
 
 [GUI]
-helpText    = "#756777"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#da3d3d"
-toggle      = "#ff9e9e"
-searchMatch = "purple:104"
+helpText     = "#756777"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#da3d3d"
+activeButton = "#ff9e9e"
+activeBase   = "#e9c1c1"
+searchMatch  = "purple:104"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/ruby_night.toml
+++ b/novelwriter/assets/themes/ruby_night.toml
@@ -66,12 +66,13 @@ linkVisited     = "red"
 accent          = "#a52a2c"
 
 [GUI]
-helpText    = "#a5a1b3"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#a52a2c"
-toggle      = "#830a0c"
-searchMatch = "purple:104"
+helpText     = "#a5a1b3"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#a52a2c"
+activeButton = "#830a0c"
+activeBase   = "#29292e"
+searchMatch  = "purple:104"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/selenium_dark.toml
+++ b/novelwriter/assets/themes/selenium_dark.toml
@@ -66,12 +66,13 @@ linkVisited     = "#9267d3"
 accent          = "red:D120"
 
 [GUI]
-helpText    = "#888095"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "faded"
-toggle      = "#35303f"
-searchMatch = "#df597070"
+helpText     = "#888095"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "faded"
+activeButton = "#35303f"
+activeBase   = "#35303f"
+searchMatch  = "#df597070"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/selenium_light.toml
+++ b/novelwriter/assets/themes/selenium_light.toml
@@ -66,12 +66,13 @@ linkVisited     = "#623a9b"
 accent          = "red"
 
 [GUI]
-helpText    = "default"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#766c81"
-toggle      = "#c1bccd"
-searchMatch = "red:80"
+helpText     = "default"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#766c81"
+activeButton = "#c1bccd"
+activeBase   = "#c1bccd"
+searchMatch  = "red:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sepia_dark.toml
+++ b/novelwriter/assets/themes/sepia_dark.toml
@@ -66,12 +66,13 @@ linkVisited     = "orange"
 accent          = "#885b4d"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#885b4d"
-toggle      = "orange:80"
-searchMatch = "cyan:88"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#885b4d"
+activeButton = "orange:80"
+activeBase   = "#4b3d37"
+searchMatch  = "cyan:88"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sepia_light.toml
+++ b/novelwriter/assets/themes/sepia_light.toml
@@ -66,12 +66,13 @@ linkVisited     = "#ac5828"
 accent          = "#a57f66"
 
 [GUI]
-helpText    = "#836050"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#a57f66"
-toggle      = "#a57f667f"
-searchMatch = "cyan:96"
+helpText     = "#836050"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#a57f66"
+activeButton = "#a57f667f"
+activeBase   = "#d8c4b2"
+searchMatch  = "cyan:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/snazzy.toml
+++ b/novelwriter/assets/themes/snazzy.toml
@@ -81,12 +81,13 @@ linkVisited     = "blue"
 accent          = "blue"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "blue:96"
-searchMatch = "orange:96"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "blue:96"
+activeBase   = "#eaeaeb"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/solarized_dark.toml
+++ b/novelwriter/assets/themes/solarized_dark.toml
@@ -87,12 +87,13 @@ linkVisited     = "blue"
 accent          = "cyan"
 
 [GUI]
-helpText    = "cyan"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "cyan"
-toggle      = "cyan:96"
-searchMatch = "yellow:128"
+helpText     = "cyan"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "cyan"
+activeButton = "cyan:96"
+activeBase   = "base:L150"
+searchMatch  = "yellow:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/solarized_light.toml
+++ b/novelwriter/assets/themes/solarized_light.toml
@@ -87,12 +87,13 @@ linkVisited     = "blue"
 accent          = "cyan"
 
 [GUI]
-helpText    = "cyan"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "cyan"
-toggle      = "cyan:96"
-searchMatch = "yellow:96"
+helpText     = "cyan"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "cyan"
+activeButton = "cyan:96"
+activeBase   = "base:D115"
+searchMatch  = "yellow:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sultana_light.toml
+++ b/novelwriter/assets/themes/sultana_light.toml
@@ -66,12 +66,13 @@ linkVisited     = "#5577bb"
 accent          = "#ad6978"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#c57b85"
-toggle      = "#ad69787f"
-searchMatch = "yellow:80"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#c57b85"
+activeButton = "#ad69787f"
+activeBase   = "#e4cccc"
+searchMatch  = "yellow:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/sultana_night.toml
+++ b/novelwriter/assets/themes/sultana_night.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#9e4c65"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#9e5c70"
-toggle      = "#9e4c657f"
-searchMatch = "#a181647f"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#9e5c70"
+activeButton = "#9e4c657f"
+activeBase   = "#4a3e4d"
+searchMatch  = "#a181647f"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tango_dark.toml
+++ b/novelwriter/assets/themes/tango_dark.toml
@@ -82,12 +82,13 @@ linkVisited     = "blue"
 accent          = "blue"
 
 [GUI]
-helpText    = "orange"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "blue:128"
-searchMatch = "orange:128"
+helpText     = "orange"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "blue:128"
+activeBase   = "#454e51"
+searchMatch  = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tango_light.toml
+++ b/novelwriter/assets/themes/tango_light.toml
@@ -82,12 +82,13 @@ linkVisited     = "blue"
 accent          = "blue:L150"
 
 [GUI]
-helpText    = "orange"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue:L200"
-toggle      = "blue:96"
-searchMatch = "orange:96"
+helpText     = "orange"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue:L200"
+activeButton = "blue:96"
+activeBase   = "#e0e0e0"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/today_deuteranopia.toml
+++ b/novelwriter/assets/themes/today_deuteranopia.toml
@@ -93,12 +93,13 @@ linkVisited     = "blue"
 accent          = "blue:L150"
 
 [GUI]
-helpText    = "blue"
-fadedText   = "faded"
-errorText   = "yellow"
-accentText  = "blue"
-toggle      = "blue:96"
-searchMatch = "yellow:96"
+helpText     = "blue"
+fadedText    = "faded"
+errorText    = "yellow"
+accentText   = "blue"
+activeButton = "blue:96"
+activeBase   = "#e0e0e0"
+searchMatch  = "yellow:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/today_tritanopia.toml
+++ b/novelwriter/assets/themes/today_tritanopia.toml
@@ -93,12 +93,13 @@ linkVisited     = "green"
 accent          = "green:L150"
 
 [GUI]
-helpText    = "green:D110"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "green"
-toggle      = "green:96"
-searchMatch = "orange:96"
+helpText     = "green:D110"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "green"
+activeButton = "green:96"
+activeBase   = "#e0e0e0"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow.toml
+++ b/novelwriter/assets/themes/tomorrow.toml
@@ -88,12 +88,13 @@ linkVisited     = "blue"
 accent          = "blue"
 
 [GUI]
-helpText    = "#5c5c5c"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "blue:96"
-searchMatch = "orange:96"
+helpText     = "#5c5c5c"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "blue:96"
+activeBase   = "#d6d6d6"
+searchMatch  = "orange:96"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night.toml
+++ b/novelwriter/assets/themes/tomorrow_night.toml
@@ -88,12 +88,13 @@ linkVisited     = "blue"
 accent          = "#2c98f7"
 
 [GUI]
-helpText    = "#a4a4a4"
-fadedText   = "#949494"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#2c98f766"
-searchMatch = "orange:128"
+helpText     = "#a4a4a4"
+fadedText    = "#949494"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#2c98f766"
+activeBase   = "#373b41"
+searchMatch  = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night_blue.toml
+++ b/novelwriter/assets/themes/tomorrow_night_blue.toml
@@ -88,12 +88,13 @@ linkVisited     = "blue"
 accent          = "#2c98f7"
 
 [GUI]
-helpText    = "#a4a4a4"
-fadedText   = "#949494"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#2c98f766"
-searchMatch = "orange:128"
+helpText     = "#a4a4a4"
+fadedText    = "#949494"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#2c98f766"
+activeBase   = "#003f8e"
+searchMatch  = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night_bright.toml
+++ b/novelwriter/assets/themes/tomorrow_night_bright.toml
@@ -88,12 +88,13 @@ linkVisited     = "blue"
 accent          = "#2c98f7"
 
 [GUI]
-helpText    = "#a4a4a4"
-fadedText   = "#949494"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#2c98f757"
-searchMatch = "orange:128"
+helpText     = "#a4a4a4"
+fadedText    = "#949494"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#2c98f757"
+activeBase   = "#424242"
+searchMatch  = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/tomorrow_night_eighties.toml
+++ b/novelwriter/assets/themes/tomorrow_night_eighties.toml
@@ -88,12 +88,13 @@ linkVisited     = "blue"
 accent          = "#2c98f7"
 
 [GUI]
-helpText    = "#a4a4a4"
-fadedText   = "#949494"
-errorText   = "red"
-accentText  = "blue"
-toggle      = "#2c98f766"
-searchMatch = "orange:128"
+helpText     = "#a4a4a4"
+fadedText    = "#949494"
+errorText    = "red"
+accentText   = "blue"
+activeButton = "#2c98f766"
+activeBase   = "#515151"
+searchMatch  = "orange:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_black_green.toml
+++ b/novelwriter/assets/themes/vivid_black_green.toml
@@ -68,12 +68,13 @@ linkVisited     = "green"
 accent          = "green:D125"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "green:D125"
-toggle      = "green:96"
-searchMatch = "red:128"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "green:D125"
+activeButton = "green:96"
+activeBase   = "#323742"
+searchMatch  = "red:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_black_red.toml
+++ b/novelwriter/assets/themes/vivid_black_red.toml
@@ -68,12 +68,13 @@ linkVisited     = "red"
 accent          = "red"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "red"
-toggle      = "red:128"
-searchMatch = "green:72"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "red"
+activeButton = "red:128"
+activeBase   = "#323742"
+searchMatch  = "green:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_white_green.toml
+++ b/novelwriter/assets/themes/vivid_white_green.toml
@@ -68,12 +68,13 @@ linkVisited     = "green"
 accent          = "green"
 
 [GUI]
-helpText    = "default:L250"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "green"
-toggle      = "green:96"
-searchMatch = "red:72"
+helpText     = "default:L250"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "green"
+activeButton = "green:96"
+activeBase   = "#d8dce0"
+searchMatch  = "red:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/vivid_white_red.toml
+++ b/novelwriter/assets/themes/vivid_white_red.toml
@@ -68,12 +68,13 @@ linkVisited     = "red"
 accent          = "red"
 
 [GUI]
-helpText    = "default:L250"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "red"
-toggle      = "red:96"
-searchMatch = "green:72"
+helpText     = "default:L250"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "red"
+activeButton = "red:96"
+activeBase   = "#d8dce0"
+searchMatch  = "green:72"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/warpgate.toml
+++ b/novelwriter/assets/themes/warpgate.toml
@@ -67,12 +67,13 @@ linkVisited     = "green"
 accent          = "green"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#58d662"
-toggle      = "cyan:80"
-searchMatch = "green:128"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#58d662"
+activeButton = "cyan:80"
+activeBase   = "#1a5463"
+searchMatch  = "green:128"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/waterlily_dark.toml
+++ b/novelwriter/assets/themes/waterlily_dark.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#ff9fbd"
 
 [GUI]
-helpText    = "faded"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#87bcc0"
-toggle      = "blue:80"
-searchMatch = "purple:80"
+helpText     = "faded"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#87bcc0"
+activeButton = "blue:80"
+activeBase   = "#3b515f"
+searchMatch  = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/assets/themes/waterlily_light.toml
+++ b/novelwriter/assets/themes/waterlily_light.toml
@@ -66,12 +66,13 @@ linkVisited     = "blue"
 accent          = "#e6859a"
 
 [GUI]
-helpText    = "default:192"
-fadedText   = "faded"
-errorText   = "red"
-accentText  = "#4da1af"
-toggle      = "cyan:112"
-searchMatch = "purple:80"
+helpText     = "default:192"
+fadedText    = "faded"
+errorText    = "red"
+accentText   = "#4da1af"
+activeButton = "cyan:112"
+activeBase   = "#c7e0e0"
+searchMatch  = "purple:80"
 
 [Syntax]
 background     = "base"

--- a/novelwriter/dialogs/preferences.py
+++ b/novelwriter/dialogs/preferences.py
@@ -44,9 +44,9 @@ from novelwriter.common import compact, describeFont, processDialogSymbols, qtAd
 from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS, DEF_TREECOL
 from novelwriter.constants import nwLabels, nwQuotes, nwUnicode, trConst
 from novelwriter.dialogs.quotes import GuiQuoteSelect
-from novelwriter.enum import nwStandardButton
+from novelwriter.enum import nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel, NScrollableForm
-from novelwriter.extensions.modified import NComboBox, NDialog, NDoubleSpinBox, NIconToolButton, NSpinBox
+from novelwriter.extensions.modified import NComboBox, NDialog, NDoubleSpinBox, NIconButton, NSpinBox
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import QtAlignCenter, QtRoleAccept, QtRoleReject
@@ -241,8 +241,7 @@ class GuiPreferences(NDialog):
         self.guiFont.setMinimumWidth(162)
         self.guiFont.setText(describeFont(self._guiFont))
         self.guiFont.setCursorPosition(0)
-        self.guiFontButton = NIconToolButton(self, iSz, "font:tool")
-        self.guiFontButton.setToolTip(self.tr("Select Font"))
+        self.guiFontButton = SHARED.theme.getIconButton(nwToolButton.FONT, self)
         self.guiFontButton.clicked.connect(self._selectGuiFont)
         self.mainForm.addRow(
             self.tr("Application font"),
@@ -302,8 +301,7 @@ class GuiPreferences(NDialog):
         self.textFont.setMinimumWidth(162)
         self.textFont.setText(describeFont(CONFIG.textFont))
         self.textFont.setCursorPosition(0)
-        self.textFontButton = NIconToolButton(self, iSz, "font:tool")
-        self.textFontButton.setToolTip(self.tr("Select Font"))
+        self.textFontButton = SHARED.theme.getIconButton(nwToolButton.FONT, self)
         self.textFontButton.clicked.connect(self._selectTextFont)
         self.mainForm.addRow(
             self.tr("Document font"),
@@ -773,7 +771,7 @@ class GuiPreferences(NDialog):
         self.dialogLine.setAlignment(QtAlignCenter)
         self.dialogLine.setText(" ".join(CONFIG.dialogLine))
 
-        self.dialogLineButton = NIconToolButton(self, iSz, "add:add")
+        self.dialogLineButton = NIconButton(self, iSz, "add:add")
         self.dialogLineButton.setToolTip(self.tr("Select Symbol"))
         self.dialogLineButton.setMenu(self.mnLineSymbols)
 
@@ -940,7 +938,7 @@ class GuiPreferences(NDialog):
         self.fmtSQuoteOpen.setFixedWidth(boxFixed)
         self.fmtSQuoteOpen.setAlignment(QtAlignCenter)
         self.fmtSQuoteOpen.setText(CONFIG.fmtSQuoteOpen)
-        self.btnSQuoteOpen = NIconToolButton(self, iSz, "quote:tool")
+        self.btnSQuoteOpen = NIconButton(self, iSz, "quote:tool")
         self.btnSQuoteOpen.setToolTip(self.tr("Select Symbol"))
         self.btnSQuoteOpen.clicked.connect(self._changeSingleQuoteOpen)
         self.mainForm.addRow(
@@ -956,7 +954,7 @@ class GuiPreferences(NDialog):
         self.fmtSQuoteClose.setFixedWidth(boxFixed)
         self.fmtSQuoteClose.setAlignment(QtAlignCenter)
         self.fmtSQuoteClose.setText(CONFIG.fmtSQuoteClose)
-        self.btnSQuoteClose = NIconToolButton(self, iSz, "quote:tool")
+        self.btnSQuoteClose = NIconButton(self, iSz, "quote:tool")
         self.btnSQuoteClose.setToolTip(self.tr("Select Symbol"))
         self.btnSQuoteClose.clicked.connect(self._changeSingleQuoteClose)
         self.mainForm.addRow(
@@ -973,7 +971,7 @@ class GuiPreferences(NDialog):
         self.fmtDQuoteOpen.setFixedWidth(boxFixed)
         self.fmtDQuoteOpen.setAlignment(QtAlignCenter)
         self.fmtDQuoteOpen.setText(CONFIG.fmtDQuoteOpen)
-        self.btnDQuoteOpen = NIconToolButton(self, iSz, "quote:tool")
+        self.btnDQuoteOpen = NIconButton(self, iSz, "quote:tool")
         self.btnDQuoteOpen.setToolTip(self.tr("Select Symbol"))
         self.btnDQuoteOpen.clicked.connect(self._changeDoubleQuoteOpen)
         self.mainForm.addRow(
@@ -989,7 +987,7 @@ class GuiPreferences(NDialog):
         self.fmtDQuoteClose.setFixedWidth(boxFixed)
         self.fmtDQuoteClose.setAlignment(QtAlignCenter)
         self.fmtDQuoteClose.setText(CONFIG.fmtDQuoteClose)
-        self.btnDQuoteClose = NIconToolButton(self, iSz, "quote:tool")
+        self.btnDQuoteClose = NIconButton(self, iSz, "quote:tool")
         self.btnDQuoteClose.setToolTip(self.tr("Select Symbol"))
         self.btnDQuoteClose.clicked.connect(self._changeDoubleQuoteClose)
         self.mainForm.addRow(

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -508,12 +508,9 @@ class _StatusPage(NFixedPage):
         self.labelColor = QLabel(self.tr("Colour"), self)
         self.labelColor.setBuddy(self.iconColor)
 
-        buttonStyle = "QToolButton {padding: 0 4px;} QToolButton::menu-indicator {image: none;}"
-
         self.colorButton = NIconButton(self, iSz)
         self.colorButton.setToolTip(self.tr("Colour"))
         self.colorButton.setSizePolicy(QtSizeMinimum, QtSizeMinimumExpanding)
-        self.colorButton.setStyleSheet(buttonStyle)
         self.colorButton.setEnabled(False)
         self.colorButton.clicked.connect(self._onColorSelect)
 
@@ -535,7 +532,6 @@ class _StatusPage(NFixedPage):
         self.shapeButton.setMenu(self.shapeMenu)
         self.shapeButton.setToolTip(self.tr("Shape"))
         self.shapeButton.setSizePolicy(QtSizeMinimum, QtSizeMinimumExpanding)
-        self.shapeButton.setStyleSheet(buttonStyle)
         self.shapeButton.setEnabled(False)
 
         self.labelShape = QLabel(self.tr("Shape"), self)

--- a/novelwriter/dialogs/projectsettings.py
+++ b/novelwriter/dialogs/projectsettings.py
@@ -54,7 +54,7 @@ from novelwriter.constants import nwLabels, trConst
 from novelwriter.core.status import CUSTOM_COL, ItemStatus, StatusEntry
 from novelwriter.enum import nwItemClass, nwStandardButton, nwStatusShape, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel, NFixedPage, NScrollableForm
-from novelwriter.extensions.modified import NComboBox, NDialog, NIconToolButton, NSpinBox
+from novelwriter.extensions.modified import NComboBox, NDialog, NIconButton, NSpinBox
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.types import QtRoleAccept, QtRoleReject, QtSizeMinimum, QtSizeMinimumExpanding, QtUserRole
@@ -468,22 +468,22 @@ class _StatusPage(NFixedPage):
             self._addItem(key, StatusEntry.duplicate(entry))
 
         # List Controls
-        self.addButton = SHARED.theme.getToolButton(nwToolButton.ADD, self)
+        self.addButton = SHARED.theme.getFlatButton(nwToolButton.ADD, self)
         self.addButton.clicked.connect(self._onItemCreate)
 
-        self.delButton = SHARED.theme.getToolButton(nwToolButton.REMOVE, self)
+        self.delButton = SHARED.theme.getFlatButton(nwToolButton.REMOVE, self)
         self.delButton.clicked.connect(self._onItemDelete)
 
-        self.upButton = SHARED.theme.getToolButton(nwToolButton.MOVE_UP, self)
+        self.upButton = SHARED.theme.getFlatButton(nwToolButton.MOVE_UP, self)
         self.upButton.clicked.connect(qtLambda(self._moveItem, -1))
 
-        self.downButton = SHARED.theme.getToolButton(nwToolButton.MOVE_DOWN, self)
+        self.downButton = SHARED.theme.getFlatButton(nwToolButton.MOVE_DOWN, self)
         self.downButton.clicked.connect(qtLambda(self._moveItem, 1))
 
-        self.importButton = SHARED.theme.getToolButton(nwToolButton.IMPORT, self)
+        self.importButton = SHARED.theme.getFlatButton(nwToolButton.IMPORT, self)
         self.importButton.clicked.connect(self._importLabels)
 
-        self.exportButton = SHARED.theme.getToolButton(nwToolButton.EXPORT, self)
+        self.exportButton = SHARED.theme.getFlatButton(nwToolButton.EXPORT, self)
         self.exportButton.clicked.connect(self._exportLabels)
 
         # Edit Form
@@ -510,7 +510,7 @@ class _StatusPage(NFixedPage):
 
         buttonStyle = "QToolButton {padding: 0 4px;} QToolButton::menu-indicator {image: none;}"
 
-        self.colorButton = NIconToolButton(self, iSz)
+        self.colorButton = NIconButton(self, iSz)
         self.colorButton.setToolTip(self.tr("Colour"))
         self.colorButton.setSizePolicy(QtSizeMinimum, QtSizeMinimumExpanding)
         self.colorButton.setStyleSheet(buttonStyle)
@@ -531,7 +531,7 @@ class _StatusPage(NFixedPage):
         buildMenu(self.shapeMenu.addMenu(self.tr("Blocks ...")), nwLabels.SHAPES_BLOCKS)
         self.shapeMenu.triggered.connect(self._shapeSelected)
 
-        self.shapeButton = NIconToolButton(self, iSz)
+        self.shapeButton = NIconButton(self, iSz)
         self.shapeButton.setMenu(self.shapeMenu)
         self.shapeButton.setToolTip(self.tr("Shape"))
         self.shapeButton.setSizePolicy(QtSizeMinimum, QtSizeMinimumExpanding)
@@ -838,10 +838,10 @@ class _ReplacePage(NFixedPage):
         self.listBox.setSortingEnabled(True)
 
         # List Controls
-        self.addButton = SHARED.theme.getToolButton(nwToolButton.ADD, self)
+        self.addButton = SHARED.theme.getFlatButton(nwToolButton.ADD, self)
         self.addButton.clicked.connect(self._onEntryCreated)
 
-        self.delButton = SHARED.theme.getToolButton(nwToolButton.REMOVE, self)
+        self.delButton = SHARED.theme.getFlatButton(nwToolButton.REMOVE, self)
         self.delButton.clicked.connect(self._onEntryDeleted)
 
         # Edit Form

--- a/novelwriter/dialogs/wordlist.py
+++ b/novelwriter/dialogs/wordlist.py
@@ -80,11 +80,11 @@ class GuiWordList(NDialog):
             scale=NColorLabel.HEADER_SCALE,
         )
 
-        self.importButton = SHARED.theme.getToolButton(nwToolButton.IMPORT, self)
+        self.importButton = SHARED.theme.getFlatButton(nwToolButton.IMPORT, self)
         self.importButton.setToolTip(self.tr("Import words from text file"))
         self.importButton.clicked.connect(self._importWords)
 
-        self.exportButton = SHARED.theme.getToolButton(nwToolButton.EXPORT, self)
+        self.exportButton = SHARED.theme.getFlatButton(nwToolButton.EXPORT, self)
         self.exportButton.setToolTip(self.tr("Export words to text file"))
         self.exportButton.clicked.connect(self._exportWords)
 
@@ -102,10 +102,10 @@ class GuiWordList(NDialog):
         # Add/Remove Form
         self.newEntry = QLineEdit(self)
 
-        self.addButton = SHARED.theme.getToolButton(nwToolButton.ADD, self)
+        self.addButton = SHARED.theme.getIconButton(nwToolButton.ADD, self)
         self.addButton.clicked.connect(self._doAdd)
 
-        self.delButton = SHARED.theme.getToolButton(nwToolButton.REMOVE, self)
+        self.delButton = SHARED.theme.getIconButton(nwToolButton.REMOVE, self)
         self.delButton.clicked.connect(self._doDelete)
 
         self.editBox = QHBoxLayout()

--- a/novelwriter/editor/editsearch.py
+++ b/novelwriter/editor/editsearch.py
@@ -31,7 +31,7 @@ from PyQt6.QtWidgets import QApplication, QFrame, QGridLayout, QHBoxLayout, QLab
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwConst
-from novelwriter.extensions.modified import NFlatIconButton, NIconToggleButton
+from novelwriter.extensions.modified import NFlatIconButton
 from novelwriter.text.autoreplace import LineEditAutoReplace
 from novelwriter.types import QtKeyEscape, QtModShift
 
@@ -132,7 +132,7 @@ class GuiDocEditSearch(QFrame):
         # Buttons
         # =======
 
-        self.showReplace = NIconToggleButton(self, iSz, "unfold:default")
+        self.showReplace = NFlatIconButton(self, iSz, "toggle-unfold:default")
         self.showReplace.toggled.connect(self._doToggleReplace)
 
         self.searchButton = NFlatIconButton(self, iSz, "search:action")

--- a/novelwriter/editor/editsearch.py
+++ b/novelwriter/editor/editsearch.py
@@ -25,15 +25,15 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from PyQt6.QtCore import QEvent, QObject, QRegularExpression, Qt, pyqtSlot
+from PyQt6.QtCore import QEvent, QObject, QRegularExpression, pyqtSlot
 from PyQt6.QtGui import QKeyEvent, QPalette
-from PyQt6.QtWidgets import QApplication, QFrame, QGridLayout, QLabel, QLineEdit, QToolBar
+from PyQt6.QtWidgets import QApplication, QFrame, QGridLayout, QHBoxLayout, QLabel, QLineEdit
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwConst
-from novelwriter.extensions.modified import NIconToggleButton, NIconToolButton
+from novelwriter.extensions.modified import NFlatIconButton, NIconToggleButton
 from novelwriter.text.autoreplace import LineEditAutoReplace
-from novelwriter.types import QtAlignLeft, QtAlignRight, QtKeyEscape, QtModShift
+from novelwriter.types import QtKeyEscape, QtModShift
 
 if TYPE_CHECKING:
     from novelwriter.editor.editor import GuiDocEditor
@@ -81,73 +81,53 @@ class GuiDocEditSearch(QFrame):
         self.replaceBox.textEdited.connect(self._editReplaceText)
         self.replaceBox.installEventFilter(self)
 
-        self.searchOpt = QToolBar(self)
-        self.searchOpt.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
-        self.searchOpt.setIconSize(iSz)
-        self.searchOpt.setContentsMargins(0, 0, 0, 0)
-
-        self.searchLabel = QLabel(self.tr("Search"), self)
-        self.searchLabel.setIndent(6)
-
         self.resultLabel = QLabel("?/?", self)
 
-        self.tbAuto = NIconToolButton(self, iSz, "search_auto:tool")
+        self.tbAuto = NFlatIconButton(self, iSz, "search_auto:tool")
         self.tbAuto.setToolTip(self.tr("Auto-Replace Symbols"))
         self.tbAuto.setCheckable(True)
         self.tbAuto.clicked.connect(self._doToggleAuto)
-        self.searchOpt.addWidget(self.tbAuto)
         self.setAutoReplaceEnabled(CONFIG.doReplace)
 
-        self.tbCase = NIconToolButton(self, iSz, "search_case:tool")
+        self.tbCase = NFlatIconButton(self, iSz, "search_case:tool")
         self.tbCase.setToolTip(self.tr("Case Sensitive"))
         self.tbCase.setCheckable(True)
         self.tbCase.setChecked(CONFIG.searchCase)
         self.tbCase.clicked.connect(self._doToggleCase)
-        self.searchOpt.addWidget(self.tbCase)
 
-        self.tbWord = NIconToolButton(self, iSz, "search_word:tool")
+        self.tbWord = NFlatIconButton(self, iSz, "search_word:tool")
         self.tbWord.setToolTip(self.tr("Whole Words Only"))
         self.tbWord.setCheckable(True)
         self.tbWord.setChecked(CONFIG.searchWord)
         self.tbWord.clicked.connect(self._doToggleWord)
-        self.searchOpt.addWidget(self.tbWord)
 
-        self.tbRegEx = NIconToolButton(self, iSz, "search_regex:tool")
+        self.tbRegEx = NFlatIconButton(self, iSz, "search_regex:tool")
         self.tbRegEx.setToolTip(self.tr("RegEx Mode"))
         self.tbRegEx.setCheckable(True)
         self.tbRegEx.setChecked(CONFIG.searchRegEx)
         self.tbRegEx.clicked.connect(self._doToggleRegEx)
-        self.searchOpt.addWidget(self.tbRegEx)
 
-        self.tbLoop = NIconToolButton(self, iSz, "search_loop:tool")
+        self.tbLoop = NFlatIconButton(self, iSz, "search_loop:tool")
         self.tbLoop.setToolTip(self.tr("Loop Search"))
         self.tbLoop.setCheckable(True)
         self.tbLoop.setChecked(CONFIG.searchLoop)
         self.tbLoop.clicked.connect(self._doToggleLoop)
-        self.searchOpt.addWidget(self.tbLoop)
 
-        self.tbProject = NIconToolButton(self, iSz, "search_project:tool")
+        self.tbProject = NFlatIconButton(self, iSz, "search_project:tool")
         self.tbProject.setToolTip(self.tr("Search Next File"))
         self.tbProject.setCheckable(True)
         self.tbProject.setChecked(CONFIG.searchNextFile)
         self.tbProject.clicked.connect(self._doToggleProject)
-        self.searchOpt.addWidget(self.tbProject)
 
-        self.searchOpt.addSeparator()
-
-        self.tbMatchCap = NIconToolButton(self, iSz, "search_preserve:tool")
+        self.tbMatchCap = NFlatIconButton(self, iSz, "search_preserve:tool")
         self.tbMatchCap.setToolTip(self.tr("Preserve Case"))
         self.tbMatchCap.setCheckable(True)
         self.tbMatchCap.setChecked(CONFIG.searchMatchCap)
         self.tbMatchCap.clicked.connect(self._doToggleMatchCap)
-        self.searchOpt.addWidget(self.tbMatchCap)
 
-        self.searchOpt.addSeparator()
-
-        self.tbCancel = NIconToolButton(self, iSz, "search_cancel:tool")
+        self.tbCancel = NFlatIconButton(self, iSz, "search_cancel:tool")
         self.tbCancel.setToolTip(self.tr("Close Search"))
         self.tbCancel.clicked.connect(self.closeSearch)
-        self.searchOpt.addWidget(self.tbCancel)
 
         # Buttons
         # =======
@@ -155,29 +135,41 @@ class GuiDocEditSearch(QFrame):
         self.showReplace = NIconToggleButton(self, iSz, "unfold:default")
         self.showReplace.toggled.connect(self._doToggleReplace)
 
-        self.searchButton = NIconToolButton(self, iSz, "search:action")
+        self.searchButton = NFlatIconButton(self, iSz, "search:action")
         self.searchButton.setToolTip(self.tr("Find in current document"))
         self.searchButton.clicked.connect(self._doSearch)
 
-        self.replaceButton = NIconToolButton(self, iSz, "search_replace:apply")
+        self.replaceButton = NFlatIconButton(self, iSz, "search_replace:apply")
         self.replaceButton.setToolTip(self.tr("Find and replace in current document"))
         self.replaceButton.clicked.connect(self._doReplace)
 
-        self.mainBox.addWidget(self.searchLabel, 0, 0, 1, 2, QtAlignLeft)
-        self.mainBox.addWidget(self.searchOpt, 0, 2, 1, 3, QtAlignRight)
+        # Assemble
+        # ========
+
+        self.searchOpt = QHBoxLayout()
+        self.searchOpt.addWidget(self.tbAuto)
+        self.searchOpt.addWidget(self.tbCase)
+        self.searchOpt.addWidget(self.tbWord)
+        self.searchOpt.addWidget(self.tbRegEx)
+        self.searchOpt.addWidget(self.tbLoop)
+        self.searchOpt.addWidget(self.tbProject)
+        self.searchOpt.addWidget(self.tbMatchCap)
+        self.searchOpt.addStretch(1)
+        self.searchOpt.addWidget(self.tbCancel)
+        self.searchOpt.setContentsMargins(0, 0, 0, 0)
+
+        self.mainBox.addLayout(self.searchOpt, 0, 1, 1, 3)
         self.mainBox.addWidget(self.showReplace, 1, 0, 1, 1)
-        self.mainBox.addWidget(self.searchBox, 1, 1, 1, 2)
-        self.mainBox.addWidget(self.searchButton, 1, 3, 1, 1)
-        self.mainBox.addWidget(self.resultLabel, 1, 4, 1, 1)
-        self.mainBox.addWidget(self.replaceBox, 2, 1, 1, 2)
-        self.mainBox.addWidget(self.replaceButton, 2, 3, 1, 1)
+        self.mainBox.addWidget(self.searchBox, 1, 1, 1, 1)
+        self.mainBox.addWidget(self.searchButton, 1, 2, 1, 1)
+        self.mainBox.addWidget(self.resultLabel, 1, 3, 1, 1)
+        self.mainBox.addWidget(self.replaceBox, 2, 1, 1, 1)
+        self.mainBox.addWidget(self.replaceButton, 2, 2, 1, 1)
 
         self.mainBox.setColumnStretch(0, 0)
         self.mainBox.setColumnStretch(1, 0)
         self.mainBox.setColumnStretch(2, 1)
         self.mainBox.setColumnStretch(3, 0)
-        self.mainBox.setColumnStretch(4, 0)
-        self.mainBox.setColumnStretch(5, 0)
         self.mainBox.setSpacing(2)
         self.mainBox.setContentsMargins(6, 6, 6, 6)
 
@@ -274,7 +266,6 @@ class GuiDocEditSearch(QFrame):
         self.setFont(SHARED.theme.guiFont)
         self.searchBox.setFont(SHARED.theme.guiFontSmall)
         self.replaceBox.setFont(SHARED.theme.guiFontSmall)
-        self.searchLabel.setFont(SHARED.theme.guiFontSmall)
         self.resultLabel.setFont(SHARED.theme.guiFontSmall)
         self.resultLabel.setMinimumWidth(SHARED.theme.getTextWidth("?/?", SHARED.theme.guiFontSmall))
 
@@ -300,10 +291,6 @@ class GuiDocEditSearch(QFrame):
             self.searchButton.refreshTheme()
             self.replaceButton.refreshTheme()
             self.showReplace.refreshTheme()
-
-        # Set stylesheets
-        self.searchOpt.setStyleSheet("QToolBar {padding: 0;}")
-        self.showReplace.setStyleSheet("QToolButton {border: none; background: transparent;}")
 
     def cycleFocus(self) -> bool:
         """Cycle focus on tab key press. This just alternates focus

--- a/novelwriter/editor/edittoolbar.py
+++ b/novelwriter/editor/edittoolbar.py
@@ -32,7 +32,7 @@ from PyQt6.QtWidgets import QVBoxLayout, QWidget
 from novelwriter import SHARED
 from novelwriter.common import qtWeakLambda
 from novelwriter.enum import nwDocAction
-from novelwriter.extensions.modified import NIconToolButton
+from novelwriter.extensions.modified import NFlatIconButton
 
 if TYPE_CHECKING:
     from novelwriter.editor.editor import GuiDocEditor
@@ -60,47 +60,47 @@ class GuiDocToolBar(QWidget):
         # General Buttons
         # ===============
 
-        self.tbBoldMD = NIconToolButton(self, iSz, "fmt_bold:markdown")
+        self.tbBoldMD = NFlatIconButton(self, iSz, "fmt_bold:markdown")
         self.tbBoldMD.setToolTip(self.tr("Markdown Bold"))
         self.tbBoldMD.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.MD_BOLD))
 
-        self.tbItalicMD = NIconToolButton(self, iSz, "fmt_italic:markdown")
+        self.tbItalicMD = NFlatIconButton(self, iSz, "fmt_italic:markdown")
         self.tbItalicMD.setToolTip(self.tr("Markdown Italic"))
         self.tbItalicMD.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.MD_ITALIC))
 
-        self.tbStrikeMD = NIconToolButton(self, iSz, "fmt_strike:markdown")
+        self.tbStrikeMD = NFlatIconButton(self, iSz, "fmt_strike:markdown")
         self.tbStrikeMD.setToolTip(self.tr("Markdown Strikethrough"))
         self.tbStrikeMD.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.MD_STRIKE))
 
-        self.tbMarkMD = NIconToolButton(self, iSz, "fmt_mark:markdown")
+        self.tbMarkMD = NFlatIconButton(self, iSz, "fmt_mark:markdown")
         self.tbMarkMD.setToolTip(self.tr("Markdown Highlight"))
         self.tbMarkMD.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.MD_MARK))
 
-        self.tbBold = NIconToolButton(self, iSz, "fmt_bold:shortcode")
+        self.tbBold = NFlatIconButton(self, iSz, "fmt_bold:shortcode")
         self.tbBold.setToolTip(self.tr("Shortcode Bold"))
         self.tbBold.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.SC_BOLD))
 
-        self.tbItalic = NIconToolButton(self, iSz, "fmt_italic:shortcode")
+        self.tbItalic = NFlatIconButton(self, iSz, "fmt_italic:shortcode")
         self.tbItalic.setToolTip(self.tr("Shortcode Italic"))
         self.tbItalic.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.SC_ITALIC))
 
-        self.tbStrike = NIconToolButton(self, iSz, "fmt_strike:shortcode")
+        self.tbStrike = NFlatIconButton(self, iSz, "fmt_strike:shortcode")
         self.tbStrike.setToolTip(self.tr("Shortcode Strikethrough"))
         self.tbStrike.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.SC_STRIKE))
 
-        self.tbUnderline = NIconToolButton(self, iSz, "fmt_underline:shortcode")
+        self.tbUnderline = NFlatIconButton(self, iSz, "fmt_underline:shortcode")
         self.tbUnderline.setToolTip(self.tr("Shortcode Underline"))
         self.tbUnderline.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.SC_ULINE))
 
-        self.tbMark = NIconToolButton(self, iSz, "fmt_mark:shortcode")
+        self.tbMark = NFlatIconButton(self, iSz, "fmt_mark:shortcode")
         self.tbMark.setToolTip(self.tr("Shortcode Highlight"))
         self.tbMark.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.SC_MARK))
 
-        self.tbSuperscript = NIconToolButton(self, iSz, "fmt_superscript:shortcode")
+        self.tbSuperscript = NFlatIconButton(self, iSz, "fmt_superscript:shortcode")
         self.tbSuperscript.setToolTip(self.tr("Shortcode Superscript"))
         self.tbSuperscript.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.SC_SUP))
 
-        self.tbSubscript = NIconToolButton(self, iSz, "fmt_subscript:shortcode")
+        self.tbSubscript = NFlatIconButton(self, iSz, "fmt_subscript:shortcode")
         self.tbSubscript.setToolTip(self.tr("Shortcode Subscript"))
         self.tbSubscript.clicked.connect(qtWeakLambda(self._emitDocAction, nwDocAction.SC_SUB))
 

--- a/novelwriter/editor/footer.py
+++ b/novelwriter/editor/footer.py
@@ -25,16 +25,15 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from PyQt6.QtCore import Qt, pyqtSlot
+from PyQt6.QtCore import pyqtSlot
 from PyQt6.QtGui import QPalette, QPixmap, QTextCursor
-from PyQt6.QtWidgets import QHBoxLayout, QLabel, QToolButton, QWidget
+from PyQt6.QtWidgets import QHBoxLayout, QLabel, QWidget
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import qtWeakLambda
 from novelwriter.constants import nwLabels, nwStats, trStats
 from novelwriter.enum import nwVimMode
-from novelwriter.extensions.modified import NFlatIconButton
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
+from novelwriter.extensions.modified import NFlatIconButton, NFlatIconTextButton
 from novelwriter.types import QtAlignLeftTop, QtBlack
 
 if TYPE_CHECKING:
@@ -287,32 +286,26 @@ class GuiDocViewFooter(QWidget):
         self.showHide.clicked.connect(qtWeakLambda(self._emitTogglePanelVisibility))
 
         # Show Comments
-        self.showComments = QToolButton(self)
-        self.showComments.setText(self.tr("Comments"))
+        self.showComments = NFlatIconTextButton(self, iSz, "toggle-bullet:action", self.tr("Comments"))
         self.showComments.setToolTip(self.tr("Show Comments"))
         self.showComments.setCheckable(True)
         self.showComments.setChecked(CONFIG.viewComments)
-        self.showComments.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.showComments.setIconSize(iSz)
         self.showComments.toggled.connect(self._doToggleComments)
 
         # Show Synopsis
-        self.showSynopsis = QToolButton(self)
-        self.showSynopsis.setText(self.tr("Synopsis"))
+        self.showSynopsis = NFlatIconTextButton(self, iSz, "toggle-bullet:action", self.tr("Synopsis"))
         self.showSynopsis.setToolTip(self.tr("Show Synopsis Comments"))
         self.showSynopsis.setCheckable(True)
         self.showSynopsis.setChecked(CONFIG.viewSynopsis)
-        self.showSynopsis.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.showSynopsis.setIconSize(iSz)
         self.showSynopsis.toggled.connect(self._doToggleSynopsis)
 
         # Show Notes
-        self.showNotes = QToolButton(self)
-        self.showNotes.setText(self.tr("Notes"))
+        self.showNotes = NFlatIconTextButton(self, iSz, "toggle-bullet:action", self.tr("Notes"))
         self.showNotes.setToolTip(self.tr("Show Notes"))
         self.showNotes.setCheckable(True)
         self.showNotes.setChecked(CONFIG.viewNotes)
-        self.showNotes.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
         self.showNotes.setIconSize(iSz)
         self.showNotes.toggled.connect(self._doToggleNotes)
 
@@ -352,21 +345,11 @@ class GuiDocViewFooter(QWidget):
         """Update theme elements."""
         logger.debug("Theme Update: GuiDocViewFooter")
 
-        fPx = int(0.9 * SHARED.theme.fontPixelSize)
-        bulletIcon = SHARED.theme.getToggleIcon("bullet:action", fPx, fPx)
-
         if not init:
             self.showHide.refreshTheme()
-
-        self.showComments.setIcon(bulletIcon)
-        self.showSynopsis.setIcon(bulletIcon)
-        self.showNotes.setIcon(bulletIcon)
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        self.showHide.setStyleSheet(buttonStyle)
-        self.showComments.setStyleSheet(buttonStyle)
-        self.showSynopsis.setStyleSheet(buttonStyle)
-        self.showNotes.setStyleSheet(buttonStyle)
+            self.showComments.refreshTheme()
+            self.showSynopsis.refreshTheme()
+            self.showNotes.refreshTheme()
 
         self.matchColors()
 

--- a/novelwriter/editor/footer.py
+++ b/novelwriter/editor/footer.py
@@ -33,7 +33,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import qtWeakLambda
 from novelwriter.constants import nwLabels, nwStats, trStats
 from novelwriter.enum import nwVimMode
-from novelwriter.extensions.modified import NIconToolButton
+from novelwriter.extensions.modified import NFlatIconButton
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import QtAlignLeftTop, QtBlack
 
@@ -282,7 +282,7 @@ class GuiDocViewFooter(QWidget):
         self.setAutoFillBackground(True)
 
         # Show/Hide Details
-        self.showHide = NIconToolButton(self, iSz, "panel:default")
+        self.showHide = NFlatIconButton(self, iSz, "panel:default")
         self.showHide.setToolTip(self.tr("Show/Hide Viewer Panel"))
         self.showHide.clicked.connect(qtWeakLambda(self._emitTogglePanelVisibility))
 

--- a/novelwriter/editor/header.py
+++ b/novelwriter/editor/header.py
@@ -34,8 +34,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import elide, qtAddAction, qtWeakLambda
 from novelwriter.enum import nwDocMode, nwState
 from novelwriter.extensions.configlayout import NPathColorLabel
-from novelwriter.extensions.modified import NIconToolButton
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
+from novelwriter.extensions.modified import NFlatIconButton
 from novelwriter.types import QtAlignCenterTop, QtAlignMiddle
 
 if TYPE_CHECKING:
@@ -88,27 +87,27 @@ class GuiDocEditHeader(QWidget):
         self.outlineMenu.triggered.connect(self._gotoBlock)
 
         # Buttons
-        self.tbButton = NIconToolButton(self, iSz, "fmt_toolbar:action")
+        self.tbButton = NFlatIconButton(self, iSz, "fmt_toolbar:action")
         self.tbButton.setVisible(False)
         self.tbButton.setToolTip(self.tr("Toggle Tool Bar"))
         self.tbButton.clicked.connect(qtWeakLambda(self._emitToggleToolBar))
 
-        self.outlineButton = NIconToolButton(self, iSz, "list:action")
+        self.outlineButton = NFlatIconButton(self, iSz, "list:action")
         self.outlineButton.setVisible(False)
         self.outlineButton.setToolTip(self.tr("Outline"))
         self.outlineButton.setMenu(self.outlineMenu)
 
-        self.searchButton = NIconToolButton(self, iSz, "search:action")
+        self.searchButton = NFlatIconButton(self, iSz, "search:action")
         self.searchButton.setVisible(False)
         self.searchButton.setToolTip(self.tr("Search"))
         self.searchButton.clicked.connect(self.docEditor.toggleSearch)
 
-        self.minmaxButton = NIconToolButton(self, iSz, "maximise:action")
+        self.minmaxButton = NFlatIconButton(self, iSz, "maximise:action")
         self.minmaxButton.setVisible(False)
         self.minmaxButton.setToolTip(self.tr("Toggle Focus Mode"))
         self.minmaxButton.clicked.connect(qtWeakLambda(self._emitToggleFocusMode))
 
-        self.closeButton = NIconToolButton(self, iSz, "close:reject")
+        self.closeButton = NFlatIconButton(self, iSz, "close:reject")
         self.closeButton.setVisible(False)
         self.closeButton.setToolTip(self.tr("Close"))
         self.closeButton.clicked.connect(self._closeDocument)
@@ -184,13 +183,6 @@ class GuiDocEditHeader(QWidget):
             self.searchButton.refreshTheme()
             self.minmaxButton.refreshTheme()
             self.closeButton.refreshTheme()
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        self.tbButton.setStyleSheet(buttonStyle)
-        self.outlineButton.setStyleSheet(buttonStyle)
-        self.searchButton.setStyleSheet(buttonStyle)
-        self.minmaxButton.setStyleSheet(buttonStyle)
-        self.closeButton.setStyleSheet(buttonStyle)
 
         self.matchColors()
 
@@ -317,32 +309,32 @@ class GuiDocViewHeader(QWidget):
         self.outlineMenu.triggered.connect(self._gotoHeader)
 
         # Buttons
-        self.outlineButton = NIconToolButton(self, iSz, "list:action")
+        self.outlineButton = NFlatIconButton(self, iSz, "list:action")
         self.outlineButton.setVisible(False)
         self.outlineButton.setToolTip(self.tr("Outline"))
         self.outlineButton.setMenu(self.outlineMenu)
 
-        self.backButton = NIconToolButton(self, iSz, "chevron_left:action")
+        self.backButton = NFlatIconButton(self, iSz, "chevron_left:action")
         self.backButton.setVisible(False)
         self.backButton.setToolTip(self.tr("Go Backward"))
         self.backButton.clicked.connect(self.docViewer.navBackward)
 
-        self.forwardButton = NIconToolButton(self, iSz, "chevron_right:action")
+        self.forwardButton = NFlatIconButton(self, iSz, "chevron_right:action")
         self.forwardButton.setVisible(False)
         self.forwardButton.setToolTip(self.tr("Go Forward"))
         self.forwardButton.clicked.connect(self.docViewer.navForward)
 
-        self.editButton = NIconToolButton(self, iSz, "edit:change")
+        self.editButton = NFlatIconButton(self, iSz, "edit:change")
         self.editButton.setVisible(False)
         self.editButton.setToolTip(self.tr("Open in Editor"))
         self.editButton.clicked.connect(self._editDocument)
 
-        self.refreshButton = NIconToolButton(self, iSz, "refresh:change")
+        self.refreshButton = NFlatIconButton(self, iSz, "refresh:change")
         self.refreshButton.setVisible(False)
         self.refreshButton.setToolTip(self.tr("Reload"))
         self.refreshButton.clicked.connect(self._refreshDocument)
 
-        self.closeButton = NIconToolButton(self, iSz, "close:reject")
+        self.closeButton = NFlatIconButton(self, iSz, "close:reject")
         self.closeButton.setVisible(False)
         self.closeButton.setToolTip(self.tr("Close"))
         self.closeButton.clicked.connect(self._closeDocument)
@@ -423,14 +415,6 @@ class GuiDocViewHeader(QWidget):
             self.editButton.refreshTheme()
             self.refreshButton.refreshTheme()
             self.closeButton.refreshTheme()
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        self.outlineButton.setStyleSheet(buttonStyle)
-        self.backButton.setStyleSheet(buttonStyle)
-        self.forwardButton.setStyleSheet(buttonStyle)
-        self.editButton.setStyleSheet(buttonStyle)
-        self.refreshButton.setStyleSheet(buttonStyle)
-        self.closeButton.setStyleSheet(buttonStyle)
 
         self.matchColors()
 

--- a/novelwriter/editor/hovercard.py
+++ b/novelwriter/editor/hovercard.py
@@ -28,12 +28,12 @@ from enum import Enum
 
 from PyQt6.QtCore import QEvent, QPoint, QRectF, Qt, QTimer, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QColor, QEnterEvent, QPainter, QPainterPath, QPaintEvent, QPen, QRegion
-from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QToolButton, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 from novelwriter import SHARED
 from novelwriter.core.indexdata import TT_NONE
 from novelwriter.enum import nwDocMode
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
+from novelwriter.extensions.modified import NFlatIconTextButton
 from novelwriter.types import QtPaintAntiAlias
 
 logger = logging.getLogger(__name__)
@@ -74,6 +74,8 @@ class GuiDocHoverCard(QFrame):
         self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
         self.setFrameStyle(QFrame.Shape.NoFrame)
 
+        iSz = SHARED.theme.baseIconSize
+
         self._tag = ""
         self._cache: dict[str, str] = {}
         self._backColor = QColor()
@@ -92,16 +94,10 @@ class GuiDocHoverCard(QFrame):
         self._separator = QWidget(self)
         self._separator.setFixedHeight(1)
 
-        self._viewBtn = QToolButton(self)
-        self._viewBtn.setText(self.tr("View"))
-        self._viewBtn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        self._viewBtn.setAutoRaise(True)
+        self._viewBtn = NFlatIconTextButton(self, iSz, "view:action", self.tr("View"))
         self._viewBtn.clicked.connect(self._onViewClicked)
 
-        self._editBtn = QToolButton(self)
-        self._editBtn.setText(self.tr("Edit"))
-        self._editBtn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        self._editBtn.setAutoRaise(True)
+        self._editBtn = NFlatIconTextButton(self, iSz, "edit:change", self.tr("Edit"))
         self._editBtn.clicked.connect(self._onEditClicked)
 
         self._buttonBox = QHBoxLayout()
@@ -127,19 +123,14 @@ class GuiDocHoverCard(QFrame):
     def updateTheme(self) -> None:
         """Update the widget's colours to match the editor's theme."""
         syntax = SHARED.theme.syntaxTheme
-        iSz = SHARED.theme.baseIconSize
 
         self._backColor = syntax.back
         self._borderColor = syntax.hidden
         self._label.setStyleSheet(f"color: {syntax.text.name()};")
         self._separator.setStyleSheet(f"background-color: {syntax.hidden.name()};")
 
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        for button, icon in ((self._viewBtn, "view:action"), (self._editBtn, "edit:change")):
-            button.setIcon(SHARED.theme.getIcon(icon))
-            button.setIconSize(iSz)
-            button.setFont(SHARED.theme.guiFontSmall)
-            button.setStyleSheet(buttonStyle)
+        self._viewBtn.setFont(SHARED.theme.guiFontSmall)
+        self._editBtn.setFont(SHARED.theme.guiFontSmall)
 
         self.clearCache()  # The HTML has hardcoded colours
         self.update()

--- a/novelwriter/editor/viewerpanel.py
+++ b/novelwriter/editor/viewerpanel.py
@@ -42,7 +42,7 @@ from novelwriter import SHARED
 from novelwriter.common import checkInt, qtAddAction
 from novelwriter.constants import nwLabels, nwLists, nwStyles, trConst
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass
-from novelwriter.extensions.modified import NIconToolButton, NTabWidget
+from novelwriter.extensions.modified import NFlatIconButton, NTabWidget
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import QtDecorationRole, QtHeaderFixed, QtHeaderToContents, QtUserRole
 
@@ -78,7 +78,7 @@ class GuiDocViewerPanel(QWidget):
         self.aInactive.setCheckable(True)
         self.aInactive.toggled.connect(self._toggleHideInactive)
 
-        self.optsButton = NIconToolButton(self, iSz, "more_vertical:default")
+        self.optsButton = NFlatIconButton(self, iSz, "more_vertical:default")
         self.optsButton.setToolTip(self.tr("Options"))
         self.optsButton.setMenu(self.optsMenu)
         self.optsButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)

--- a/novelwriter/editor/viewerpanel.py
+++ b/novelwriter/editor/viewerpanel.py
@@ -43,7 +43,6 @@ from novelwriter.common import checkInt, qtAddAction
 from novelwriter.constants import nwLabels, nwLists, nwStyles, trConst
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass
 from novelwriter.extensions.modified import NFlatIconButton, NTabWidget
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.types import QtDecorationRole, QtHeaderFixed, QtHeaderToContents, QtUserRole
 
 if TYPE_CHECKING:
@@ -113,7 +112,6 @@ class GuiDocViewerPanel(QWidget):
         """Update theme elements."""
         logger.debug("Theme Update: GuiDocViewerPanel")
 
-        self.optsButton.setStyleSheet(SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON))
         self.mainTabs.refreshTheme()
         if not init:
             self.optsButton.refreshTheme()

--- a/novelwriter/enum.py
+++ b/novelwriter/enum.py
@@ -294,6 +294,7 @@ class nwToolButton(Enum):
     BROWSE = 6
     EDIT = 7
     REVERT = 8
+    FONT = 9
 
 
 class nwState(Enum):

--- a/novelwriter/extensions/expandpanel.py
+++ b/novelwriter/extensions/expandpanel.py
@@ -26,7 +26,7 @@ from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import QWIDGETSIZE_MAX, QHBoxLayout, QLayout, QSplitter, QSplitterHandle, QVBoxLayout, QWidget
 
 from novelwriter import SHARED
-from novelwriter.extensions.modified import NClickableLabel, NIconToggleButton, NSplitterHandle
+from novelwriter.extensions.modified import NClickableLabel, NFlatIconButton, NSplitterHandle
 
 
 class NExpandablePanel(QWidget):
@@ -44,7 +44,7 @@ class NExpandablePanel(QWidget):
         self._ep_expanded = True
         self._ep_widget = QWidget(self)
 
-        self._ep_toggle = NIconToggleButton(self, SHARED.theme.baseIconSize, "unfold:default")
+        self._ep_toggle = NFlatIconButton(self, SHARED.theme.baseIconSize, "toggle-unfold:default", padding=0)
         self._ep_toggle.setChecked(self._ep_expanded)
         self._ep_toggle.toggled.connect(self._toggleExpanded)
 

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QEvent, QModelIndex, QSize, Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QIcon, QPainter, QPaintEvent, QPalette
+from PyQt6.QtGui import QPainter, QPaintEvent, QPalette
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -49,7 +49,20 @@ from PyQt6.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.enum import nwStandardButton
-from novelwriter.types import QtAlignCenter, QtMouseLeft, QtMouseMiddle, QtMouseOver, QtRoleAccept, QtRoleReject
+from novelwriter.types import (
+    QtAlignCenter,
+    QtAlignLeftMiddle,
+    QtIconDisabled,
+    QtIconNormal,
+    QtIconOff,
+    QtIconOn,
+    QtMouseLeft,
+    QtMouseMiddle,
+    QtMouseOver,
+    QtRoleAccept,
+    QtRoleReject,
+    QtToolButtonTextIcon,
+)
 
 if TYPE_CHECKING:
     from enum import Enum
@@ -351,51 +364,56 @@ class NFlatIconButton(QToolButton):
     A flat icon-only tool button.
     """
 
-    __slots__ = ("_icon",)
+    __slots__ = ("_icon", "_iconToggle")
 
-    def __init__(self, parent: QWidget, iconSize: QSize, icon: str | None = None, padding: float = 0.23) -> None:
+    def __init__(self, parent: QWidget, iconSize: QSize, icon: str, padding: float = 0.23) -> None:
         super().__init__(parent=parent)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         self.setIconSize(iconSize)
         self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         self.setFixedSize(round(iconSize.width() * (1 + 2 * padding)), round(iconSize.height() * (1 + 2 * padding)))
         self._icon = icon
+        self._iconToggle = icon.startswith("toggle-")
+        self.setCheckable(self._iconToggle)
         if icon:  # pragma: no branch
             self.setThemeIcon(icon)
 
     def setThemeIcon(self, icon: str) -> None:
         """Set an icon from the current theme."""
         self._icon = icon
-        self.setIcon(SHARED.theme.getIcon(icon))
+        if self._iconToggle:
+            self.setIcon(SHARED.theme.getToggleIcon(icon, self.iconSize().width(), self.iconSize().height()))
+        else:
+            self.setIcon(SHARED.theme.getIcon(icon))
 
     def refreshTheme(self) -> None:
         """Refresh the icon for theme updates."""
         if self._icon:  # pragma: no branch
-            self.setIcon(SHARED.theme.getIcon(self._icon))
+            self.setThemeIcon(self._icon)
 
     def paintEvent(self, event: QPaintEvent | None) -> None:
         """Paint the icon with a background colour when hovered or checked."""
         opt = QStyleOptionToolButton()
         opt.initFrom(self)
 
+        rect = self.rect()
         painter = QPainter(self)
-        if self.isCheckable() and self.isChecked():
-            painter.fillRect(self.rect(), SHARED.theme.activeButton)
+        if not self._iconToggle and self.isCheckable() and self.isChecked():
+            painter.fillRect(rect, SHARED.theme.activeButton)
         elif opt.state & QtMouseOver == QtMouseOver:
-            painter.fillRect(self.rect(), SHARED.theme.activeBase)
+            painter.fillRect(rect, SHARED.theme.activeBase)
 
         icon = self.icon()
         if not icon.isNull():
             size = self.iconSize()
-            rect = self.rect()
             x = rect.x() + (rect.width() - size.width()) // 2
             y = rect.y() + (rect.height() - size.height()) // 2
-            mode = QIcon.Mode.Normal if self.isEnabled() else QIcon.Mode.Disabled
-            state = QIcon.State.On if self.isChecked() else QIcon.State.Off
+            mode = QtIconNormal if self.isEnabled() else QtIconDisabled
+            state = QtIconOn if self.isChecked() else QtIconOff
             icon.paint(painter, x, y, size.width(), size.height(), QtAlignCenter, mode, state)
 
 
-class NIconToggleButton(QToolButton):
+class NFlatIconTextButton(QToolButton):
     """Custom: Modified QToolButton.
 
     A quicker way to create a toggle button that switches icon when
@@ -404,30 +422,60 @@ class NIconToggleButton(QToolButton):
     setCheckable(True) instead.
     """
 
-    __slots__ = ("_icon", "_size")
+    __slots__ = ("_icon", "_iconToggle")
 
-    def __init__(self, parent: QWidget, iconSize: QSize, icon: str | None = None) -> None:
+    def __init__(self, parent: QWidget, iconSize: QSize, icon: str, text: str) -> None:
         super().__init__(parent=parent)
-        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.setToolButtonStyle(QtToolButtonTextIcon)
         self.setIconSize(iconSize)
         self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        self.setCheckable(True)
-        self.setStyleSheet("border: none; background: transparent;")
+        self.setText(text)
         self._icon = icon
-        self._size = iconSize
+        self._iconToggle = icon.startswith("toggle-")
+        self.setCheckable(self._iconToggle)
         if icon:  # pragma: no branch
             self.setThemeIcon(icon)
 
     def setThemeIcon(self, icon: str) -> None:
         """Set an icon from the current theme."""
         self._icon = icon
-        self._size = self.iconSize()
-        self.setIcon(SHARED.theme.getToggleIcon(icon, self._size.width(), self._size.height()))
+        if self._iconToggle:
+            self.setIcon(SHARED.theme.getToggleIcon(icon, self.iconSize().width(), self.iconSize().height()))
+        else:
+            self.setIcon(SHARED.theme.getIcon(icon))
 
     def refreshTheme(self) -> None:
         """Refresh the icon for theme updates."""
         if self._icon:  # pragma: no branch
-            self.setIcon(SHARED.theme.getToggleIcon(self._icon, self._size.width(), self._size.height()))
+            self.setThemeIcon(self._icon)
+
+    def paintEvent(self, event: QPaintEvent | None) -> None:
+        """Paint the icon with a background colour when hovered or checked."""
+        opt = QStyleOptionToolButton()
+        opt.initFrom(self)
+
+        rect = self.rect()
+        painter = QPainter(self)
+        if opt.state & QtMouseOver == QtMouseOver:
+            painter.fillRect(rect, SHARED.theme.activeBase)
+
+        icon = self.icon()
+        size = self.iconSize()
+        mode = QtIconNormal if self.isEnabled() else QtIconDisabled
+        state = QtIconOn if self.isChecked() else QtIconOff
+        if text := self.text():
+            margin = (rect.height() - size.height()) // 2
+            x = rect.x() + margin
+            y = rect.y() + margin
+            if not icon.isNull():
+                icon.paint(painter, x, y, size.width(), size.height(), QtAlignCenter, mode, state)
+            textRect = rect.adjusted(x + size.width() + margin, 0, -margin, 0)
+            painter.setPen(opt.palette.color(QPalette.ColorRole.ButtonText))
+            painter.drawText(textRect, QtAlignLeftMiddle, text)
+        elif not icon.isNull():
+            x = rect.x() + (rect.width() - size.width()) // 2
+            y = rect.y() + (rect.height() - size.height()) // 2
+            icon.paint(painter, x, y, size.width(), size.height(), QtAlignCenter, mode, state)
 
 
 class NTabWidget(QTabWidget):

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -26,7 +26,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QEvent, QModelIndex, QSize, Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QPainter, QPaintEvent, QPalette
+from PyQt6.QtGui import QIcon, QPainter, QPaintEvent, QPalette
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -39,6 +39,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QSplitter,
     QSplitterHandle,
+    QStyleOptionToolButton,
     QTabBar,
     QTabWidget,
     QToolButton,
@@ -48,7 +49,7 @@ from PyQt6.QtWidgets import (
 
 from novelwriter import CONFIG, SHARED
 from novelwriter.enum import nwStandardButton
-from novelwriter.types import QtAlignCenter, QtHexArgb, QtMouseLeft, QtMouseMiddle, QtRoleAccept, QtRoleReject
+from novelwriter.types import QtAlignCenter, QtMouseLeft, QtMouseMiddle, QtMouseOver, QtRoleAccept, QtRoleReject
 
 if TYPE_CHECKING:
     from enum import Enum
@@ -311,10 +312,10 @@ class NPushButton(QPushButton):
             self.setIcon(SHARED.theme.getIcon(self._icon))
 
 
-class NIconToolButton(QToolButton):
-    """Custom: Modified QToolButton.
+class NIconButton(QToolButton):
+    """Custom: Icon Push Button.
 
-    A quicker way to create a tool button using the app theme.
+    A tool button that looks like an icon-only push button.
     """
 
     __slots__ = ("_icon",)
@@ -328,12 +329,39 @@ class NIconToolButton(QToolButton):
         if icon:  # pragma: no branch
             self.setThemeIcon(icon)
 
-    def setCheckable(self, checkable: bool) -> None:
-        """Overload the checkable setter to change the button style."""
-        super().setCheckable(checkable)
-        if checkable:
-            col = SHARED.theme.activeButton.name(QtHexArgb)
-            self.setStyleSheet(f"QToolButton:checked {{background: {col};}}")
+    def setThemeIcon(self, icon: str) -> None:
+        """Set an icon from the current theme."""
+        self._icon = icon
+        self.setIcon(SHARED.theme.getIcon(icon))
+
+    def refreshTheme(self) -> None:
+        """Refresh the icon for theme updates."""
+        if self._icon:  # pragma: no branch
+            self.setIcon(SHARED.theme.getIcon(self._icon))
+
+    def sizeHint(self) -> QSize:
+        """Pad the size hint to a square the height of a standard QPushButton."""
+        height = round(self.fontMetrics().height() * 1.5)
+        return QSize(height, height)
+
+
+class NFlatIconButton(QToolButton):
+    """Custom: Flat Icon Tool Button.
+
+    A flat icon-only tool button.
+    """
+
+    __slots__ = ("_icon",)
+
+    def __init__(self, parent: QWidget, iconSize: QSize, icon: str | None = None, padding: float = 0.23) -> None:
+        super().__init__(parent=parent)
+        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
+        self.setIconSize(iconSize)
+        self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.setFixedSize(round(iconSize.width() * (1 + 2 * padding)), round(iconSize.height() * (1 + 2 * padding)))
+        self._icon = icon
+        if icon:  # pragma: no branch
+            self.setThemeIcon(icon)
 
     def setThemeIcon(self, icon: str) -> None:
         """Set an icon from the current theme."""
@@ -344,9 +372,27 @@ class NIconToolButton(QToolButton):
         """Refresh the icon for theme updates."""
         if self._icon:  # pragma: no branch
             self.setIcon(SHARED.theme.getIcon(self._icon))
-        if self.isCheckable():
-            col = SHARED.theme.activeButton.name(QtHexArgb)
-            self.setStyleSheet(f"QToolButton:checked {{background: {col};}}")
+
+    def paintEvent(self, event: QPaintEvent | None) -> None:
+        """Paint the icon with a background colour when hovered or checked."""
+        opt = QStyleOptionToolButton()
+        opt.initFrom(self)
+
+        painter = QPainter(self)
+        if self.isCheckable() and self.isChecked():
+            painter.fillRect(self.rect(), SHARED.theme.activeButton)
+        elif opt.state & QtMouseOver == QtMouseOver:
+            painter.fillRect(self.rect(), SHARED.theme.activeBase)
+
+        icon = self.icon()
+        if not icon.isNull():
+            size = self.iconSize()
+            rect = self.rect()
+            x = rect.x() + (rect.width() - size.width()) // 2
+            y = rect.y() + (rect.height() - size.height()) // 2
+            mode = QIcon.Mode.Normal if self.isEnabled() else QIcon.Mode.Disabled
+            state = QIcon.State.On if self.isChecked() else QIcon.State.Off
+            icon.paint(painter, x, y, size.width(), size.height(), QtAlignCenter, mode, state)
 
 
 class NIconToggleButton(QToolButton):

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -332,7 +332,7 @@ class NIconToolButton(QToolButton):
         """Overload the checkable setter to change the button style."""
         super().setCheckable(checkable)
         if checkable:
-            col = SHARED.theme.toggleCol.name(QtHexArgb)
+            col = SHARED.theme.activeButton.name(QtHexArgb)
             self.setStyleSheet(f"QToolButton:checked {{background: {col};}}")
 
     def setThemeIcon(self, icon: str) -> None:
@@ -345,7 +345,7 @@ class NIconToolButton(QToolButton):
         if self._icon:  # pragma: no branch
             self.setIcon(SHARED.theme.getIcon(self._icon))
         if self.isCheckable():
-            col = SHARED.theme.toggleCol.name(QtHexArgb)
+            col = SHARED.theme.activeButton.name(QtHexArgb)
             self.setStyleSheet(f"QToolButton:checked {{background: {col};}}")
 
 
@@ -435,7 +435,7 @@ class NTabBar(QTabBar):
                 continue
 
             if i == selected:
-                painter.fillRect(rect, palette.alternateBase())
+                painter.fillRect(rect, SHARED.theme.activeBase)
                 painter.setPen(SHARED.theme.accentText)
                 painter.drawLine(rL, rT, rR, rT)
             else:

--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -400,11 +400,11 @@ class NFlatIconButton(QToolButton):
         painter = QPainter(self)
         if not self._iconToggle and self.isCheckable() and self.isChecked():
             painter.fillRect(rect, SHARED.theme.activeButton)
-        elif opt.state & QtMouseOver == QtMouseOver:
+        elif opt.state & QtMouseOver == QtMouseOver:  # pragma: no cover
             painter.fillRect(rect, SHARED.theme.activeBase)
 
         icon = self.icon()
-        if not icon.isNull():
+        if not icon.isNull():  # pragma: no branch
             size = self.iconSize()
             x = rect.x() + (rect.width() - size.width()) // 2
             y = rect.y() + (rect.height() - size.height()) // 2
@@ -456,26 +456,22 @@ class NFlatIconTextButton(QToolButton):
 
         rect = self.rect()
         painter = QPainter(self)
-        if opt.state & QtMouseOver == QtMouseOver:
+        if opt.state & QtMouseOver == QtMouseOver:  # pragma: no cover
             painter.fillRect(rect, SHARED.theme.activeBase)
 
         icon = self.icon()
         size = self.iconSize()
         mode = QtIconNormal if self.isEnabled() else QtIconDisabled
         state = QtIconOn if self.isChecked() else QtIconOff
-        if text := self.text():
+        if text := self.text():  # pragma: no branch
             margin = (rect.height() - size.height()) // 2
             x = rect.x() + margin
             y = rect.y() + margin
-            if not icon.isNull():
+            if not icon.isNull():  # pragma: no branch
                 icon.paint(painter, x, y, size.width(), size.height(), QtAlignCenter, mode, state)
             textRect = rect.adjusted(x + size.width() + margin, 0, -margin, 0)
             painter.setPen(opt.palette.color(QPalette.ColorRole.ButtonText))
             painter.drawText(textRect, QtAlignLeftMiddle, text)
-        elif not icon.isNull():
-            x = rect.x() + (rect.width() - size.width()) // 2
-            y = rect.y() + (rect.height() - size.height()) // 2
-            icon.paint(painter, x, y, size.width(), size.height(), QtAlignCenter, mode, state)
 
 
 class NTabWidget(QTabWidget):

--- a/novelwriter/extensions/pagedsidebar.py
+++ b/novelwriter/extensions/pagedsidebar.py
@@ -33,6 +33,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from novelwriter import SHARED
 from novelwriter.types import (
     QtAlignLeft,
     QtMouseOver,
@@ -151,7 +152,7 @@ class _PagedToolButton(QToolButton):
         palette = self.palette()
 
         if opt.state & QtMouseOver == QtMouseOver:  # pragma: no cover
-            painter.setBrush(palette.light())
+            painter.setBrush(SHARED.theme.activeBase)
             painter.drawRoundedRect(0, 0, width, height, 4, 4)
 
         if self.isChecked():

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -44,7 +44,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import minmax, qtAddAction, qtAddMenu, qtWeakLambda
 from novelwriter.constants import nwKeyWords, nwLabels, trConst
 from novelwriter.enum import nwChange, nwDocMode, nwNovelExtra, nwOutline
-from novelwriter.extensions.modified import NIconToolButton, NTreeView
+from novelwriter.extensions.modified import NFlatIconButton, NTreeView
 from novelwriter.extensions.novelselector import NovelSelector
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.models.novelmodel import NovelModel
@@ -199,12 +199,12 @@ class GuiNovelToolBar(QWidget):
         self.novelValue.setSizePolicy(QtSizeExpanding, QtSizeExpanding)
         self.novelValue.novelSelectionChanged.connect(self.setCurrentRoot)
 
-        self.tbNovel = NIconToolButton(self, iSz, "cls_novel:root")
+        self.tbNovel = NFlatIconButton(self, iSz, "cls_novel:root")
         self.tbNovel.setToolTip(self.tr("Novel Root"))
         self.tbNovel.clicked.connect(self.novelValue.showPopup)
 
         # Refresh Button
-        self.tbRefresh = NIconToolButton(self, iSz, "refresh:change")
+        self.tbRefresh = NFlatIconButton(self, iSz, "refresh:change")
         self.tbRefresh.setToolTip(self.tr("Refresh"))
         self.tbRefresh.clicked.connect(self.forceRefreshNovelTree)
 
@@ -223,7 +223,7 @@ class GuiNovelToolBar(QWidget):
         self.aLastColSize = qtAddAction(self.mLastCol, self.tr("Column Size"))
         self.aLastColSize.triggered.connect(self._selectLastColumnSize)
 
-        self.tbMore = NIconToolButton(self, iSz, "more_vertical:default")
+        self.tbMore = NFlatIconButton(self, iSz, "more_vertical:default")
         self.tbMore.setToolTip(self.tr("More Options"))
         self.tbMore.setMenu(self.mMore)
 

--- a/novelwriter/gui/noveltree.py
+++ b/novelwriter/gui/noveltree.py
@@ -46,7 +46,6 @@ from novelwriter.constants import nwKeyWords, nwLabels, trConst
 from novelwriter.enum import nwChange, nwDocMode, nwNovelExtra, nwOutline
 from novelwriter.extensions.modified import NFlatIconButton, NTreeView
 from novelwriter.extensions.novelselector import NovelSelector
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.models.novelmodel import NovelModel
 from novelwriter.types import (
     QtHeaderStretch,
@@ -257,11 +256,6 @@ class GuiNovelToolBar(QWidget):
             self.tbNovel.refreshTheme()
             self.tbRefresh.refreshTheme()
             self.tbMore.refreshTheme()
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        self.tbNovel.setStyleSheet(buttonStyle)
-        self.tbRefresh.setStyleSheet(buttonStyle)
-        self.tbMore.setStyleSheet(buttonStyle)
 
         self.novelValue.setStyleSheet(
             "QComboBox {border-style: none; padding-left: 0;} QComboBox::drop-down {border-style: none}"

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -51,7 +51,7 @@ from novelwriter.dialogs.docsplit import GuiDocSplit
 from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass, nwItemLayout, nwItemType
-from novelwriter.extensions.modified import NIconToolButton
+from novelwriter.extensions.modified import NFlatIconButton
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.models.itemmodel import ProjectModel, ProjectNode
 from novelwriter.types import (
@@ -265,17 +265,17 @@ class GuiProjectToolBar(QWidget):
         self.mQuick = QMenu(self)
         self.mQuick.triggered.connect(self._onQuickLinkSelected)
 
-        self.tbQuick = NIconToolButton(self, iSz, "bookmarks:action")
+        self.tbQuick = NFlatIconButton(self, iSz, "bookmarks:action")
         self.tbQuick.setToolTip("{0} [Ctrl+L]".format(self.tr("Quick Links")))
         self.tbQuick.setShortcut("Ctrl+L")
         self.tbQuick.setMenu(self.mQuick)
 
         # Move Buttons
-        self.tbMoveU = NIconToolButton(self, iSz, "chevron_up:action")
+        self.tbMoveU = NFlatIconButton(self, iSz, "chevron_up:action")
         self.tbMoveU.setToolTip("{0} [Ctrl+Up]".format(self.tr("Move Up")))
         self.tbMoveU.clicked.connect(self.projTree.moveItemUp)
 
-        self.tbMoveD = NIconToolButton(self, iSz, "chevron_down:action")
+        self.tbMoveD = NFlatIconButton(self, iSz, "chevron_down:action")
         self.tbMoveD.setToolTip("{0} [Ctrl+Down]".format(self.tr("Move Down")))
         self.tbMoveD.clicked.connect(self.projTree.moveItemDown)
 
@@ -309,7 +309,7 @@ class GuiProjectToolBar(QWidget):
         self.mAddRoot.triggered.connect(self._onAddRootSelected)
         self._buildRootMenu()
 
-        self.tbAdd = NIconToolButton(self, iSz, "add:add")
+        self.tbAdd = NFlatIconButton(self, iSz, "add:add")
         self.tbAdd.setToolTip("{0} [Ctrl+N]".format(self.tr("Add Item")))
         self.tbAdd.setShortcut("Ctrl+N")
         self.tbAdd.setMenu(self.mAdd)
@@ -326,7 +326,7 @@ class GuiProjectToolBar(QWidget):
         self.aEmptyTrash = qtAddAction(self.mMore, self.tr("Empty Trash"))
         self.aEmptyTrash.triggered.connect(self.projTree.emptyTrash)
 
-        self.tbMore = NIconToolButton(self, iSz, "more_vertical:default")
+        self.tbMore = NFlatIconButton(self, iSz, "more_vertical:default")
         self.tbMore.setToolTip(self.tr("More Options"))
         self.tbMore.setMenu(self.mMore)
 

--- a/novelwriter/gui/projtree.py
+++ b/novelwriter/gui/projtree.py
@@ -52,7 +52,6 @@ from novelwriter.dialogs.editlabel import GuiEditLabel
 from novelwriter.dialogs.projectsettings import GuiProjectSettings
 from novelwriter.enum import nwChange, nwDocMode, nwItemClass, nwItemLayout, nwItemType
 from novelwriter.extensions.modified import NFlatIconButton
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.models.itemmodel import ProjectModel, ProjectNode
 from novelwriter.types import (
     QtHeaderFixed,
@@ -353,13 +352,6 @@ class GuiProjectToolBar(QWidget):
     def updateTheme(self, *, init: bool = False) -> None:
         """Update theme elements."""
         logger.debug("Theme Update: GuiProjectToolBar")
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        self.tbQuick.setStyleSheet(buttonStyle)
-        self.tbMoveU.setStyleSheet(buttonStyle)
-        self.tbMoveD.setStyleSheet(buttonStyle)
-        self.tbAdd.setStyleSheet(buttonStyle)
-        self.tbMore.setStyleSheet(buttonStyle)
 
         if not init:
             self.tbQuick.refreshTheme()

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -50,7 +50,7 @@ from novelwriter.constants import nwLabels, trConst
 from novelwriter.core.projectsearch import DocSearch
 from novelwriter.enum import nwChange, nwDocMode
 from novelwriter.extensions.expandpanel import NExpandablePanel, NExpandablePanelGroup
-from novelwriter.extensions.modified import NIconToolButton
+from novelwriter.extensions.modified import NFlatIconButton
 from novelwriter.extensions.switchbox import NSwitchBox
 from novelwriter.models.searchmodel import SearchNode, SearchResultModel
 from novelwriter.text.autoreplace import LineEditAutoReplace
@@ -115,28 +115,28 @@ class GuiProjectSearch(QWidget):
         self.searchOpt.setIconSize(iSz)
         self.searchOpt.setContentsMargins(0, 0, 0, 0)
 
-        self.tbAuto = NIconToolButton(self, iSz, "search_auto:tool")
+        self.tbAuto = NFlatIconButton(self, iSz, "search_auto:tool")
         self.tbAuto.setToolTip(self.tr("Auto-Replace Symbols"))
         self.tbAuto.setCheckable(True)
         self.tbAuto.setChecked(CONFIG.searchProjAuto)
         self.tbAuto.clicked.connect(self._toggleAuto)
         self.searchOpt.addWidget(self.tbAuto)
 
-        self.tbCase = NIconToolButton(self, iSz, "search_case:tool")
+        self.tbCase = NFlatIconButton(self, iSz, "search_case:tool")
         self.tbCase.setToolTip(self.tr("Case Sensitive"))
         self.tbCase.setCheckable(True)
         self.tbCase.setChecked(CONFIG.searchProjCase)
         self.tbCase.clicked.connect(self._toggleCase)
         self.searchOpt.addWidget(self.tbCase)
 
-        self.tbWord = NIconToolButton(self, iSz, "search_word:tool")
+        self.tbWord = NFlatIconButton(self, iSz, "search_word:tool")
         self.tbWord.setToolTip(self.tr("Whole Words Only"))
         self.tbWord.setCheckable(True)
         self.tbWord.setChecked(CONFIG.searchProjWord)
         self.tbWord.clicked.connect(self._toggleWord)
         self.searchOpt.addWidget(self.tbWord)
 
-        self.tbRegEx = NIconToolButton(self, iSz, "search_regex:tool")
+        self.tbRegEx = NFlatIconButton(self, iSz, "search_regex:tool")
         self.tbRegEx.setToolTip(self.tr("RegEx Mode"))
         self.tbRegEx.setCheckable(True)
         self.tbRegEx.setChecked(CONFIG.searchProjRegEx)

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -33,8 +33,7 @@ from novelwriter.common import qtWeakLambda
 from novelwriter.constants import nwLabels, trConst
 from novelwriter.enum import nwTheme, nwView
 from novelwriter.extensions.eventfilters import StatusTipFilter
-from novelwriter.extensions.modified import NIconToolButton
-from novelwriter.gui.theme import STYLES_BIG_TOOLBUTTON
+from novelwriter.extensions.modified import NFlatIconButton
 
 if TYPE_CHECKING:
     from novelwriter.guimain import GuiMain
@@ -60,40 +59,40 @@ class GuiSideBar(QWidget):
         self.installEventFilter(StatusTipFilter(self.mainGui))
 
         # Buttons
-        self.tbProject = NIconToolButton(self, iSz, "sb_project:sidebar")
+        self.tbProject = NFlatIconButton(self, iSz, "sb_project:sidebar", 0.25)
         self.tbProject.setToolTip("{0} [Ctrl+T]".format(self.tr("Project Tree View")))
         self.tbProject.clicked.connect(qtWeakLambda(self._emitViewChange, nwView.PROJECT))
 
-        self.tbNovel = NIconToolButton(self, iSz, "sb_novel:sidebar")
+        self.tbNovel = NFlatIconButton(self, iSz, "sb_novel:sidebar", 0.25)
         self.tbNovel.setToolTip("{0} [Ctrl+T]".format(self.tr("Novel Tree View")))
         self.tbNovel.clicked.connect(qtWeakLambda(self._emitViewChange, nwView.NOVEL))
 
-        self.tbSearch = NIconToolButton(self, iSz, "sb_search:sidebar")
+        self.tbSearch = NFlatIconButton(self, iSz, "sb_search:sidebar", 0.25)
         self.tbSearch.setToolTip("{0} [Ctrl+Shift+F]".format(self.tr("Project Search")))
         self.tbSearch.clicked.connect(qtWeakLambda(self._emitViewChange, nwView.SEARCH))
 
-        self.tbOutline = NIconToolButton(self, iSz, "sb_outline:sidebar")
+        self.tbOutline = NFlatIconButton(self, iSz, "sb_outline:sidebar", 0.25)
         self.tbOutline.setToolTip("{0} [Ctrl+Shift+T]".format(self.tr("Novel Outline View")))
         self.tbOutline.clicked.connect(qtWeakLambda(self._emitViewChange, nwView.OUTLINE))
 
-        self.tbTheme = NIconToolButton(self, iSz)
+        self.tbTheme = NFlatIconButton(self, iSz, None, 0.25)
         self.tbTheme.setToolTip(self.tr("Switch Colour Theme"))
         self.tbTheme.clicked.connect(self._cycleColorTheme)
 
-        self.tbDetails = NIconToolButton(self, iSz, "sb_details:sidebar")
+        self.tbDetails = NFlatIconButton(self, iSz, "sb_details:sidebar", 0.25)
         self.tbDetails.setToolTip("{0} [Shift+F6]".format(self.tr("Novel Details")))
         self.tbDetails.clicked.connect(self.mainGui.showNovelDetailsDialog)
 
-        self.tbStats = NIconToolButton(self, iSz, "sb_stats:sidebar")
+        self.tbStats = NFlatIconButton(self, iSz, "sb_stats:sidebar", 0.25)
         self.tbStats.setToolTip("{0} [F6]".format(self.tr("Writing Statistics")))
         self.tbStats.clicked.connect(self.mainGui.showWritingStatsDialog)
 
-        self.tbBuild = NIconToolButton(self, iSz, "sb_build:sidebar")
+        self.tbBuild = NFlatIconButton(self, iSz, "sb_build:sidebar", 0.25)
         self.tbBuild.setToolTip("{0} [F5]".format(self.tr("Manuscript Build")))
         self.tbBuild.clicked.connect(self.mainGui.showBuildManuscriptDialog)
 
         # Settings Menu
-        self.tbSettings = NIconToolButton(self, iSz, "settings:sidebar")
+        self.tbSettings = NFlatIconButton(self, iSz, "settings:sidebar", 0.25)
         self.tbSettings.setToolTip(self.tr("Settings"))
 
         self.mSettings = _PopRightMenu(self.tbSettings)
@@ -127,17 +126,6 @@ class GuiSideBar(QWidget):
     def updateTheme(self, *, init: bool = False) -> None:
         """Initialise GUI elements that depend on specific settings."""
         logger.debug("Theme Update: GuiSideBar")
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_BIG_TOOLBUTTON)
-        self.tbProject.setStyleSheet(buttonStyle)
-        self.tbNovel.setStyleSheet(buttonStyle)
-        self.tbSearch.setStyleSheet(buttonStyle)
-        self.tbOutline.setStyleSheet(buttonStyle)
-        self.tbBuild.setStyleSheet(buttonStyle)
-        self.tbDetails.setStyleSheet(buttonStyle)
-        self.tbStats.setStyleSheet(buttonStyle)
-        self.tbTheme.setStyleSheet(buttonStyle)
-        self.tbSettings.setStyleSheet(buttonStyle)
 
         if not init:
             self.tbProject.refreshTheme()

--- a/novelwriter/gui/sidebar.py
+++ b/novelwriter/gui/sidebar.py
@@ -75,7 +75,7 @@ class GuiSideBar(QWidget):
         self.tbOutline.setToolTip("{0} [Ctrl+Shift+T]".format(self.tr("Novel Outline View")))
         self.tbOutline.clicked.connect(qtWeakLambda(self._emitViewChange, nwView.OUTLINE))
 
-        self.tbTheme = NFlatIconButton(self, iSz, None, 0.25)
+        self.tbTheme = NFlatIconButton(self, iSz, "", 0.25)
         self.tbTheme.setToolTip(self.tr("Switch Colour Theme"))
         self.tbTheme.clicked.connect(self._cycleColorTheme)
 

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -33,7 +33,7 @@ from PyQt6.QtWidgets import QApplication, QHBoxLayout, QLabel, QStatusBar, QWidg
 from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatPercent, formatTime, languageName
 from novelwriter.constants import nwConst, nwLabels, nwStats, trStats
-from novelwriter.extensions.modified import NClickableLabel, NIconToolButton
+from novelwriter.extensions.modified import NClickableLabel, NFlatIconButton
 from novelwriter.extensions.progressbars import NColorRangeProgress
 from novelwriter.extensions.statusled import StatusLED
 from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
@@ -67,7 +67,7 @@ class GuiMainStatus(QStatusBar):
         # =================
 
         # The Daily Progress Bar
-        self.dayReset = NIconToolButton(self, iSz, "revert:reset")
+        self.dayReset = NFlatIconButton(self, iSz, "revert:reset")
         self.dayReset.setToolTip(self.tr("Reset Daily Progress"))
         self.dayReset.setVisible(False)
         self.dayReset.clicked.connect(self._resetDailyProgress)

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -36,7 +36,6 @@ from novelwriter.constants import nwConst, nwLabels, nwStats, trStats
 from novelwriter.extensions.modified import NClickableLabel, NFlatIconButton
 from novelwriter.extensions.progressbars import NColorRangeProgress
 from novelwriter.extensions.statusled import StatusLED
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 
 if TYPE_CHECKING:
     from novelwriter.types import T_MsgSeverity
@@ -193,9 +192,6 @@ class GuiMainStatus(QStatusBar):
         self.dayReset.refreshTheme()
         self.dayProg.refreshTheme()
         self.projProg.refreshTheme()
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        self.dayReset.setStyleSheet(buttonStyle)
 
     ##
     #  Setters

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -56,7 +56,9 @@ from novelwriter.types import (
     QtColDisabled,
     QtColInactive,
     QtFontSemiBold,
-    QtHexArgb,
+    QtIconNormal,
+    QtIconOff,
+    QtIconOn,
     QtPaintAntiAlias,
     QtTransparent,
 )
@@ -65,9 +67,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-STYLES_MIN_TOOLBUTTON = "minimalToolButton"
-STYLES_BIG_TOOLBUTTON = "bigToolButton"
 
 STANDARD_BUTTONS = {
     nwStandardButton.OK: (QT_TRANSLATE_NOOP("Button", "OK"), "btn_ok:action"),
@@ -171,7 +170,6 @@ class GuiTheme:
         "_lightThemes",
         "_meta",
         "_qColors",
-        "_styleSheets",
         "_svgColors",
         "_syntaxList",
         "accentCol",
@@ -239,7 +237,6 @@ class GuiTheme:
         self._currentTheme = ""
         self._guiPalette = QPalette()
         self._allThemes: dict[str, ThemeEntry] = {}
-        self._styleSheets: dict[str, str] = {}
         self._svgColors: dict[str, bytes] = {}
         self._qColors: dict[str, QColor] = {}
 
@@ -607,13 +604,8 @@ class GuiTheme:
         # Finalise
         QApplication.setPalette(self._guiPalette)
         QToolTip.setPalette(self._guiPalette)  # Fixes an issue with desktop overrides on Linux, see #2871
-        self._buildStyleSheets(self._guiPalette)
 
         return True
-
-    def getStyleSheet(self, name: str) -> str:
-        """Load a standard style sheet."""
-        return self._styleSheets.get(name, "")
 
     def parseColor(self, value: str, default: QColor = QtBlack) -> QColor:
         """Parse a string as a colour value."""
@@ -781,28 +773,6 @@ class GuiTheme:
         """Set a palette colour value from a config string."""
         self._guiPalette.setBrush(value, self._readColor(section, name))
 
-    def _buildStyleSheets(self, palette: QPalette) -> None:
-        """Build default style sheets."""
-        self._styleSheets = {}
-
-        text = palette.text().color()
-        text.setAlpha(48)
-        tCol = text.name(QtHexArgb)
-
-        # Minimal Tool Button
-        self._styleSheets[STYLES_MIN_TOOLBUTTON] = (
-            "QToolButton {padding: 2px; margin: 0; border: none; background: transparent;} "
-            f"QToolButton:hover {{border: none; background: {tCol};}} "
-            "QToolButton::menu-indicator {image: none;} "
-        )
-
-        # Big Tool Button
-        self._styleSheets[STYLES_BIG_TOOLBUTTON] = (
-            "QToolButton {padding: 6px; margin: 0; border: none; background: transparent;} "
-            f"QToolButton:hover {{border: none; background: {tCol};}} "
-            "QToolButton::menu-indicator {image: none;} "
-        )
-
     def _scanThemes(self, files: list[Path]) -> None:
         """Scan the GUI themes folder and list all themes."""
         data: dict[str, tuple[str, str, bool, Path]] = {}
@@ -851,8 +821,8 @@ class GuiIcons:
     )
 
     TOGGLE_ICON_KEYS: Final[dict[str, tuple[str, str]]] = {
-        "bullet": ("bullet-on", "bullet-off"),
-        "unfold": ("unfold-show", "unfold-hide"),
+        "toggle-bullet": ("bullet-on", "bullet-off"),
+        "toggle-unfold": ("unfold-show", "unfold-hide"),
     }
     IMAGE_MAP: Final[dict[str, tuple[str, str]]] = {
         "welcome": ("welcome.webp", "welcome.webp"),
@@ -974,8 +944,8 @@ class GuiIcons:
             pix0 = self.getPixmap(f"{self.TOGGLE_ICON_KEYS[key][0]}:{color}", width, height)
             pix1 = self.getPixmap(f"{self.TOGGLE_ICON_KEYS[key][1]}:{color}", width, height)
             icon = QIcon()
-            icon.addPixmap(pix0, QIcon.Mode.Normal, QIcon.State.On)
-            icon.addPixmap(pix1, QIcon.Mode.Normal, QIcon.State.Off)
+            icon.addPixmap(pix0, QtIconNormal, QtIconOn)
+            icon.addPixmap(pix1, QtIconNormal, QtIconOff)
             return icon
         return self._noIcon
 
@@ -1021,7 +991,7 @@ class GuiIcons:
         """Return an icon from the icon buffer as a QPixmap. If it
         doesn't exist, return an empty QPixmap.
         """
-        return self.getIcon(name, width, height).pixmap(width, height, QIcon.Mode.Normal)
+        return self.getIcon(name, width, height).pixmap(width, height, QtIconNormal)
 
     def getStandardButton(self, button: nwStandardButton, parent: QWidget) -> NPushButton:
         """Return a standard button with icon and text."""

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -175,6 +175,8 @@ class GuiTheme:
         "_syntaxList",
         "accentCol",
         "accentText",
+        "activeBase",
+        "activeButton",
         "baseButtonHeight",
         "baseIconHeight",
         "baseIconSize",
@@ -210,7 +212,6 @@ class GuiTheme:
         "syntaxTheme",
         "textNHeight",
         "textNWidth",
-        "toggleCol",
         "toolButtonIconSize",
     )
 
@@ -227,7 +228,8 @@ class GuiTheme:
         self.errorText = QColor(255, 0, 0)
         self.accentText = QColor(0, 0, 255)
         self.accentCol = QColor(255, 0, 255)  # Needed until we move to Qt 6.6
-        self.toggleCol = QColor(0, 0, 255)
+        self.activeButton = QColor(0, 0, 255)
+        self.activeBase = QColor(225, 225, 225)
         self.searchCol = QColor(255, 196, 0, 96)
 
         # Theme Data
@@ -501,7 +503,8 @@ class GuiTheme:
             self.fadedText = self._readColor(section, "fadedText")
             self.errorText = self._readColor(section, "errorText")
             self.accentText = self._readColor(section, "accentText")
-            self.toggleCol = self._readColor(section, "toggle")
+            self.activeButton = self._readColor(section, "activeButton")
+            self.activeBase = self._readColor(section, "activeBase")
             self.searchCol = self._readColor(section, "searchMatch")
 
         # Syntax
@@ -690,6 +693,7 @@ class GuiTheme:
 
         # Reset GUI Palette
         base = palette.color(QPalette.ColorRole.Base)
+        altBase = palette.color(QPalette.ColorRole.AlternateBase)
         default = palette.color(QPalette.ColorRole.Text)
         faded = QColor(128, 128, 128)
         dimmed = QColor(130, 130, 130) if isDark else QColor(190, 190, 190)
@@ -709,7 +713,8 @@ class GuiTheme:
 
         # Accent Colours
         self.accentCol = purple
-        self.toggleCol = blue
+        self.activeButton = blue
+        self.activeBase = altBase
         self.searchCol = QColor(orange)
         self.searchCol.setAlpha(96)
 

--- a/novelwriter/gui/theme.py
+++ b/novelwriter/gui/theme.py
@@ -49,7 +49,7 @@ from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS, DEF_TREEC
 from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwStandardButton, nwTheme, nwToolButton
 from novelwriter.error import logException
-from novelwriter.extensions.modified import NIconToolButton, NPushButton
+from novelwriter.extensions.modified import NFlatIconButton, NIconButton, NPushButton
 from novelwriter.types import (
     QtBlack,
     QtColActive,
@@ -99,6 +99,7 @@ TOOL_BUTTONS = {
     nwToolButton.BROWSE: (QT_TRANSLATE_NOOP("Button", "Browse"), "browse:system"),
     nwToolButton.EDIT: (QT_TRANSLATE_NOOP("Button", "Edit"), "edit:change"),
     nwToolButton.REVERT: (QT_TRANSLATE_NOOP("Button", "Revert"), "revert:reset"),
+    nwToolButton.FONT: (QT_TRANSLATE_NOOP("Button", "Select Font"), "font:tool"),
 }
 
 
@@ -186,15 +187,16 @@ class GuiTheme:
         "fontPixelSizeLarge",
         "fontPointSize",
         "getDecoration",
+        "getFlatButton",
         "getHeaderDecoration",
         "getHeaderDecorationNarrow",
         "getIcon",
+        "getIconButton",
         "getItemIcon",
         "getItemIconStyle",
         "getPixmap",
         "getStandardButton",
         "getToggleIcon",
-        "getToolButton",
         "guiFont",
         "guiFontB",
         "guiFontBU",
@@ -247,7 +249,8 @@ class GuiTheme:
         self.getItemIcon = self.iconCache.getItemIcon
         self.getToggleIcon = self.iconCache.getToggleIcon
         self.getDecoration = self.iconCache.getDecoration
-        self.getToolButton = self.iconCache.getToolButton
+        self.getIconButton = self.iconCache.getIconButton
+        self.getFlatButton = self.iconCache.getFlatButton
         self.getItemIconStyle = self.iconCache.getItemIconStyle
         self.getStandardButton = self.iconCache.getStandardButton
         self.getHeaderDecoration = self.iconCache.getHeaderDecoration
@@ -1030,10 +1033,17 @@ class GuiIcons:
             icon,
         )
 
-    def getToolButton(self, button: nwToolButton, parent: QWidget) -> NIconToolButton:
+    def getIconButton(self, button: nwToolButton, parent: QWidget) -> NIconButton:
         """Return a tool button with icon."""
         toolTip, icon = TOOL_BUTTONS.get(button, ("", ""))
-        toolButton = NIconToolButton(parent, self._theme.baseIconSize, icon)
+        toolButton = NIconButton(parent, self._theme.baseIconSize, icon)
+        toolButton.setToolTip(QCoreApplication.translate("Button", toolTip))
+        return toolButton
+
+    def getFlatButton(self, button: nwToolButton, parent: QWidget) -> NFlatIconButton:
+        """Return a tool button with icon."""
+        toolTip, icon = TOOL_BUTTONS.get(button, ("", ""))
+        toolButton = NFlatIconButton(parent, self._theme.baseIconSize, icon)
         toolButton.setToolTip(QCoreApplication.translate("Button", toolTip))
         return toolButton
 

--- a/novelwriter/manuscript/manusbuild.py
+++ b/novelwriter/manuscript/manusbuild.py
@@ -51,7 +51,7 @@ from novelwriter.constants import nwLabels
 from novelwriter.core.item import ProjectItem
 from novelwriter.enum import nwBuildFmt, nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel
-from novelwriter.extensions.modified import NDialog, NIconToolButton, NPushButton
+from novelwriter.extensions.modified import NDialog, NPushButton
 from novelwriter.extensions.progressbars import NProgressSimple
 from novelwriter.manuscript.docbuild import DocumentBuilder
 from novelwriter.types import QtAlignCenter, QtRoleAction, QtRoleDestruct, QtUserRole
@@ -152,7 +152,7 @@ class GuiManuscriptBuild(NDialog):
         # Build Path
         self.lblPath = QLabel(self.tr("Path"), self)
         self.buildPath = QLineEdit(self)
-        self.btnBrowse = SHARED.theme.getToolButton(nwToolButton.BROWSE, self)
+        self.btnBrowse = SHARED.theme.getIconButton(nwToolButton.BROWSE, self)
 
         self.pathBox = QHBoxLayout()
         self.pathBox.addWidget(self.buildPath)
@@ -162,7 +162,7 @@ class GuiManuscriptBuild(NDialog):
         # Build Name
         self.lblName = QLabel(self.tr("File Name"), self)
         self.buildName = QLineEdit(self)
-        self.btnReset = NIconToolButton(self, iSz, "revert:reset")
+        self.btnReset = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnReset.setToolTip(self.tr("Reset file name to default"))
 
         self.nameBox = QHBoxLayout()

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -65,7 +65,6 @@ from novelwriter.extensions.progressbars import NProgressCircle
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.formats.tokenizer import HeadingFormatter
 from novelwriter.formats.toqdoc import ToQTextDocument
-from novelwriter.gui.theme import STYLES_MIN_TOOLBUTTON
 from novelwriter.manuscript.buildsettings import BuildCollection, BuildSettings
 from novelwriter.manuscript.docbuild import DocumentBuilder
 from novelwriter.manuscript.manusbuild import GuiManuscriptBuild
@@ -296,12 +295,6 @@ class GuiManuscript(NToolDialog):
             self.btnPrint.refreshTheme()
             self.btnBuild.refreshTheme()
             self.btnClose.refreshTheme()
-
-        buttonStyle = SHARED.theme.getStyleSheet(STYLES_MIN_TOOLBUTTON)
-        self.tbAdd.setStyleSheet(buttonStyle)
-        self.tbDel.setStyleSheet(buttonStyle)
-        self.tbCopy.setStyleSheet(buttonStyle)
-        self.tbEdit.setStyleSheet(buttonStyle)
 
         self.detailsTabs.refreshTheme()
 

--- a/novelwriter/manuscript/manuscript.py
+++ b/novelwriter/manuscript/manuscript.py
@@ -60,7 +60,7 @@ from novelwriter import CONFIG, SHARED
 from novelwriter.common import formatInt, formatPercent, fuzzyTime
 from novelwriter.constants import nwHeadFmt, nwLabels, nwStats, nwUnicode, trStats
 from novelwriter.enum import nwStandardButton
-from novelwriter.extensions.modified import NIconToolButton, NTabWidget, NToolDialog
+from novelwriter.extensions.modified import NFlatIconButton, NTabWidget, NToolDialog
 from novelwriter.extensions.progressbars import NProgressCircle
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.formats.tokenizer import HeadingFormatter
@@ -120,19 +120,19 @@ class GuiManuscript(NToolDialog):
         # Build Controls
         # ==============
 
-        self.tbAdd = NIconToolButton(self, iSz, "add:add")
+        self.tbAdd = NFlatIconButton(self, iSz, "add:add")
         self.tbAdd.setToolTip(self.tr("Add New Build"))
         self.tbAdd.clicked.connect(self._createNewBuild)
 
-        self.tbDel = NIconToolButton(self, iSz, "remove:remove")
+        self.tbDel = NFlatIconButton(self, iSz, "remove:remove")
         self.tbDel.setToolTip(self.tr("Delete Selected Build"))
         self.tbDel.clicked.connect(self._deleteSelectedBuild)
 
-        self.tbCopy = NIconToolButton(self, iSz, "copy:action")
+        self.tbCopy = NFlatIconButton(self, iSz, "copy:action")
         self.tbCopy.setToolTip(self.tr("Duplicate Selected Build"))
         self.tbCopy.clicked.connect(self._copySelectedBuild)
 
-        self.tbEdit = NIconToolButton(self, iSz, "edit:change")
+        self.tbEdit = NFlatIconButton(self, iSz, "edit:change")
         self.tbEdit.setToolTip(self.tr("Edit Selected Build"))
         self.tbEdit.clicked.connect(self._editSelectedBuild)
 

--- a/novelwriter/manuscript/manussettings.py
+++ b/novelwriter/manuscript/manussettings.py
@@ -52,7 +52,7 @@ from novelwriter.common import describeFont, fontMatcher, languageName, processL
 from novelwriter.constants import nwHeadFmt, nwKeyWords, nwLabels, nwStyles, nwUnicode, trConst
 from novelwriter.enum import nwStandardButton, nwToolButton
 from novelwriter.extensions.configlayout import NColorLabel, NFixedPage, NScrollableForm, NScrollablePage
-from novelwriter.extensions.modified import NComboBox, NDoubleSpinBox, NIconToolButton, NSpinBox, NToolDialog
+from novelwriter.extensions.modified import NComboBox, NDoubleSpinBox, NIconButton, NSpinBox, NToolDialog
 from novelwriter.extensions.pagedsidebar import NPagedSideBar
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.extensions.switchbox import NSwitchBox
@@ -377,15 +377,15 @@ class _FilterTab(NFixedPage):
         # Filters
         # =======
 
-        self.includedButton = NIconToolButton(self, iSz)
+        self.includedButton = NIconButton(self, iSz)
         self.includedButton.setToolTip(self.tr("Always included"))
         self.includedButton.clicked.connect(qtLambda(self._setSelectedMode, self.F_INCLUDED))
 
-        self.excludedButton = NIconToolButton(self, iSz)
+        self.excludedButton = NIconButton(self, iSz)
         self.excludedButton.setToolTip(self.tr("Always excluded"))
         self.excludedButton.clicked.connect(qtLambda(self._setSelectedMode, self.F_EXCLUDED))
 
-        self.resetButton = NIconToolButton(self, iSz)
+        self.resetButton = NIconButton(self, iSz)
         self.resetButton.setToolTip(self.tr("Reset to default"))
         self.resetButton.clicked.connect(qtLambda(self._setSelectedMode, self.F_FILTERED))
 
@@ -625,7 +625,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblPart = QLabel(self._build.getLabel("headings.fmtPart"), self)
         self.fmtPart = QLineEdit("", self)
         self.fmtPart.setReadOnly(True)
-        self.btnPart = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
+        self.btnPart = SHARED.theme.getIconButton(nwToolButton.EDIT, self)
         self.btnPart.clicked.connect(qtLambda(self._editHeading, self.EDIT_TITLE))
         self.swtPart = NSwitch(self, height=iPx)
         self.hdePart = QLabel(trHide, self)
@@ -642,7 +642,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblChapter = QLabel(self._build.getLabel("headings.fmtChapter"), self)
         self.fmtChapter = QLineEdit("", self)
         self.fmtChapter.setReadOnly(True)
-        self.btnChapter = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
+        self.btnChapter = SHARED.theme.getIconButton(nwToolButton.EDIT, self)
         self.btnChapter.clicked.connect(qtLambda(self._editHeading, self.EDIT_CHAPTER))
         self.swtChapter = NSwitch(self, height=iPx)
         self.hdeChapter = QLabel(trHide, self)
@@ -659,7 +659,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblUnnumbered = QLabel(self._build.getLabel("headings.fmtUnnumbered"), self)
         self.fmtUnnumbered = QLineEdit("", self)
         self.fmtUnnumbered.setReadOnly(True)
-        self.btnUnnumbered = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
+        self.btnUnnumbered = SHARED.theme.getIconButton(nwToolButton.EDIT, self)
         self.btnUnnumbered.clicked.connect(qtLambda(self._editHeading, self.EDIT_UNNUM))
         self.swtUnnumbered = NSwitch(self, height=iPx)
         self.hdeUnnumbered = QLabel(trHide, self)
@@ -676,7 +676,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblScene = QLabel(self._build.getLabel("headings.fmtScene"), self)
         self.fmtScene = QLineEdit("", self)
         self.fmtScene.setReadOnly(True)
-        self.btnScene = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
+        self.btnScene = SHARED.theme.getIconButton(nwToolButton.EDIT, self)
         self.btnScene.clicked.connect(qtLambda(self._editHeading, self.EDIT_SCENE))
         self.swtScene = NSwitch(self, height=iPx)
         self.hdeScene = QLabel(trHide, self)
@@ -693,7 +693,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblAScene = QLabel(self._build.getLabel("headings.fmtAltScene"), self)
         self.fmtAScene = QLineEdit("", self)
         self.fmtAScene.setReadOnly(True)
-        self.btnAScene = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
+        self.btnAScene = SHARED.theme.getIconButton(nwToolButton.EDIT, self)
         self.btnAScene.clicked.connect(qtLambda(self._editHeading, self.EDIT_HSCENE))
         self.swtAScene = NSwitch(self, height=iPx)
         self.hdeAScene = QLabel(trHide, self)
@@ -710,7 +710,7 @@ class _HeadingsTab(NScrollablePage):
         self.lblSection = QLabel(self._build.getLabel("headings.fmtSection"), self)
         self.fmtSection = QLineEdit("", self)
         self.fmtSection.setReadOnly(True)
-        self.btnSection = SHARED.theme.getToolButton(nwToolButton.EDIT, self)
+        self.btnSection = SHARED.theme.getIconButton(nwToolButton.EDIT, self)
         self.btnSection.clicked.connect(qtLambda(self._editHeading, self.EDIT_SECTION))
         self.swtSection = NSwitch(self, height=iPx)
         self.hdeSection = QLabel(trHide, self)
@@ -1086,7 +1086,7 @@ class _FormattingTab(NScrollableForm):
         for keyword in nwKeyWords.VALID_KEYS:
             qtAddAction(self.mnKeywords, trConst(nwLabels.KEY_NAME[keyword]), data=keyword)
 
-        self.ignoredKeywordsButton = NIconToolButton(self, iSz, "add:add")
+        self.ignoredKeywordsButton = NIconButton(self, iSz, "add:add")
         self.ignoredKeywordsButton.setToolTip(self.tr("Select Keyword"))
         self.ignoredKeywordsButton.setMenu(self.mnKeywords)
         self.addRow(
@@ -1111,8 +1111,7 @@ class _FormattingTab(NScrollableForm):
         # Text Font
         self.textFont = QLineEdit(self)
         self.textFont.setReadOnly(True)
-        self.btnTextFont = NIconToolButton(self, iSz, "font:tool")
-        self.btnTextFont.setToolTip(self.tr("Select Font"))
+        self.btnTextFont = SHARED.theme.getIconButton(nwToolButton.FONT, self)
         self.btnTextFont.clicked.connect(self._selectFont)
         self.addRow(
             self._build.getLabel("format.textFont"),
@@ -1190,7 +1189,7 @@ class _FormattingTab(NScrollableForm):
         self.titleMarginT.setFixedNumbersWidth(4)
         self.titleMarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
         self.titleMarginB.setFixedNumbersWidth(4)
-        self.btnTitleProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnTitleProps = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnTitleProps.clicked.connect(self._resetTitleProps)
 
         self.pixH0S = QLabel(self)
@@ -1219,7 +1218,7 @@ class _FormattingTab(NScrollableForm):
         self.h1MarginT.setFixedNumbersWidth(4)
         self.h1MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
         self.h1MarginB.setFixedNumbersWidth(4)
-        self.btnH1Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnH1Props = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnH1Props.clicked.connect(self._resetH1Props)
 
         self.pixH1S = QLabel(self)
@@ -1248,7 +1247,7 @@ class _FormattingTab(NScrollableForm):
         self.h2MarginT.setFixedNumbersWidth(4)
         self.h2MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
         self.h2MarginB.setFixedNumbersWidth(4)
-        self.btnH2Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnH2Props = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnH2Props.clicked.connect(self._resetH2Props)
 
         self.pixH2S = QLabel(self)
@@ -1277,7 +1276,7 @@ class _FormattingTab(NScrollableForm):
         self.h3MarginT.setFixedNumbersWidth(4)
         self.h3MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
         self.h3MarginB.setFixedNumbersWidth(4)
-        self.btnH3Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnH3Props = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnH3Props.clicked.connect(self._resetH3Props)
 
         self.pixH3S = QLabel(self)
@@ -1306,7 +1305,7 @@ class _FormattingTab(NScrollableForm):
         self.h4MarginT.setFixedNumbersWidth(4)
         self.h4MarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
         self.h4MarginB.setFixedNumbersWidth(4)
-        self.btnH4Props = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnH4Props = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnH4Props.clicked.connect(self._resetH4Props)
 
         self.pixH4S = QLabel(self)
@@ -1333,7 +1332,7 @@ class _FormattingTab(NScrollableForm):
         self.textMarginT.setFixedNumbersWidth(4)
         self.textMarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
         self.textMarginB.setFixedNumbersWidth(4)
-        self.btnTextProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnTextProps = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnTextProps.clicked.connect(self._resetTextProps)
 
         self.pixTTT = QLabel(self)
@@ -1350,7 +1349,7 @@ class _FormattingTab(NScrollableForm):
         self.sepMarginT.setFixedNumbersWidth(4)
         self.sepMarginB = NDoubleSpinBox(self, minVal=0.0, maxVal=10.0, step=0.1)
         self.sepMarginB.setFixedNumbersWidth(4)
-        self.btnSepProps = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnSepProps = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnSepProps.clicked.connect(self._resetSepProps)
 
         self.pixSPT = QLabel(self)
@@ -1442,7 +1441,7 @@ class _FormattingTab(NScrollableForm):
         # Header
         self.pageHeader = QLineEdit(self)
         self.pageHeader.setMinimumWidth(200)
-        self.btnPageHeader = SHARED.theme.getToolButton(nwToolButton.REVERT, self)
+        self.btnPageHeader = SHARED.theme.getIconButton(nwToolButton.REVERT, self)
         self.btnPageHeader.clicked.connect(self._resetPageHeader)
         self.addRow(
             self._build.getLabel("doc.pageHeader"),

--- a/novelwriter/tools/dictionaries.py
+++ b/novelwriter/tools/dictionaries.py
@@ -93,7 +93,7 @@ class GuiDictionaries(NNonBlockingDialog):
         self.huInfo.setOpenExternalLinks(True)
         self.huInfo.setWordWrap(True)
         self.huInput = QLineEdit(self)
-        self.huBrowse = SHARED.theme.getToolButton(nwToolButton.BROWSE, self)
+        self.huBrowse = SHARED.theme.getIconButton(nwToolButton.BROWSE, self)
         self.huBrowse.clicked.connect(self._doBrowseHunspell)
         self.huImport = QPushButton(self.tr("Add Dictionary"), self)
         self.huImport.setIcon(SHARED.theme.getIcon("add:add"))
@@ -111,7 +111,7 @@ class GuiDictionaries(NNonBlockingDialog):
         self.inInfo = QLabel(self.tr("Dictionary install location"), self)
         self.inPath = QLineEdit(self)
         self.inPath.setReadOnly(True)
-        self.inBrowse = SHARED.theme.getToolButton(nwToolButton.BROWSE, self)
+        self.inBrowse = SHARED.theme.getIconButton(nwToolButton.BROWSE, self)
         self.inBrowse.clicked.connect(self._doOpenInstallLocation)
 
         self.inBox = QHBoxLayout()

--- a/novelwriter/tools/welcome.py
+++ b/novelwriter/tools/welcome.py
@@ -52,7 +52,7 @@ from novelwriter.constants import nwFiles
 from novelwriter.core.coretools import ProjectBuilder
 from novelwriter.enum import nwItemClass, nwStandardButton
 from novelwriter.extensions.configlayout import NColorLabel, NWrappedWidgetBox
-from novelwriter.extensions.modified import NDialog, NIconToolButton, NSpinBox
+from novelwriter.extensions.modified import NDialog, NIconButton, NSpinBox
 from novelwriter.extensions.switch import NSwitch
 from novelwriter.extensions.versioninfo import VersionInfoWidget
 from novelwriter.types import (
@@ -630,7 +630,7 @@ class _NewProjectForm(QWidget):
         self.projPath = QLineEdit(self)
         self.projPath.setReadOnly(True)
 
-        self.browsePath = NIconToolButton(self, iSz, "browse:system")
+        self.browsePath = NIconButton(self, iSz, "browse:system")
         self.browsePath.setToolTip(self.tr("Browse for new project path"))
         self.browsePath.clicked.connect(self._doBrowse)
 
@@ -645,7 +645,7 @@ class _NewProjectForm(QWidget):
         self.projFill = QLineEdit(self)
         self.projFill.setReadOnly(True)
 
-        self.browseFill = NIconToolButton(self, iSz, "document_add:add")
+        self.browseFill = NIconButton(self, iSz, "document_add:add")
         self.browseFill.setToolTip(self.tr("Fill new project"))
 
         self.fillMenu = QMenu(self.browseFill)

--- a/novelwriter/types.py
+++ b/novelwriter/types.py
@@ -24,7 +24,17 @@ from __future__ import annotations
 from typing import Literal
 
 from PyQt6.QtCore import QAbstractAnimation, Qt
-from PyQt6.QtGui import QColor, QFont, QKeySequence, QPainter, QPalette, QTextCharFormat, QTextCursor, QTextFormat
+from PyQt6.QtGui import (
+    QColor,
+    QFont,
+    QIcon,
+    QKeySequence,
+    QPainter,
+    QPalette,
+    QTextCharFormat,
+    QTextCursor,
+    QTextFormat,
+)
 from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QHeaderView, QSizePolicy, QStyle
 
 # Custom Types
@@ -89,6 +99,11 @@ QtHexArgb = QColor.NameFormat.HexArgb
 QtColActive = QPalette.ColorGroup.Active
 QtColInactive = QPalette.ColorGroup.Inactive
 QtColDisabled = QPalette.ColorGroup.Disabled
+
+# Styles
+
+QtToolButtonTextIcon = Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+QtToolButtonIconOnly = Qt.ToolButtonStyle.ToolButtonIconOnly
 
 # Model Item Data
 
@@ -185,6 +200,13 @@ QtHeaderFixed = QHeaderView.ResizeMode.Fixed
 QtScrollAlwaysOn = Qt.ScrollBarPolicy.ScrollBarAlwaysOn
 QtScrollAlwaysOff = Qt.ScrollBarPolicy.ScrollBarAlwaysOff
 QtScrollAsNeeded = Qt.ScrollBarPolicy.ScrollBarAsNeeded
+
+# Icon Modes
+
+QtIconNormal = QIcon.Mode.Normal
+QtIconDisabled = QIcon.Mode.Disabled
+QtIconOn = QIcon.State.On
+QtIconOff = QIcon.State.Off
 
 # Font Weight
 

--- a/tests/extensions/test_modified.py
+++ b/tests/extensions/test_modified.py
@@ -35,8 +35,8 @@ from novelwriter.extensions.modified import (
     NDialog,
     NDoubleSpinBox,
     NFlatIconButton,
+    NFlatIconTextButton,
     NFontDialog,
-    NIconToggleButton,
     NNonBlockingDialog,
     NSpinBox,
     NSplitterHandle,
@@ -268,13 +268,13 @@ def testNClickableLabel_Main(qtbot):
 
 
 @pytest.mark.gui
-def testNToolButtons_Main(qtbot, mockGUI):
-    """Test the NFlatIconButton and NIconToggleButton classes."""
+def testNFlatButtons_Main(qtbot, mockGUI):
+    """Test the NFlatIconButton and NFlatIconTextButton classes."""
     dialog = SimpleDialog(None)
 
     size = QSize(16, 16)
     button1 = NFlatIconButton(dialog, size, "add:add")
-    button2 = NIconToggleButton(dialog, size, "bullet:action")
+    button2 = NFlatIconTextButton(dialog, size, "bullet:action", "Text")
 
     assert button1.iconSize() == size
     assert button2.iconSize() == size

--- a/tests/extensions/test_modified.py
+++ b/tests/extensions/test_modified.py
@@ -34,9 +34,9 @@ from novelwriter.extensions.modified import (
     NComboBox,
     NDialog,
     NDoubleSpinBox,
+    NFlatIconButton,
     NFontDialog,
     NIconToggleButton,
-    NIconToolButton,
     NNonBlockingDialog,
     NSpinBox,
     NSplitterHandle,
@@ -269,11 +269,11 @@ def testNClickableLabel_Main(qtbot):
 
 @pytest.mark.gui
 def testNToolButtons_Main(qtbot, mockGUI):
-    """Test the NIconToolButton and NIconToggleButton classes."""
+    """Test the NFlatIconButton and NIconToggleButton classes."""
     dialog = SimpleDialog(None)
 
     size = QSize(16, 16)
-    button1 = NIconToolButton(dialog, size, "add:add")
+    button1 = NFlatIconButton(dialog, size, "add:add")
     button2 = NIconToggleButton(dialog, size, "bullet:action")
 
     assert button1.iconSize() == size

--- a/tests/gui/test_theme.py
+++ b/tests/gui/test_theme.py
@@ -37,12 +37,12 @@ from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS
 from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwTheme
 from novelwriter.gui.theme import (
-    STYLES_MIN_TOOLBUTTON,
     GuiTheme,
     ThemeEntry,
     ThemeMeta,
     _listContent,
 )
+from novelwriter.types import QtIconNormal, QtIconOff, QtIconOn
 
 from tests.mocked import causeOSError
 
@@ -448,10 +448,6 @@ def testGuiTheme_Methods(monkeypatch):
         mp.setattr(QPalette, "windowText", lambda *a: mockWhite)
         assert theme.isDesktopDarkMode() is True
 
-    # Stylesheets
-    assert theme.getStyleSheet(STYLES_MIN_TOOLBUTTON) != ""
-    assert theme.getStyleSheet("stuff") == ""
-
 
 @pytest.mark.gui
 def testGuiTheme_ScanIcons(monkeypatch, tstPaths):
@@ -582,11 +578,11 @@ def testGuiTheme_LoadIcons():
     assert qIcon != iconCache._noIcon
 
     # Toggle icon
-    qIcon = iconCache.getToggleIcon("bullet:tool", 24, 24)
+    qIcon = iconCache.getToggleIcon("toggle-bullet:tool", 24, 24)
     assert isinstance(qIcon, QIcon)
     assert qIcon != iconCache._noIcon
-    pOn = qIcon.pixmap(24, 24, QIcon.Mode.Normal, QIcon.State.On)
-    pOff = qIcon.pixmap(24, 24, QIcon.Mode.Normal, QIcon.State.Off)
+    pOn = qIcon.pixmap(24, 24, QtIconNormal, QtIconOn)
+    pOff = qIcon.pixmap(24, 24, QtIconNormal, QtIconOff)
     assert pOn != pOff
 
     # Unknown toggle icon

--- a/tests/gui/test_theme.py
+++ b/tests/gui/test_theme.py
@@ -37,7 +37,6 @@ from novelwriter.config import DEF_GUI_DARK, DEF_GUI_LIGHT, DEF_ICONS
 from novelwriter.constants import nwLabels
 from novelwriter.enum import nwItemClass, nwItemLayout, nwItemType, nwTheme
 from novelwriter.gui.theme import (
-    STYLES_BIG_TOOLBUTTON,
     STYLES_MIN_TOOLBUTTON,
     GuiTheme,
     ThemeEntry,
@@ -451,7 +450,6 @@ def testGuiTheme_Methods(monkeypatch):
 
     # Stylesheets
     assert theme.getStyleSheet(STYLES_MIN_TOOLBUTTON) != ""
-    assert theme.getStyleSheet(STYLES_BIG_TOOLBUTTON) != ""
     assert theme.getStyleSheet("stuff") == ""
 
 

--- a/tests/gui/test_theme.py
+++ b/tests/gui/test_theme.py
@@ -827,7 +827,8 @@ def testGuiTheme_CheckTheme(theme):
             "fadedText",
             "errorText",
             "accentText",
-            "toggle",
+            "activeButton",
+            "activeBase",
             "searchMatch",
         ],
         "Syntax": [


### PR DESCRIPTION
**Summary:**

This PR adds a new theme colour `activeBase` and renames `toggle` to `activeButton`. The flat icon buttons and toggle buttons have also been redesigned, as well as the icon button that imitates a push button without text.

**Related Issue(s):**

Closes #2910

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
