### PR TITLE
Fix document block search

### DIFF
--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -177,7 +177,7 @@ class GuiDocEditor(QTextEdit):
         "_checkDispatcher",
         "_checkJob",
         "_checkJobId",
-        "_checkPassNo",
+        "_checkPassPos",
         "_completer",
         "_dirtyBlocks",
         "_doReplace",
@@ -298,7 +298,7 @@ class GuiDocEditor(QTextEdit):
         self._selCacheFormat: T_SelCache = {}
         self._dirtyBlocks: dict[int, QTextBlock] = {}
         self._suppressed = False
-        self._checkPassNo = -1
+        self._checkPassPos: int | None = None
         self._spellPassNotify = False
         self._checkJob: T_TextCheckJob | None = None
         self._checkJobId = 0
@@ -505,7 +505,7 @@ class GuiDocEditor(QTextEdit):
         self._timerHover.stop()
         self._hoverCard.hide()
         self._hoverCard.clearCache()
-        self._checkPassNo = -1
+        self._checkPassPos = None
         self._spellPassNotify = False
         self._checkJob = None
         self._dirtyBlocks.clear()
@@ -1716,12 +1716,11 @@ class GuiDocEditor(QTextEdit):
     def _dispatchTextCheck(self) -> None:
         """Send the next batch of text blocks to the text check worker.
         Modified blocks are prioritised, then the blocks queued for the
-        background document pass. The pass position is tracked by block
-        number, which may drift when the document is edited during the
-        pass, but modified blocks are covered by the debounce anyway.
+        background document pass, resolved by character position since
+        the document can be edited between dispatches.
         """
         if self._checkJob is not None:
-            # There is already a job running, and a new dispatch is made when its results come in
+            # There is already a job running
             return
 
         job: list[T_TextCheckBlock] = []
@@ -1732,15 +1731,16 @@ class GuiDocEditor(QTextEdit):
                 payload.append((len(job), *data.checkData()))
                 job.append((block, data, data.revision))
 
-        while self._checkPassNo >= 0 and len(job) < nwConst.CHECK_PASS_CHUNK:
-            block = self._qDocument.findBlockByNumber(self._checkPassNo)
-            if block.isValid():
+        if self._checkPassPos is not None:
+            block = self._qDocument.findBlock(self._checkPassPos)
+            while block.isValid() and len(job) < nwConst.CHECK_PASS_CHUNK:
                 if isinstance(data := block.userData(), TextBlockData):
                     payload.append((len(job), *data.checkData()))
                     job.append((block, data, data.revision))
-                self._checkPassNo += 1
-            else:
-                self._checkPassNo = -1
+                block = block.next()
+            self._checkPassPos = block.position() if block.isValid() else None
+            if self._checkPassPos is None:
+                logger.debug("Text check background pass complete")
 
         if job:
             self._checkJobId += 1
@@ -2977,7 +2977,7 @@ class GuiDocEditor(QTextEdit):
         self._timerTextCheck.stop()
         self._dirtyBlocks.clear()
         self._checkJob = None
-        self._checkPassNo = -1
+        self._checkPassPos = None
         if checkSpell or checkFormat:
             if viewport := self.viewport():  # pragma: no branch
                 # Check the visible blocks first so that their result
@@ -2991,7 +2991,8 @@ class GuiDocEditor(QTextEdit):
                         if checkFormat:
                             data.formatCheck()
                     block = block.next()
-            self._checkPassNo = 0
+            self._checkPassPos = 0
+            logger.debug("Text check starting background pass over %d blocks", self._qDocument.blockCount())
             self._dispatchTextCheck()
         self._updateCheckSelections()
 

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -2529,11 +2529,14 @@ class GuiDocEditor(QTextEdit):
 
     def _selectedBlocks(self, cursor: QTextCursor) -> list[QTextBlock]:
         """Return a list of all blocks selected by a cursor."""
+        blocks: list[QTextBlock] = []
         if cursor.hasSelection():
