### PR TITLE
Fix repeated shortcodes in pasted rich text

### DIFF
--- a/docs/source/features/shortcuts.rst
+++ b/docs/source/features/shortcuts.rst
@@ -134,6 +134,7 @@ Other Editor Shortcuts
    ":kbd:`Ctrl+Return`",       "Open the tag or reference under the cursor in the viewer"
    ":kbd:`Ctrl+Shift+Return`", "Open the tag or reference under the cursor in the editor"
    ":kbd:`Ctrl+Shift+A`",      "Select all text in the current paragraph"
+   ":kbd:`Ctrl+Shift+V`",      "Paste text as plain text from clipboard to cursor position"
    ":kbd:`Ctrl+Left`",         "Move to previous word."
    ":kbd:`Ctrl+Right`",        "Move to next word."
    ":kbd:`Ctrl+Up`",           "Move to previous paragraph."

--- a/novelwriter/editor/editor.py
+++ b/novelwriter/editor/editor.py
@@ -384,6 +384,11 @@ class GuiDocEditor(QTextEdit):
         self._followTagEdit.setContext(QtWidgetShortcut)
         self._followTagEdit.activated.connect(qtWeakLambda(self._processTag, edit=True))
 
+        self._pastePlainText = QShortcut(self)
+        self._pastePlainText.setKeys(["Ctrl+Shift+V"])
+        self._pastePlainText.setContext(QtWidgetShortcut)
+        self._pastePlainText.activated.connect(self._pasteAsPlainText)
+
         self._prevLine = QShortcut(self)
         self._prevLine.setKey("Ctrl+Up")
         self._prevLine.setContext(QtWidgetShortcut)
@@ -1451,16 +1456,7 @@ class GuiDocEditor(QTextEdit):
         else:
             return
 
-        if text:
-            # Ensures line height is applied, see #2874
-            logger.debug("Inserted text into document")
-            cursor = self.textCursor()
-            cursor.beginEditBlock()
-            cursor.insertText(text)
-            cursor.endEditBlock()
-            self.setTextCursor(cursor)
-            # Deferred to avoid re-entrancy, see #2917
-            QTimer.singleShot(0, lambda: self.ensureCursorVisible(centre=False))
+        self._insertPlainText(text)
 
     ##
     #  Public Slots
@@ -1517,6 +1513,12 @@ class GuiDocEditor(QTextEdit):
     ##
     #  Private Slots
     ##
+
+    @pyqtSlot()
+    def _pasteAsPlainText(self) -> None:
+        """Paste the clipboard's plain text content."""
+        if clipboard := QApplication.clipboard():  # pragma: no branch
+            self._insertPlainText(clipboard.text())
 
     @pyqtSlot(int, int, int)
     def _docChange(self, pos: int, removed: int, added: int) -> None:
@@ -2599,6 +2601,19 @@ class GuiDocEditor(QTextEdit):
             self.setTextCursor(cursor)
 
         return
+
+    def _insertPlainText(self, text: str) -> None:
+        """Insert plain text at the current cursor position."""
+        if text:
+            # Ensures line height is applied, see #2874
+            logger.debug("Inserted text into document")
+            cursor = self.textCursor()
+            cursor.beginEditBlock()
+            cursor.insertText(text)
+            cursor.endEditBlock()
+            self.setTextCursor(cursor)
+            # Deferred to avoid re-entrancy, see #2917
+            QTimer.singleShot(0, lambda: self.ensureCursorVisible(centre=False))
 
     ##
     #  Internal Functions : Vim Mode

--- a/novelwriter/formats/fromqdoc.py
+++ b/novelwriter/formats/fromqdoc.py
@@ -153,21 +153,49 @@ class FromQTextDocument:
 
     def _formatBlock(self, block: QTextBlock) -> str:
         """Format the text of a block, applying inline formatting to
-        each of its fragments.
+        each of its fragments. Adjacent Qt fragments that carry the
+        same effective formatting are merged first, as Qt's HTML
+        round trip can split a single formatted run into several
+        fragments that differ only in formatting-irrelevant
+        properties like anchors (see #2978).
         """
         blockText = block.text()
-        parts = []
-        offset = 0
+        merged: list[tuple[str, dict[str, bool]]] = []
         it = block.begin()
         while not it.atEnd():
             if (frag := it.fragment()).isValid():  # pragma: no branch
                 text = frag.text()
-                parts.append(self._formatFragment(text, offset, blockText, frag.charFormat()))
-                offset += len(text)
+                active = self._activeFormats(frag.charFormat())
+                if merged and merged[-1][1] == active:
+                    prevText, _ = merged[-1]
+                    merged[-1] = (prevText + text, active)
+                else:
+                    merged.append((text, active))
             it += 1
+
+        parts = []
+        offset = 0
+        for text, active in merged:
+            parts.append(self._formatFragment(text, offset, blockText, active))
+            offset += len(text)
+
         return self._resolveSoftBreaks("".join(parts))
 
