### PR TITLE
Fix native font picker on macOS does not change the selected font

### DIFF
--- a/novelwriter/extensions/modified.py
+++ b/novelwriter/extensions/modified.py
@@ -157,6 +157,16 @@ class NFontDialog(QFontDialog):
     def selectFont(font: QFont, parent: QWidget, title: str, native: bool) -> tuple[QFont, bool]:
         """Open the dialog and select a font."""
         if native:
+            if CONFIG.osDarwin:
+                # The macOS font panel has no accept button, so closing it
+                # must count as accepting the current font.
+                # Also we can't use `QFontDialog.getFont(..)` because it
+                # always returns the previously selected font without an accept action
+                dialog = QFontDialog(font, parent)
+                dialog.setWindowTitle(title)
+                dialog.exec()
+                return dialog.currentFont(), True
+
             # If we're using the native dialog, let Qt handle it
             font, result = QFontDialog.getFont(font, parent, title)
             return font, bool(result)

--- a/tests/extensions/test_modified.py
+++ b/tests/extensions/test_modified.py
@@ -29,6 +29,7 @@ from PyQt6.QtCore import QEvent, QPoint, QPointF, QSize, Qt
 from PyQt6.QtGui import QFont, QKeyEvent, QMouseEvent, QPixmap, QStandardItem, QStandardItemModel, QWheelEvent
 from PyQt6.QtWidgets import QFontDialog, QSplitter, QWidget
 
+from novelwriter import CONFIG
 from novelwriter.extensions.modified import (
     NClickableLabel,
     NComboBox,
@@ -113,9 +114,19 @@ def testNFontDialog_Main(qtbot, monkeypatch, nwGUI):
     mockNative = Mock()
     mockNative.return_value = (other, True)
     with monkeypatch.context() as mp:
+        mp.setattr(CONFIG, "osDarwin", False)
         mp.setattr(QFontDialog, "getFont", mockNative)
         font, result = NFontDialog.selectFont(current, widget, "Title", True)
         mockNative.assert_called_once_with(current, widget, "Title")
+        assert font is other
+        assert result is True
+
+    # Test native dialog on macOS
+    with monkeypatch.context() as mp:
+        mp.setattr(CONFIG, "osDarwin", True)
+        mp.setattr(QFontDialog, "exec", lambda *a: None)
+        mp.setattr(QFontDialog, "currentFont", lambda *a: other)
+        font, result = NFontDialog.selectFont(current, widget, "Title", True)
         assert font is other
         assert result is True
 


### PR DESCRIPTION
<!--
Please check the following before you make a pull request:

* The branch you are making the pull request from (in your own fork) has a unique and descriptive
  name. Do not make a pull request directly from your copy of `main`.
* If you are submitting translation files, only submit the files that you have added translations
  to, not the other .ts files that may have been updated in the process.
* Make sure your contribution follows the style guide and other requirements mentioned in the
  CONTRIBUTING.md file in the repository.
* Fill in the Summary section below, and if relevant, mention the issue numbers related to the PR.
-->

**Summary:**
When "Use the system's font selection dialog" is ON, Qt uses the native NSFontPanel to allow users to choose a font. However, this experience does not have ok/cancel buttons as on macOS we usually expect settings to 'just be' applied:

<img width="895" height="658" alt="Screenshot 2026-08-15 at 09 22 02" src="https://github.com/user-attachments/assets/486aa5c7-e6dd-4932-a3ca-ee71622f9b1b" />

This creates a situation where `QFontDialog.getFont` will always return `ok=False` and the font value remains as the previously selected font (so the user changes are discarded since Qt didn't get an explicit confirmation). In other words, it's currently not possible to change fonts anywhere in preferences as long as "Use the system's font selection dialog" is on.

This PR introduces a work-around for this by making an exception when novelWriter is running on macOS so any changes in the native font picker are assumed to be the user's preferred font. Users can still discard the selection by clicking Cancel on the preferences dialog.

It is a bit hacky, but I couldn't find a better way to tackle the situation... the alternative would be disabling the native font picker for macOS all together but I thought that's a bit too far.

**Related Issue(s):**

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] All linting checks are passing and the style guide is followed
* [ ] Documentation (as docstrings) is complete and understandable
* [ ] Only files that have been actively changed are committed