-            iS = self._qDocument.findBlock(cursor.selectionStart()).blockNumber()
-            iE = self._qDocument.findBlock(cursor.selectionEnd()).blockNumber()
-            return [self._qDocument.findBlockByNumber(i) for i in range(iS, iE + 1)]
-        return []
+            block = self._qDocument.findBlock(cursor.selectionStart())
+            lastNum = self._qDocument.findBlock(cursor.selectionEnd()).blockNumber()
+            while block.isValid() and block.blockNumber() <= lastNum:
+                blocks.append(block)
+                block = block.next()
+        return blocks
 
     def _removeInParLineBreaks(self) -> None:
         """Strip line breaks within paragraphs in the selected text."""

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -192,6 +192,7 @@ class GuiDocEditor(QTextEdit):
         "_hoverPos",
         "_keyContext",
         "_lastActive",
+        "_lastDocTask",
         "_lastEdit",
         "_lastFind",
         "_lineColor",
@@ -278,6 +279,7 @@ class GuiDocEditor(QTextEdit):
         # Document Variables
         self._lastEdit = 0.0  # Timestamp of last edit
         self._lastActive = 0.0  # Timestamp of last activity
+        self._lastDocTask = -1.0  # Timestamp of last edit processed by _runDocumentTasks
         self._lastFind = None  # Position of the last found search word
         self._doReplace = False  # Switch to temporarily disable auto-replace
         self._lineColor = QtTransparent
@@ -489,6 +491,7 @@ class GuiDocEditor(QTextEdit):
         self._docHandle = None
         self._lastEdit = 0.0
         self._lastActive = 0.0
+        self._lastDocTask = -1.0
         self._lastFind = None
         self._doReplace = False
 
@@ -1877,8 +1880,9 @@ class GuiDocEditor(QTextEdit):
     @pyqtSlot()
     def _runDocumentTasks(self) -> None:
         """Run timer document tasks."""
-        if self._docHandle:
+        if self._docHandle and self._lastEdit > self._lastDocTask:
             logger.debug("Running document tasks")
+            self._lastDocTask = self._lastEdit
             if not self._docCounter.busy:
                 self._docCounter.count(self.getText())
 

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -3199,11 +3199,11 @@ class GuiDocEditor(QTextEdit):
     def _skipToParagraph(self, step: int) -> None:
         """Move cursor to next paragraph by step."""
         if step != 0:
-            cursor = self.textCursor()
-            limit = -1 if step < 0 else self._qDocument.blockCount()
-            for i in range(cursor.blockNumber() + step, limit, step):
-                block = self._qDocument.findBlockByNumber(i)
+            block = self.textCursor().block()
+            while block.isValid():
+                block = block.next() if step > 0 else block.previous()
                 if block.isValid() and block.text().strip():
+                    cursor = self.textCursor()
                     cursor.setPosition(block.position())
                     self.setTextCursor(cursor)
                     break

--- a/novelwriter/editor/editordocument.py
+++ b/novelwriter/editor/editordocument.py
@@ -186,12 +186,14 @@ class GuiTextDocument(QTextDocument):
     def iterBlockByType(self, cType: int, maxCount: int = 1000) -> Iterable[QTextBlock]:
         """Iterate over all text blocks of a given type."""
         count = 0
-        for i in range(self.blockCount()):
-            block = self.findBlockByNumber(i)
-            if count < maxCount and block.isValid() and block.userState() & cType > 0:
-                count += 1
+        block = self.begin()
+        while block.isValid():
+            if block.userState() & cType > 0:
                 yield block
-        return
+                count += 1
+                if count >= maxCount:
+                    return
+            block = block.next()
 
     ##
     #  Private Slots

