### PR TITLE
Fix project search reentrancy

### DIFF
--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -1393,7 +1393,7 @@ class GuiDocEditor(QTextEdit):
     def inputMethodEvent(self, event: QInputMethodEvent) -> None:
         """Handle text being input from CJK input methods."""
         super().inputMethodEvent(event)
-        if event.commitString():
+        if event.commitString():  # pragma: no branch
             # See issues #2267 and #2517
             self.ensureCursorVisible(centre=False)
             # cursorRect() is still stale immediately after the commit,

--- a/novelwriter/gui/search.py
+++ b/novelwriter/gui/search.py
@@ -342,35 +342,36 @@ class GuiProjectSearch(QWidget):
 
     @pyqtSlot()
     def _processSearch(self) -> None:
-        """Perform a search."""
+        """Perform a search. This function is re-entrant. See #2924."""
         if not self._blocked:
-            QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
-            start = time()
-            SHARED.saveEditor()
-            searchText = self.searchText.text()
-
             self._blocked = True
-            self._model.clear()
-            self._activeSearch = bool(searchText)
-            if searchText:
-                self._search.setUserRegEx(self.tbRegEx.isChecked())
-                self._search.setCaseSensitive(self.tbCase.isChecked())
-                self._search.setWholeWords(self.tbWord.isChecked())
-                handles = []
-                for item, results, capped in self._search.iterSearch(SHARED.project, searchText):
-                    if results:
-                        self._model.setResult(item, results, capped)
-                        handles.append(item.itemHandle)
-                # Expanding a row forces the tree view to lay out all
-                # currently loaded rows, so this is deferred until after
-                # all results are in the model to avoid doing it once
-                # per document as the tree grows
-                for handle in handles:
-                    self._expandResult(handle)
-            logger.debug("Search took %.3f ms", 1000 * (time() - start))
-            QApplication.restoreOverrideCursor()
+            try:
+                QApplication.setOverrideCursor(QCursor(Qt.CursorShape.WaitCursor))
+                start = time()
+                SHARED.saveEditor()
+                searchText = self.searchText.text()
 
-        self._blocked = False
+                self._model.clear()
+                self._activeSearch = bool(searchText)
+                if searchText:
+                    self._search.setUserRegEx(self.tbRegEx.isChecked())
+                    self._search.setCaseSensitive(self.tbCase.isChecked())
+                    self._search.setWholeWords(self.tbWord.isChecked())
+                    handles = []
+                    for item, results, capped in self._search.iterSearch(SHARED.project, searchText):
+                        if results:
+                            self._model.setResult(item, results, capped)
+                            handles.append(item.itemHandle)
+
+                    # Run separately to avoid re-layout
+                    for handle in handles:
+                        self._expandResult(handle)
+
+                logger.debug("Search took %.3f ms", 1000 * (time() - start))
+                QApplication.restoreOverrideCursor()
+
+            finally:
+                self._blocked = False
 
     @pyqtSlot(QModelIndex, QModelIndex)
     def _searchResultSelected(self, current: QModelIndex, previous: QModelIndex) -> None:

--- a/tests/gui/test_search.py
+++ b/tests/gui/test_search.py
@@ -404,12 +404,9 @@ def testGuiProjectSearch_ReentrancyGuard(nwGUI, fncPath, mockRnd, ipsumText, mon
     def nestedIterSearch(self, project, searchText):
         for i, result in enumerate(realIterSearch(self, project, searchText)):
             if i == 0:
-                # Simulate a nested invocation entering mid-iteration, as
-                # would happen through the incMainProgress() pump.
+                # Simulate a nested invocation entering mid-iteration
                 search._processSearch()
-                # The nested call must see the guard held and skip its
-                # body, but must not clear it out from under the outer,
-                # still-running call.
+                # The nested call must see the guard held and skip its body
                 assert search._blocked is True
             yield result
 
@@ -419,8 +416,7 @@ def testGuiProjectSearch_ReentrancyGuard(nwGUI, fncPath, mockRnd, ipsumText, mon
 
     # The guard is released once the outer call actually finishes
     assert search._blocked is False
-    # The model reflects the completed outer search, undisturbed by the
-    # nested no-op call
+    # The model reflects the completed outer search, undisturbed by the nested no-op call
     assert model.rowCount(root) == 2
 
 

--- a/tests/gui/test_search.py
+++ b/tests/gui/test_search.py
@@ -34,6 +34,7 @@ from PyQt6.QtWidgets import QStyleOptionViewItem
 from novelwriter import CONFIG, SHARED
 from novelwriter.constants import nwItemClass, nwUnicode
 from novelwriter.core.project import NWProject
+from novelwriter.core.projectsearch import DocSearch
 from novelwriter.enum import nwChange, nwDocMode, nwView
 from novelwriter.types import QtDisplayRole, QtKeyDown, QtKeyReturn, QtKeyUp
 
@@ -379,6 +380,48 @@ def testGuiProjectSearch_EdgeCases(nwGUI, fncPath, mockRnd, ipsumText):
 
     search.closeProjectTasks()
     assert model.rowCount(root) == 0
+
+
+@pytest.mark.gui
+def testGuiProjectSearch_ReentrancyGuard(nwGUI, fncPath, mockRnd, ipsumText, monkeypatch):
+    """Regression test for the processSearch re-entrancy guard."""
+    mockRnd.reset()
+    buildTestProject(NWProject(), fncPath)
+    nwGUI.openProject(fncPath)
+    project = SHARED.project
+    project.storage.getDocument(C.hChapterDoc).writeDocument("## New Chapter\n\n" + ipsumText[0])
+    project.storage.getDocument(C.hSceneDoc).writeDocument("### New Scene\n\n" + ipsumText[1])
+
+    nwGUI._changeView(nwView.SEARCH)
+    search = nwGUI.projSearch
+    model = search._model
+    root = QModelIndex()
+
+    search.beginSearch("Lorem")
+
+    realIterSearch = DocSearch.iterSearch
+
+    def nestedIterSearch(self, project, searchText):
+        for i, result in enumerate(realIterSearch(self, project, searchText)):
+            if i == 0:
+                # Simulate a nested invocation entering mid-iteration, as
+                # would happen through the incMainProgress() pump.
+                search._processSearch()
+                # The nested call must see the guard held and skip its
+                # body, but must not clear it out from under the outer,
+                # still-running call.
+                assert search._blocked is True
+            yield result
+
+    monkeypatch.setattr(DocSearch, "iterSearch", nestedIterSearch)
+
+    search._processSearch()
+
+    # The guard is released once the outer call actually finishes
+    assert search._blocked is False
+    # The model reflects the completed outer search, undisturbed by the
+    # nested no-op call
+    assert model.rowCount(root) == 2
 
 
 @pytest.mark.gui


### PR DESCRIPTION
**Summary:**

Fix a re-entrancy bug in project search by adding a simple busy flag and if-check.

**Related Issue(s):**

Closes #2924

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