-    def _formatFragment(self, text: str, start: int, blockText: str, cFormat: QTextCharFormat) -> str:
+    def _activeFormats(self, cFormat: QTextCharFormat) -> dict[str, bool]:
+        """Extract the set of Markdown-relevant formats that are
+        active for a given character format.
+        """
+        align = cFormat.verticalAlignment()
+        return {
+            "underline": cFormat.fontUnderline(),
+            "sub": align == QtVAlignSub,
+            "sup": align == QtVAlignSuper,
+            "strike": cFormat.fontStrikeOut(),
+            "italic": cFormat.fontItalic(),
+            "bold": cFormat.fontWeight() >= QFont.Weight.Bold,
+        }
+
+    def _formatFragment(self, text: str, start: int, blockText: str, active: dict[str, bool]) -> str:
         """Wrap a single formatted text fragment in the appropriate
         Markdown syntax or novelWriter shortcode.
         """
@@ -183,16 +211,6 @@ class FromQTextDocument:
         cleanEdges = (coreStart == 0 or not _isWordChar(blockText[coreStart - 1])) and (
             coreEnd >= len(blockText) or not _isWordChar(blockText[coreEnd])
         )
-
-        align = cFormat.verticalAlignment()
-        active = {
-            "underline": cFormat.fontUnderline(),
-            "sub": align == QtVAlignSub,
-            "sup": align == QtVAlignSuper,
-            "strike": cFormat.fontStrikeOut(),
-            "italic": cFormat.fontItalic(),
-            "bold": cFormat.fontWeight() >= QFont.Weight.Bold,
-        }
 
         for name in MARKDOWN_FMTS:
             if not active[name]:

--- a/tests/editor/test_editor.py
+++ b/tests/editor/test_editor.py
@@ -2977,6 +2977,32 @@ def testGuiDocEditor_InsertFromMimeData_Markdown(qtbot, nwGUI, projPath, mockRnd
 
 
 @pytest.mark.gui
+def testGuiDocEditor_PasteAsPlainText(qtbot, nwGUI, projPath, mockRnd):
+    """Test that the Ctrl+Shift+V shortcut always inserts the
+    clipboard's plain text, ignoring any HTML or Markdown formatting
+    also present on the clipboard.
+    """
+    buildTestProject(NWProject(), projPath)
+    nwGUI.openProject(projPath)
+    docEditor = nwGUI.docEditor
+    assert docEditor.loadText(C.hSceneDoc) is True
+    docEditor.setCursorPosition(0)
+
+    clipboard = QApplication.clipboard()
+    assert clipboard is not None
+    clipboard.clear()
+
+    mime = QMimeData()
+    mime.setHtml("<p><b>Bold</b> text.</p>")
+    mime.setText("Plain text.")
+    clipboard.setMimeData(mime)
+
+    docEditor._pasteAsPlainText()
+
+    assert docEditor.getText().startswith("Plain text.")
+
+
+@pytest.mark.gui
 def testGuiDocEditor_LineHeightDoubleReturn(qtbot, nwGUI, projPath, mockRnd):
     """Test that a blank-line paragraph break (two consecutive Return
     presses) works normally with a non-default line height set on

--- a/tests/formats/test_fromqdoc.py
+++ b/tests/formats/test_fromqdoc.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pytest
 
-from PyQt6.QtGui import QFont, QTextDocument
+from PyQt6.QtGui import QFont, QTextCharFormat, QTextCursor, QTextDocument
 
 from novelwriter import CONFIG
 from novelwriter.core.project import NWProject
@@ -83,6 +83,38 @@ def testFromQTextDocument_General():
     document.setHtml("<p>First</p><p><br></p><p>Second</p>")
     result = FromQTextDocument(document).convertText()
     assert result == "First\n\n\nSecond\n"
+
+
+@pytest.mark.core
+def testFromQTextDocument_MergeSplitFragments():
+    """Test that adjacent Qt fragments with identical Markdown-relevant
+    formatting are merged before being wrapped. See issue #2978.
+    """
+    document = QTextDocument()
+    cursor = QTextCursor(document)
+
+    boldAnchor = QTextCharFormat()
+    boldAnchor.setFontWeight(QFont.Weight.Bold)
+    boldAnchor.setAnchor(True)
+    boldAnchor.setAnchorNames(["motivation"])
+    cursor.insertText("M", boldAnchor)
+
+    bold = QTextCharFormat()
+    bold.setFontWeight(QFont.Weight.Bold)
+    cursor.insertText("otivation", bold)
+
+    # Sanity check that the document really does hold two fragments
+    # here, i.e. that this test exercises the merge and is not
+    # trivially true because Qt already coalesced them.
+    it = document.begin().begin()
+    fragments = []
+    while not it.atEnd():
+        fragments.append(it.fragment().text())
+        it += 1
+    assert fragments == ["M", "otivation"]
+
+    result = FromQTextDocument(document).convertText().strip()
+    assert result == "**Motivation**"
 
 
 @pytest.mark.core


### PR DESCRIPTION
**Summary:**

Fixes a bug where formatting sometimes was repeated unnecessarily when pasting rich text where hidden formats were present inside the pasted text. Fragments should not be split if the final format is the same.

Also adds a shortcut `Ctrl+Shift+V` that always pasts the clipboard text as plain text.

**Related Issue(s):**

Closes #2978
Closes #2979

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [x] The overall test coverage is increased or remains the same as before
* [x] All tests are passing
* [x] All linting checks are passing and the style guide is followed
* [x] Documentation (as docstrings) is complete and understandable
* [x] Only files that have been actively changed are committed