--- a/novelwriter/editor/highlighter.py
+++ b/novelwriter/editor/highlighter.py
@@ -274,12 +274,12 @@ class GuiDocHighlighter(QSyntaxHighlighter):
         content type.
         """
         if document := self.document():  # pragma: no branch
-            nBlocks = document.blockCount()
             tStart = time()
-            for i in range(nBlocks):
-                block = document.findBlockByNumber(i)
+            block = document.begin()
+            while block.isValid():
                 if block.userState() & cType > 0:
                     self.rehighlightBlock(block)
+                block = block.next()
             logger.debug("Document highlighted in %.3f ms", (1000 * (time() - tStart)))
 
     ##

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -3170,6 +3170,7 @@ def testGuiDocEditor_WordCounters(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     assert docEditor._docCounter.busy is False
 
     # Run the full word counter
+    docEditor._lastEdit = time()  # Simulate an edit since the last run
     docEditor._runDocumentTasks()
     assert docEditor._docCounter.busy is True
 
@@ -3208,11 +3209,14 @@ def testGuiDocEditor_WordCounters(qtbot, monkeypatch, nwGUI, projPath, ipsumText
     assert docEditor._selCounter.busy is False
     assert docEditor.docFooter.wordsText.text() == f"Selected: {wC}"
 
-    # Document tasks run regardless of how long ago the last edit was,
-    # since the timer is only started in response to an actual edit,
-    # fires once, and then stops rather than polling indefinitely
+    # A repeated run with no edit since the last one is skipped entirely
     threadPool._runObj = None
     docEditor._lastEdit = time() - 100.0
+    docEditor._runDocumentTasks()
+    assert threadPool.runnable() is None
+
+    # A genuine new edit makes the next run go ahead again
+    docEditor._lastEdit = time()
     docEditor._runDocumentTasks()
     assert threadPool.runnable() is not None
 

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -821,7 +821,7 @@ def testGuiDocEditor_SpellChecking(qtbot, monkeypatch, nwGUI, projPath, ipsumTex
         # A full pass runs chunked worker jobs until the document is
         # done, which with a synchronous worker completes immediately
         docEditor._beginCheckPass()
-        assert docEditor._checkPassNo == -1
+        assert docEditor._checkPassPos is None
         assert docEditor._checkJob is None
 
         # A full spell check notifies when the pass completes
@@ -4265,9 +4265,9 @@ def testGuiDocEditor_BigDocLifecycle(qtbot, nwGUI, projPath, ipsumText, mockRnd)
     assert docEditor.getCursorPosition() != cursPos
 
     # A spell check pass is also skipped while busy
-    docEditor._checkPassNo = 99
+    docEditor._checkPassPos = 99
     docEditor.spellCheckDocument()
-    assert docEditor._checkPassNo == 99
+    assert docEditor._checkPassPos == 99
 
     with qtbot.waitSignal(docEditor._qDocument.layoutSettled, timeout=5000):
         pass

--- a/tests/editor/test_editordocument.py
+++ b/tests/editor/test_editordocument.py
@@ -25,6 +25,7 @@ import pytest
 
 from novelwriter.constants import nwConst
 from novelwriter.core.project import NWProject
+from novelwriter.editor.highlighter import BLOCK_TITLE
 
 from tests.helpers import C, buildTestProject
 
@@ -99,3 +100,24 @@ def testGuiTextDocument_BigDocOperations(qtbot, monkeypatch, nwGUI, projPath, ip
     with qtbot.waitSignal(qDoc.layoutSettled, timeout=5000):
         pass
     assert qDoc.isLayoutBusy() is False
+
+
+@pytest.mark.gui
+def testGuiTextDocument_IterBlockByType(qtbot, nwGUI, projPath, mockRnd):
+    """Test that iterBlockByType stops at maxCount instead of
+    continuing to scan the rest of the document.
+    """
+    buildTestProject(NWProject(), projPath)
+    nwGUI.openProject(projPath)
+    assert nwGUI.openDocument(C.hSceneDoc) is True
+    qDoc = nwGUI.docEditor._qDocument
+
+    qDoc.setPlainText("\n\n".join(f"### Heading {i}" for i in range(5)))
+
+    # There are more matching blocks than the cap below
+    allTitles = list(qDoc.iterBlockByType(BLOCK_TITLE, maxCount=1000))
+    assert [b.text() for b in allTitles] == [f"### Heading {i}" for i in range(5)]
+
+    # A smaller maxCount stops early instead of yielding the rest
+    capped = list(qDoc.iterBlockByType(BLOCK_TITLE, maxCount=2))
+    assert [b.text() for b in capped] == ["### Heading 0", "### Heading 1"]


### PR DESCRIPTION
**Summary:**

This PR fixes a series of issues related to finding blocks in the editor document. The issue is an old one and related to the three find method on the QTextDocument, which are all binary searches because the document structure is a tree, not an array. I always assumed they were using index lookups under the hood. Consequently they are O(log n) rather than plain O(n). Several places these were run inside loops that just ran over regions of the document, so O(m log n). Since the document has a block iterator, that's the better solution, and we're back to O(n).

Since you need a pretty huge document for the O(log n) to have a meaningful impact, it is mostly a non-issue, but it is wasteful and may cause stuttering in the responsiveness of the editor.

**Related Issue(s):**

Closes #2930

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
