### PR TITLE
Refactor project autosave

### DIFF
--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -273,6 +273,7 @@ class Index:
 
             try:
                 meta = data.get("novelWriter.meta", {})
+                self._indexUpgrade = meta.get("version") != __hexversion__
                 self._tagsIndex.unpackData(data["novelWriter.tagsIndex"])
                 self._itemIndex.unpackData(data["novelWriter.itemIndex"])
             except Exception:
@@ -280,7 +281,6 @@ class Index:
                 logException()
                 return False
 
-            self._indexUpgrade = meta.get("version") != __hexversion__
             self._indexRevision = checkInt(meta.get("revision"), 0)
 
         logger.debug("Checking index")

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -80,8 +80,8 @@ class Index:
     """
 
     __slots__ = (
-        "_indexBroken",
         "_indexChange",
+        "_indexRevision",
         "_indexUpgrade",
         "_itemIndex",
         "_novelExtra",
@@ -98,15 +98,15 @@ class Index:
         # Storage and State
         self._tagsIndex = TagsIndex()
         self._itemIndex = ItemIndex(project, self._tagsIndex)
-        self._indexBroken = False
         self._indexUpgrade = False
 
         # Models
         self._novelModels: dict[str, NovelModel] = {}
         self._novelExtra = nwNovelExtra.HIDDEN
 
-        # TimeStamps
+        # Track Changes
         self._indexChange = 0.0
+        self._indexRevision = 0
         self._rootChange = {}
 
     def __repr__(self) -> str:
@@ -118,12 +118,19 @@ class Index:
     ##
 
     @property
-    def indexBroken(self) -> bool:
-        return self._indexBroken
+    def indexRebuild(self) -> bool:
+        """Return True if the index needs to be rebuilt."""
+        return self._indexRevision != self._project.data.indexRevision
 
     @property
     def indexUpgrade(self) -> bool:
-        return self._indexUpgrade
+        """Return True if the index was loaded from an older version."""
+        return self._indexUpgrade or self._indexRevision != self._project.data.indexRevision
+
+    @property
+    def indexRevision(self) -> int:
+        """Return the current index revision number."""
+        return self._indexRevision
 
     ##
     #  Getters
@@ -152,6 +159,7 @@ class Index:
         self._tagsIndex.clear()
         self._itemIndex.clear()
         self._indexChange = 0.0
+        self._indexRevision += 1  # We must not reset the revision number
         self._rootChange = {}
         SHARED.emitIndexCleared(self._project)
 
@@ -164,7 +172,6 @@ class Index:
                 text = self._project.storage.getDocumentText(nwItem.itemHandle)
                 self.scanText(nwItem.itemHandle, text, blockSignal=True)
             SHARED.incMainProgress()
-        self._indexBroken = False
         SHARED.emitIndexAvailable(self._project)
         for tHandle in self._novelModels:
             self.refreshNovelModel(tHandle)
@@ -243,7 +250,6 @@ class Index:
             return False
 
         tStart = time()
-        self._indexBroken = False
         if safeExists(indexFile):
             logger.debug("Loading index file")
             try:
@@ -252,18 +258,17 @@ class Index:
             except Exception:
                 logger.error("Failed to load index file")
                 logException()
-                self._indexBroken = True
                 return False
 
             try:
                 meta = data.get("novelWriter.meta", {})
                 self._indexUpgrade = meta.get("version") != __hexversion__
+                self._indexRevision = meta.get("revision", 0)
                 self._tagsIndex.unpackData(data["novelWriter.tagsIndex"])
                 self._itemIndex.unpackData(data["novelWriter.itemIndex"])
             except Exception:
                 logger.error("The index content is invalid")
                 logException()
-                self._indexBroken = True
                 return False
 
         logger.debug("Checking index")
@@ -293,7 +298,11 @@ class Index:
         start = time()
 
         try:
-            meta = {"version": __hexversion__, "timestamp": formatTimeStamp(start)}
+            meta = {
+                "version": __hexversion__,
+                "timestamp": formatTimeStamp(start),
+                "revision": self._indexRevision,
+            }
             with open(indexFile, mode="w+", encoding="utf-8") as outFile:
                 outFile.write(
                     jsonCombine({
@@ -363,6 +372,7 @@ class Index:
         # Update timestamps for index changes
         nowTime = time()
         self._indexChange = nowTime
+        self._indexRevision += 1
         self._rootChange[tItem.itemRoot] = nowTime
         if not blockSignal:
             if changedRefs := sorted(oldRefs | self._itemRefHandles(tHandle)):

--- a/novelwriter/core/index.py
+++ b/novelwriter/core/index.py
@@ -30,7 +30,16 @@ from time import time
 from typing import TYPE_CHECKING
 
 from novelwriter import SHARED, __hexversion__
-from novelwriter.common import formatTimeStamp, isHandle, isItemClass, isTitleTag, jsonCombine, jsonEncode, safeExists
+from novelwriter.common import (
+    checkInt,
+    formatTimeStamp,
+    isHandle,
+    isItemClass,
+    isTitleTag,
+    jsonCombine,
+    jsonEncode,
+    safeExists,
+)
 from novelwriter.constants import nwFiles, nwKeyWords, nwStyles
 from novelwriter.core.indexdata import NOTE_TYPES, TT_NONE, IndexHeading, IndexNode, T_NoteTypes
 from novelwriter.enum import nwComment, nwItemClass, nwItemLayout, nwItemType, nwNovelExtra
@@ -73,10 +82,12 @@ class Index:
     lookups from the tags and back to items where they are defined.
 
     The index data is cached in a JSON file between writing sessions in
-    order to save startup time. The cached index is validated on input,
-    and a broken flag set if it is not valid. If it is invalid, the
-    loaded data is cleared and it is up to the calling code to initiate
-    a rebuild of the index data.
+    order to save startup time. The cache is only written on a full save,
+    not on autosave, so its revision number is compared against the one
+    recorded in the project file to determine whether it is up to date.
+    A mismatch, either because the cache is invalid/missing or because
+    it is older than the project file's revision, means the calling code
+    must initiate a rebuild of the index data.
     """
 
     __slots__ = (
@@ -125,7 +136,7 @@ class Index:
     @property
     def indexUpgrade(self) -> bool:
         """Return True if the index was loaded from an older version."""
-        return self._indexUpgrade or self._indexRevision != self._project.data.indexRevision
+        return self._indexUpgrade
 
     @property
     def indexRevision(self) -> int:
@@ -262,14 +273,15 @@ class Index:
 
             try:
                 meta = data.get("novelWriter.meta", {})
-                self._indexUpgrade = meta.get("version") != __hexversion__
-                self._indexRevision = meta.get("revision", 0)
                 self._tagsIndex.unpackData(data["novelWriter.tagsIndex"])
                 self._itemIndex.unpackData(data["novelWriter.itemIndex"])
             except Exception:
                 logger.error("The index content is invalid")
                 logException()
                 return False
+
+            self._indexUpgrade = meta.get("version") != __hexversion__
+            self._indexRevision = checkInt(meta.get("revision"), 0)
 
         logger.debug("Checking index")
 

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -447,6 +447,10 @@ class NWProject:
         if not isinstance(xmlWriter, ProjectXMLWriter):
             return False
 
+        if not autoSave:
+            # We only update the index revision on full save
+            self._data.setIndexRevision(self._index.indexRevision)
+
         saveTime = time()
         SHARED.clearErrorCache()
         editTime = self._data.editTime + max(round(saveTime - self._session.start), 0)
@@ -456,8 +460,10 @@ class NWProject:
             return False
 
         # Save other project data
-        self._options.saveSettings()
-        self._index.saveIndex()
+        if not autoSave:
+            self._options.saveSettings()
+            self._index.saveIndex()
+
         self._storage.runPostSaveTasks(autoSave=autoSave)
 
         # Update recent projects

--- a/novelwriter/core/project.py
+++ b/novelwriter/core/project.py
@@ -447,12 +447,9 @@ class NWProject:
         if not isinstance(xmlWriter, ProjectXMLWriter):
             return False
 
-        if not autoSave:
-            # We only update the index revision on full save
-            self._data.setIndexRevision(self._index.indexRevision)
-
         saveTime = time()
         SHARED.clearErrorCache()
+        self._data.setIndexRevision(self._index.indexRevision)
         editTime = self._data.editTime + max(round(saveTime - self._session.start), 0)
         content = self._tree.pack()
         if not xmlWriter.write(self._data, content, saveTime, editTime):

--- a/novelwriter/core/projectdata.py
+++ b/novelwriter/core/projectdata.py
@@ -70,6 +70,7 @@ class ProjectData:
         "_doBackup",
         "_editTime",
         "_import",
+        "_indexRevision",
         "_initCounts",
         "_language",
         "_lastHandle",
@@ -100,6 +101,7 @@ class ProjectData:
         self._saveCount = 0
         self._autoCount = 0
         self._editTime = 0
+        self._indexRevision = 0
 
         # Project Settings
         self._doBackup = True
@@ -179,6 +181,11 @@ class ProjectData:
     def editTime(self) -> int:
         """Return the number of seconds the project has been edited."""
         return self._editTime
+
+    @property
+    def indexRevision(self) -> int:
+        """Return the last known index revision number."""
+        return self._indexRevision
 
     @property
     def doBackup(self) -> bool:
@@ -356,6 +363,10 @@ class ProjectData:
         """Set the edit time from last session."""
         self._editTime = checkInt(value, 0)
         self._project.setProjectChanged(True)
+
+    def setIndexRevision(self, value: Any) -> None:
+        """Set the index revision number from last session."""
+        self._indexRevision = checkInt(value, 0)
 
     def setDoBackup(self, value: Any) -> None:
         """Set the do write backup flag."""

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -109,18 +109,18 @@ class ProjectXMLReader:
         the project or the content into their respective section nodes
         as attributes. The id attribute was also added to the project.
 
-        Rev 1: Drops the titleFormat node from settings. 2.1 Beta 1.
+        Rev 1: Drops the titleFormat node from settings (2.1).
         Rev 2: Drops the title node from project and adds the TEMPLATE
-               class for items. 2.3 Beta 1.
-        Rev 3: Added TEMPLATE class. 2.3.
+               class for items (2.3).
+        Rev 3: Added TEMPLATE class (2.3).
         Rev 4: Added shape attribute to status and importance entry
-               nodes. 2.5.
+               nodes (2.5).
         Rev 5: Added novelChars and notesChars attributes to content
-               node. 2.7 RC 1.
+               node (2.7).
         Rev 6: Replaced red, green and blue attributes with a single
-               color attribute. 2.8 Beta 1.
-        Rev 7: Added projectTarget and dailyTarget nodes to settings.
-               26.2 Beta 1.
+               color attribute (2.8).
+        Rev 7: Added projectTarget and dailyTarget nodes to settings,
+               and indexRevision in project (26.2).
     """
 
     def __init__(self, path: str | Path) -> None:
@@ -242,6 +242,7 @@ class ProjectXMLReader:
         data.setSaveCount(xSection.attrib.get("saveCount", 0))  # Moved in 1.5
         data.setAutoCount(xSection.attrib.get("autoCount", 0))  # Moved in 1.5
         data.setEditTime(xSection.attrib.get("editTime", 0))  # Moved in 1.5
+        data.setIndexRevision(xSection.attrib.get("indexRevision", 0))  # Added in 1.5 Rev 7
 
         for xItem in xSection:
             if xItem.tag == "name":
@@ -510,6 +511,7 @@ class ProjectXMLWriter:
             "saveCount": str(data.saveCount),
             "autoCount": str(data.autoCount),
             "editTime": str(editTime),
+            "indexRevision": str(data.indexRevision),
         }
 
         xProject = ET.SubElement(xRoot, "project", attrib=projAttr)

--- a/novelwriter/core/projectxml.py
+++ b/novelwriter/core/projectxml.py
@@ -120,7 +120,7 @@ class ProjectXMLReader:
         Rev 6: Replaced red, green and blue attributes with a single
                color attribute (2.8).
         Rev 7: Added projectTarget and dailyTarget nodes to settings,
-               and indexRevision in project (26.2).
+               and indexRevision attribute to project (26.2).
     """
 
     def __init__(self, path: str | Path) -> None:

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -98,7 +98,6 @@ from novelwriter.enum import (
 from novelwriter.extensions.eventfilters import WheelEventFilter
 from novelwriter.formats.fromqdoc import FromQTextDocument
 from novelwriter.text.autoreplace import TextAutoReplace
-from novelwriter.text.counting import standardCounter
 from novelwriter.text.formats import processHeading
 from novelwriter.tools.lipsum import GuiLipsum
 from novelwriter.types import (
@@ -760,9 +759,6 @@ class GuiDocEditor(QTextEdit):
             return False
 
         text = self.getText()
-        cC, wC, pC = standardCounter(text)
-        self._updateDocCounts(cC, wC, pC)
-
         if not self._nwDocument.writeDocument(text):
             saveOk = False
             if self._nwDocument.hashError and SHARED.question(

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -249,6 +249,11 @@ class GuiDocEditor(QTextEdit):
         "wheelEventFilter",
     )
 
+    SEP_TABLE = str.maketrans({
+        nwUnicode.U_LSEP: "\n",  # Line Separator
+        nwUnicode.U_PSEP: "\n",  # Paragraph Separator
+    })
+
     closeEditorRequest = pyqtSignal()
     docTextChanged = pyqtSignal(str, float)
     editedStatusChanged = pyqtSignal(bool)
@@ -854,16 +859,12 @@ class GuiDocEditor(QTextEdit):
 
         See: https://doc.qt.io/qt-6/qtextdocument.html#toPlainText
         """
-        text = self._qDocument.toRawText()
-        text = text.replace(nwUnicode.U_LSEP, "\n")  # Line separators
-        return text.replace(nwUnicode.U_PSEP, "\n")  # Paragraph separators
+        return self._qDocument.toRawText().translate(self.SEP_TABLE)
 
     def getSelectedText(self) -> str:
         """Get currently selected text."""
         if (cursor := self.textCursor()).hasSelection():
-            text = cursor.selectedText()
-            text = text.replace(nwUnicode.U_LSEP, "\n")  # Line separators
-            return text.replace(nwUnicode.U_PSEP, "\n")  # Paragraph separators
+            return cursor.selectedText().translate(self.SEP_TABLE)
         return ""
 
     def getCursorPosition(self) -> int:

--- a/novelwriter/guimain.py
+++ b/novelwriter/guimain.py
@@ -501,7 +501,7 @@ class GuiMain(QMainWindow):
             self.viewDocument(lastViewed)
 
         # Check if we need to rebuild the index
-        if SHARED.project.index.indexBroken:
+        if SHARED.project.index.indexRebuild:
             if not SHARED.project.index.indexUpgrade:
                 SHARED.warn(self.tr("The project index is broken. Rebuilding index."))
             self.rebuildIndex()

--- a/sample/nwProject.nwx
+++ b/sample/nwProject.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
-<novelWriterXML appVersion="26.2b1" hexVersion="0x260200b1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-30 21:34:49">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2383" autoCount="430" editTime="110655">
+<novelWriterXML appVersion="26.2b1" hexVersion="0x260200b1" fileVersion="1.5" fileRevision="7" timeStamp="2026-08-01 16:29:47">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2384" autoCount="430" editTime="110660" indexRevision="0">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>
@@ -9,7 +9,7 @@
     <language>en_GB</language>
     <spellChecking auto="yes">None</spellChecking>
     <projectTarget date="None" last="1137" mode="words">15000</projectTarget>
-    <dailyTarget auto="no" last="0" date="2026-07-30">1000</dailyTarget>
+    <dailyTarget auto="no" last="0" date="2026-08-01">1000</dailyTarget>
     <targetSkipRoots>
       <entry>d2d81f4831814</entry>
     </targetSkipRoots>

--- a/tests/_files/nwProject-1.5.nwx
+++ b/tests/_files/nwProject-1.5.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2026-07-20 17:28:47">
-  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2369" autoCount="429" editTime="1000">
+  <project id="e2be99af-f9bf-4403-857a-c3d1ac25abea" saveCount="2369" autoCount="429" editTime="1000" indexRevision="0">
     <name>Sample Project</name>
     <author>Jane Smith</author>
   </project>

--- a/tests/_reference/coreIndex_LoadSave_tagsIndex.json
+++ b/tests/_reference/coreIndex_LoadSave_tagsIndex.json
@@ -1,7 +1,8 @@
 {
   "novelWriter.meta": {
     "version": "0x020800a2",
-    "timestamp": "2025-10-05 17:06:58"
+    "timestamp": "2025-10-05 17:06:58",
+    "revision": 15
   },
   "novelWriter.tagsIndex": {
     "bod": {"name": "Bod", "display": "Nobody Owens", "handle": "4c4f28287af27", "heading": "T0001", "class": "CHARACTER"},

--- a/tests/_reference/projectXML_ReadLegacy10.nwx
+++ b/tests/_reference/projectXML_ReadLegacy10.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2020-05-28 09:59:15">
-  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="0" autoCount="0" editTime="1000">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="0" autoCount="0" editTime="1000" indexRevision="0">
     <name>Sample Project</name>
     <author>Jay Doh</author>
   </project>

--- a/tests/_reference/projectXML_ReadLegacy11.nwx
+++ b/tests/_reference/projectXML_ReadLegacy11.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2020-06-26 21:20:24">
-  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000" indexRevision="0">
     <name>Sample Project</name>
     <author>Jay Doh</author>
   </project>

--- a/tests/_reference/projectXML_ReadLegacy12.nwx
+++ b/tests/_reference/projectXML_ReadLegacy12.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2021-08-30 23:33:44">
-  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000" indexRevision="0">
     <name>Sample Project</name>
     <author>Jay Doh</author>
   </project>

--- a/tests/_reference/projectXML_ReadLegacy13.nwx
+++ b/tests/_reference/projectXML_ReadLegacy13.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2022-10-25 18:26:15">
-  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000" indexRevision="0">
     <name>Sample Project</name>
     <author>Jay Doh</author>
   </project>

--- a/tests/_reference/projectXML_ReadLegacy14.nwx
+++ b/tests/_reference/projectXML_ReadLegacy14.nwx
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <novelWriterXML appVersion="26.2a1" hexVersion="0x260200a1" fileVersion="1.5" fileRevision="7" timeStamp="2022-10-15 12:12:59">
-  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000">
+  <project id="d0f3fe10-c6e6-4310-8bfd-181eb4224eed" saveCount="5" autoCount="10" editTime="1000" indexRevision="0">
     <name>Sample Project</name>
     <author>Jay Doh</author>
   </project>

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -151,11 +151,11 @@ def testIndex_LoadSave(qtbot, monkeypatch, prjLipsum, nwGUI, tstPaths):
     with monkeypatch.context() as mp:
         mp.setattr(json, "load", causeException)
         assert index.loadIndex() is False
-        assert index.indexBroken is True
+        assert index.indexRebuild is True
 
     # Make the load pass
     assert index.loadIndex() is True
-    assert index.indexBroken is False
+    assert index.indexRebuild is False
     assert index.indexUpgrade is False
 
     assert str(index._tagsIndex.packData()) == tagIndex
@@ -175,12 +175,12 @@ def testIndex_LoadSave(qtbot, monkeypatch, prjLipsum, nwGUI, tstPaths):
     # Write an empty index file and load it
     projFile.write_text("{}", encoding="utf-8")
     assert index.loadIndex() is False
-    assert index.indexBroken is True
+    assert index.indexRebuild is True
 
     # Write an index file that passes loading, but is still empty
     projFile.write_text('{"novelWriter.tagsIndex": {}, "novelWriter.itemIndex": {}}', encoding="utf-8")
     assert index.loadIndex() is True
-    assert index.indexBroken is False
+    assert index.indexRebuild is False
 
     # Check that the index is re-populated
     assert "04468803b92e1" in index._itemIndex

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -100,6 +100,10 @@ def testIndex_LoadSave(qtbot, monkeypatch, prjLipsum, nwGUI, tstPaths):
     # Make the save pass
     assert index.saveIndex() is True
 
+    # A full save also records the index revision on the project, which
+    # is normally done by NWProject.saveProject before it calls saveIndex
+    project.data.setIndexRevision(index.indexRevision)
+
     # Take a copy of the index
     tagIndex = str(index._tagsIndex.packData())
     itemsIndex = str(index._itemIndex.packData())
@@ -170,7 +174,7 @@ def testIndex_LoadSave(qtbot, monkeypatch, prjLipsum, nwGUI, tstPaths):
 
     # Check File
     copyfile(projFile, testFile)
-    assert cmpFiles(testFile, compFile, ignLines=[3, 4])
+    assert cmpFiles(testFile, compFile, ignLines=[3, 4, 5])
 
     # Write an empty index file and load it
     projFile.write_text("{}", encoding="utf-8")
@@ -1169,7 +1173,7 @@ def testTagsIndex_Main():
     # Pack Data
     assert tagsIndex.packData() == content
 
-    # Delete the second key and a non-existant key. Deleting must also
+    # Delete the second key and a non-existent key. Deleting must also
     # drop the tag from the all-tags bucket, unlike a reclassification
     del tagsIndex["Tag2"]
     del tagsIndex["Tag4"]

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -338,10 +338,10 @@ def testNWProject_Open(monkeypatch, caplog, mockGUI, fncPath, mockRnd):
     with monkeypatch.context() as mp:
         mp.setattr(ProjectXMLReader, "state", property(lambda *a: XMLReadState.WAS_LEGACY))
         mp.setattr("novelwriter.core.index.Index.loadIndex", lambda *a: True)
-        project.index._indexBroken = True
+        project.index._indexRevision = 0
         assert project.openProject(fncPath, clearLock=True) is True
         assert "The file format of your project is about to be" in SHARED.lastAlert[0]
-        assert project.index._indexBroken is False
+        assert project.index._indexRevision == 4
 
     project.closeProject()
 

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -380,6 +380,42 @@ def testNWProject_Save(monkeypatch, mockGUI, mockRnd, fncPath):
 
 
 @pytest.mark.core
+def testNWProject_AutoSaveIndexRevision(mockGUI, mockRnd, fncPath):
+    """Test that the index revision is kept current in the project file
+    on every save, including autosave.
+    """
+    project = NWProject()
+    mockRnd.reset()
+    buildTestProject(project, fncPath)  # Performs a full save
+
+    savedRevision = project.index.indexRevision
+    assert project.data.indexRevision == savedRevision
+
+    # Edit a document and only autosave, so the index cache on disk is left untouched
+    tHandle = next(i.itemHandle for i in project.tree if i.isFileType())
+    doc = project.storage.getDocument(tHandle)
+    doc.writeDocument("### More Content\n\n")
+    project.index.reIndexHandle(tHandle)
+    assert project.index.indexRevision > savedRevision
+
+    assert project.saveProject(autoSave=True) is True
+    autoSavedRevision = project.index.indexRevision
+    assert project.data.indexRevision == autoSavedRevision
+    assert autoSavedRevision > savedRevision
+    project.closeProject()
+
+    # Simulate recovering after a crash.
+    # The cached index.json on disk still reflects the state as of the
+    # last full save, so it must be flagged as needing a rebuild.
+    recovered = NWProject()
+    assert recovered.openProject(fncPath, clearLock=True) is True
+    assert recovered.index.indexRevision == savedRevision
+    assert recovered.data.indexRevision == autoSavedRevision
+    assert recovered.index.indexRebuild is True
+    recovered.closeProject()
+
+
+@pytest.mark.core
 def testNWProject_Methods(monkeypatch, mockGUI, fncPath, mockRnd):
     """Test other project class methods and functions."""
     project = NWProject()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -186,7 +186,7 @@ def buildTestProject(project: NWProject, path: Path) -> None:
 
     project.session.startSession()
     project.setProjectChanged(True)
-    project.saveProject(autoSave=True)
+    project.saveProject()
     project._valid = True
     project._tree._ready = True
 

--- a/tests/test_guimain.py
+++ b/tests/test_guimain.py
@@ -229,6 +229,32 @@ def testGuiMain_Launch(qtbot, monkeypatch, nwGUI, projPath, fncPath):
 
 
 @pytest.mark.gui
+def testGuiMain_IndexRebuild(qtbot, monkeypatch, nwGUI, projPath):
+    """Test that a genuinely invalid index cache, as opposed to one
+    from a version upgrade, triggers the "index is broken" warning as
+    well as a rebuild of the index.
+    """
+    buildTestProject(NWProject(), projPath)
+    indexFile = projPath / "meta" / nwFiles.INDEX_FILE
+    assert indexFile.is_file()
+
+    # Corrupt the cached index file on disk
+    indexFile.write_text("{not valid json", encoding="utf-8")
+
+    warnMock = Mock()
+    rebuildMock = Mock()
+    with monkeypatch.context() as mp:
+        mp.setattr(SHARED, "warn", warnMock)
+        mp.setattr(nwGUI, "rebuildIndex", rebuildMock)
+        assert nwGUI.openProject(projPath) is True
+
+    assert SHARED.project.index.indexUpgrade is False
+    assert any("index is broken" in str(call) for call in warnMock.call_args_list)
+    assert rebuildMock.called is True
+    nwGUI.closeProject()
+
+
+@pytest.mark.gui
 def testGuiMain_ProjectTreeItems(qtbot, monkeypatch, nwGUI, projPath, mockRnd):
     """Test handling of project tree items based on GUI focus states."""
     buildTestProject(NWProject(), projPath)

--- a/tests/test_guimain.py
+++ b/tests/test_guimain.py
@@ -173,7 +173,7 @@ def testGuiMain_Launch(qtbot, monkeypatch, nwGUI, projPath, fncPath):
     warnMock = Mock()
     rebuildMock = Mock()
     with monkeypatch.context() as mp:
-        mp.setattr(type(SHARED.project.index), "indexBroken", property(lambda self: True))
+        mp.setattr(type(SHARED.project.index), "indexRebuild", property(lambda self: True))
         mp.setattr(type(SHARED.project.index), "indexUpgrade", property(lambda self: True))
         mp.setattr(SHARED, "warn", warnMock)
         mp.setattr(nwGUI, "rebuildIndex", rebuildMock)


### PR DESCRIPTION
**Summary:**

Change how the index is handled in the auto-save process. Basically, it is now skipped, together with the state of user changes to GUI state. These are only saved when the project is saved in full. To make sure the cache is not stale on reload, a revision number is now added to both the cache and the project XML, which will force a rebuild of the index if they do not match. This is a generally more robust check anyway, and will also catch changes related to the user using version control software on the files, but ignoring the index.json so that it is reset and drifts out of sync. Currently, this just results in stale index info.

**Related Issue(s):**

Closes #2928
Closes #2931

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
