### PR TITLE
Fix pre-release version number for flatpak

### DIFF
--- a/utils/build_flatpak.py
+++ b/utils/build_flatpak.py
@@ -38,7 +38,6 @@ from utils.common import (
     extractVersion,
     makeCheckSum,
     readFile,
-    stripVersion,
     toUpload,
     writeFile,
 )
@@ -152,8 +151,7 @@ def flatpak(args: argparse.Namespace) -> None:
     qtVersion = buildInfo["qt_version"]
     enchantVersion = buildInfo["enchant_version"]
 
-    numVers, _, relDate = extractVersion()
-    pkgVers = stripVersion(numVers)
+    pkgVers, _, relDate = extractVersion()
     relDate = datetime.datetime.strptime(relDate, "%Y-%m-%d")
 
     bldDir = ROOT_DIR / "dist_flatpak"
@@ -240,8 +238,8 @@ def flathub(args: argparse.Namespace) -> None:
     qtVersion = buildInfo["qt_version"]
     enchantVersion = buildInfo["enchant_version"]
 
-    numVers, _, _ = extractVersion()
-    tag = f"v{numVers}"
+    pkgVers, _, _ = extractVersion()
+    tag = f"v{pkgVers}"
 
     bldDir = ROOT_DIR / "dist_flathub"
     bldDir.mkdir(exist_ok=True)
@@ -254,7 +252,7 @@ def flathub(args: argparse.Namespace) -> None:
     print("======================")
     print("")
 
-    commitApiUrl = NW_COMMIT_API.format(version=numVers)
+    commitApiUrl = NW_COMMIT_API.format(version=pkgVers)
     try:
         print(f"Checking: {commitApiUrl}")
         with urllib.request.urlopen(commitApiUrl) as response:
@@ -266,7 +264,7 @@ def flathub(args: argparse.Namespace) -> None:
         print("")
         print(str(exc))
         print("")
-        print(f"Has version {numVers} been tagged and pushed to GitHub yet?")
+        print(f"Has version {pkgVers} been tagged and pushed to GitHub yet?")
         print("")
         sys.exit(1)
 


### PR DESCRIPTION
**Summary:**

The package dropped the pre-release tag.

**Related Issue(s):**

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
