### PR TITLE
Run the Python GC on a timer

### DIFF
--- a/novelwriter/__init__.py
+++ b/novelwriter/__init__.py
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
 
+import gc
 import getopt
 import logging
 import os
@@ -190,6 +191,9 @@ def main(sysArgs: list | None = None) -> GuiMain | None:
         pkgLogger.addHandler(cHandle)
 
     logger.info("Starting novelWriter %s (%s) %s", __version__, __hexversion__, __date__)
+
+    # Disable GC, running in GuiMain instead (#2927)
+    gc.disable()
 
     # Check Packages and Versions
     errorData = []

--- a/novelwriter/gui/statusbar.py
+++ b/novelwriter/gui/statusbar.py
@@ -320,6 +320,7 @@ class GuiMainStatus(QStatusBar):
         full memory usage, set environment variable PYTHONTRACEMALLOC=1
         before starting novelWriter.
         """
+        import gc
         import tracemalloc
 
         count = len(QApplication.allWidgets())
@@ -332,12 +333,17 @@ class GuiMainStatus(QStatusBar):
             self._debugInfo = True
 
         current, peak = tracemalloc.get_traced_memory()
+        young, old0, old1 = gc.get_count()
         stamp = datetime.now().strftime("%H:%M:%S")
         message = (
             f"Widgets: {count} \u2013 "
             f"{self._traceMallocRef} Memory: {current / 1024:,.2f} kiB \u2013 "
-            f"Peak: {peak / 1024:,.2f} kiB"
+            f"Peak: {peak / 1024:,.2f} kiB \u2013 "
+            f"GC: {young}/{old0}/{old1}"
         )
+        if garbage := len(gc.garbage):
+            # Objects the collector could not free, should normally stay at 0
+            message += f" \u2013 Uncollectable: {garbage}"
         self.showMessage(f"Debug [{stamp}] {message}", 6000)
         logger.debug("[MEMINFO] %s", message)
 

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -21,6 +21,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
 
+import gc
 import logging
 import sys
 
@@ -317,10 +318,16 @@ class GuiMain(QMainWindow):
         self.asDocTimer = QTimer(self)
         self.asDocTimer.timeout.connect(self._autoSaveDocument)
 
+        # Set Up Garbage Collector Timer
+        self.gcTimer = QTimer(self)
+        self.gcTimer.setInterval(5000)
+        self.gcTimer.timeout.connect(self._runGarbageCollect)
+
         # Initialise Main GUI
         self.initMain()
         self.asProjTimer.start()
         self.asDocTimer.start()
+        self.gcTimer.start()
         self.mainStatus.clearStatus()
 
         logger.debug("Ready: GUI")
@@ -1255,6 +1262,13 @@ class GuiMain(QMainWindow):
         if SHARED.hasProject and self.docEditor.docChanged:
             logger.debug("Auto-saving document")
             self.saveDocument()
+
+    @pyqtSlot()
+    def _runGarbageCollect(self) -> None:
+        """Run the cyclic garbage collector on the main thread, since
+        automatic collection is disabled at startup. See #2927.
+        """
+        gc.collect()
 
     @pyqtSlot()
     def _updateStatusWordCount(self) -> None:

--- a/utils/debug/crash_hunt.sh
+++ b/utils/debug/crash_hunt.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # A debug script that will run the test suite repeatedly, looking for
-# crashes. Takes the number of attempts as $1 (default 10).
+# crashes. Takes the number of attempts as $1 (default 10). Any further
+# arguments are forwarded to pytest, e.g. --run-long.
 
 COUNT=${1:-10}
+shift || true
 
 mkdir -p ./debug
 LOGDIR=./debug
@@ -15,7 +17,7 @@ while [ $i -lt "$COUNT" ]; do
     -ex "handle SIGSEGV stop nopass" \
     -ex "handle SIGABRT stop nopass" \
     -ex run -ex "bt full" -ex quit \
-    --args .venv/bin/python -m pytest tests -q \
+    --args .venv/bin/python -m pytest tests -q "$@" \
     > "$LOGDIR/crash_hunt_run_$i.log" 2>&1
   if grep -qE "SIGSEGV|SIGABRT|Segmentation fault" "$LOGDIR/crash_hunt_run_$i.log"; then
     echo ">>> CRASH on attempt $i — see $LOGDIR/crash_hunt_run_$i.log <<<"


### PR DESCRIPTION
**Summary:**

This PR disables the garbage collector at startup and runs it on a timer every 5 seconds in the main thread. This is to prevent it from being triggered off-thread when we're using Qt's thread pool.

This is the same approach Calibre uses.

**Related Issue(s):**

Closes #2927

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
